### PR TITLE
feat: add generate_config tool with MCP elicitation and create-config prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ That's it — no configuration needed. The server auto-detects your Nuxt config,
 | `detect_i18n_config` | Loads your Nuxt config and returns locales, layers, directories, and project config |
 | `list_locale_dirs` | Lists locale directories grouped by layer, with file counts and key namespaces |
 | `get_translations` | Reads values for specific dot-path keys from a locale/layer (`*` for all locales) |
-| `get_missing_translations` | Finds keys in a reference locale that are missing or empty in targets |
+| `get_missing_translations` | Finds keys present in the reference locale (default locale) that are missing or empty in targets. Comparison is **one-directional** — keys that only exist in a target locale but not in the reference are not reported. Pass `referenceLocale` to change the baseline. |
 | `search_translations` | Searches by key pattern or value substring |
 | `add_translations` | Adds new keys across locales (fails if key exists) |
 | `update_translations` | Updates existing keys (fails if key doesn't exist) |

--- a/src/generator/config-generator.ts
+++ b/src/generator/config-generator.ts
@@ -1,0 +1,374 @@
+import { join } from 'node:path'
+import type { I18nConfig, LocaleDefinition, LocaleDir, ProjectConfig } from '../config/types.js'
+import { readLocaleFile } from '../io/json-reader.js'
+import { getLeafKeys, getNestedValue } from '../io/key-operations.js'
+import { log } from '../utils/logger.js'
+
+// ─── Stop words for glossary extraction ──────────────────────────
+
+const STOP_WORDS = new Set([
+  // English
+  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'shall', 'can', 'need', 'must', 'ought',
+  'and', 'but', 'or', 'nor', 'not', 'so', 'yet', 'for', 'with',
+  'about', 'against', 'between', 'through', 'during', 'before', 'after',
+  'above', 'below', 'to', 'from', 'up', 'down', 'in', 'out', 'on',
+  'off', 'over', 'under', 'again', 'further', 'then', 'once', 'here',
+  'there', 'when', 'where', 'why', 'how', 'all', 'each', 'every',
+  'both', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'only',
+  'own', 'same', 'than', 'too', 'very', 'just', 'because', 'as', 'if',
+  'into', 'it', 'its', 'this', 'that', 'these', 'those', 'what', 'which',
+  'who', 'whom', 'of', 'at', 'by', 'any', 'also', 'you', 'your',
+  'we', 'our', 'they', 'their', 'he', 'she', 'him', 'her', 'his',
+  'my', 'me', 'i',
+  // German
+  'der', 'die', 'das', 'ein', 'eine', 'ist', 'sind', 'war', 'waren',
+  'und', 'oder', 'aber', 'nicht', 'mit', 'von', 'zu', 'für', 'auf',
+  'dem', 'den', 'des', 'sich', 'als', 'auch', 'es', 'im', 'ich',
+  'wir', 'sie', 'er', 'ihr', 'noch', 'nach', 'wird', 'bei', 'aus',
+  'wie', 'nur', 'noch', 'werden', 'hat', 'über', 'hab', 'am', 'bis',
+  'wenn', 'an', 'um', 'kann', 'dann', 'so', 'da', 'schon', 'vor',
+  'mal', 'mir', 'dir', 'dich', 'mich', 'uns', 'was', 'einem', 'einer',
+  // French
+  'le', 'la', 'les', 'un', 'une', 'des', 'du', 'de', 'est', 'sont',
+  'et', 'ou', 'mais', 'pas', 'avec', 'pour', 'sur', 'dans', 'par',
+  'en', 'au', 'aux', 'ce', 'cette', 'ces', 'il', 'elle', 'on', 'nous',
+  'vous', 'ils', 'elles', 'qui', 'que', 'ne', 'se', 'sa', 'son', 'ses',
+  // Spanish
+  'el', 'los', 'del', 'al', 'es', 'son', 'fue', 'con', 'para',
+  'por', 'como', 'más', 'pero', 'sus', 'está', 'hay',
+])
+
+// ─── BCP-47 primary subtag → human-readable language name ────────
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  af: 'Afrikaans', ar: 'Arabic', bg: 'Bulgarian', bn: 'Bengali',
+  ca: 'Catalan', cs: 'Czech', da: 'Danish', de: 'German',
+  el: 'Greek', en: 'English', es: 'Spanish', et: 'Estonian',
+  fa: 'Persian', fi: 'Finnish', fr: 'French', he: 'Hebrew',
+  hi: 'Hindi', hr: 'Croatian', hu: 'Hungarian', id: 'Indonesian',
+  it: 'Italian', ja: 'Japanese', ko: 'Korean', lt: 'Lithuanian',
+  lv: 'Latvian', ms: 'Malay', nb: 'Norwegian Bokmål', nl: 'Dutch',
+  nn: 'Norwegian Nynorsk', no: 'Norwegian', pl: 'Polish',
+  pt: 'Portuguese', ro: 'Romanian', ru: 'Russian', sk: 'Slovak',
+  sl: 'Slovenian', sr: 'Serbian', sv: 'Swedish', th: 'Thai',
+  tr: 'Turkish', uk: 'Ukrainian', vi: 'Vietnamese', zh: 'Chinese',
+}
+
+const REGION_NAMES: Record<string, string> = {
+  US: 'American', GB: 'British', AU: 'Australian', CA: 'Canadian',
+  BR: 'Brazilian', PT: 'European Portuguese', MX: 'Mexican',
+  AR: 'Argentine', CL: 'Chilean', CO: 'Colombian',
+  AT: 'Austrian', CH: 'Swiss', DE: 'German',
+  BE: 'Belgian', FR: 'French',
+  CN: 'Simplified Chinese', TW: 'Traditional Chinese', HK: 'Hong Kong',
+}
+
+// ─── Public API ──────────────────────────────────────────────────
+
+/**
+ * Reads locale files and generates a complete ProjectConfig.
+ * Only function with I/O — all others are pure.
+ */
+export async function generateProjectConfig(config: I18nConfig): Promise<ProjectConfig> {
+  const { localeDirs, locales, defaultLocale, fallbackLocale } = config
+  const nonAliasLayers = localeDirs.filter(d => !d.aliasOf)
+
+  const defaultLocaleDef = locales.find(l => l.code === defaultLocale)
+  if (!defaultLocaleDef) {
+    throw new Error(`Default locale '${defaultLocale}' not found in locale definitions`)
+  }
+
+  const defaultLocaleDataByLayer = new Map<string, Record<string, unknown>>()
+  const keysByLayer = new Map<string, string[]>()
+
+  for (const dir of nonAliasLayers) {
+    const filePath = join(dir.path, defaultLocaleDef.file)
+    try {
+      const data = await readLocaleFile(filePath)
+      defaultLocaleDataByLayer.set(dir.layer, data)
+      keysByLayer.set(dir.layer, getLeafKeys(data))
+    } catch {
+      log.warn(`Could not read default locale for layer '${dir.layer}': ${filePath}`)
+      defaultLocaleDataByLayer.set(dir.layer, {})
+      keysByLayer.set(dir.layer, [])
+    }
+  }
+
+  const secondLocaleDef = locales.find(l => l.code !== defaultLocale)
+  let secondLocaleDataByLayer: Map<string, Record<string, unknown>> | undefined
+
+  if (secondLocaleDef) {
+    secondLocaleDataByLayer = new Map()
+    const firstLayer = nonAliasLayers[0]
+    if (firstLayer) {
+      const filePath = join(firstLayer.path, secondLocaleDef.file)
+      try {
+        const data = await readLocaleFile(filePath)
+        secondLocaleDataByLayer.set(firstLayer.layer, data)
+      } catch {
+        log.warn(`Could not read second locale for examples: ${filePath}`)
+      }
+    }
+  }
+
+  const context = generateContext(localeDirs, locales)
+  const layerRules = generateLayerRules(localeDirs, keysByLayer)
+  const glossary = generateGlossary(defaultLocaleDataByLayer, defaultLocale)
+  const translationPrompt = generateTranslationPrompt()
+  const localeNotes = generateLocaleNotes(locales, fallbackLocale)
+
+  let examples: Array<Record<string, string>> = []
+  if (secondLocaleDef && secondLocaleDataByLayer) {
+    examples = generateExamples(
+      defaultLocaleDataByLayer,
+      secondLocaleDataByLayer,
+      defaultLocaleDef.code,
+      secondLocaleDef.code,
+    )
+  }
+
+  return {
+    context,
+    layerRules,
+    glossary,
+    translationPrompt,
+    localeNotes,
+    examples,
+  }
+}
+
+// ─── Pure generator functions ────────────────────────────────────
+
+export function generateLayerRules(
+  localeDirs: LocaleDir[],
+  keysByLayer: Map<string, string[]>,
+): Array<{ layer: string; description: string; when: string }> {
+  const rules: Array<{ layer: string; description: string; when: string }> = []
+
+  let rootLayer = ''
+  let maxKeys = 0
+  for (const [layer, keys] of keysByLayer) {
+    if (keys.length > maxKeys) {
+      maxKeys = keys.length
+      rootLayer = layer
+    }
+  }
+
+  for (const dir of localeDirs) {
+    if (dir.aliasOf) {
+      rules.push({
+        layer: dir.layer,
+        description: `Alias of ${dir.aliasOf} — shares its translations.`,
+        when: `Same as ${dir.aliasOf}. Do not add keys here directly.`,
+      })
+      continue
+    }
+
+    const keys = keysByLayer.get(dir.layer) ?? []
+    const topLevelNamespaces = extractTopLevelNamespaces(keys)
+    const nsDisplay = topLevelNamespaces.length > 0
+      ? topLevelNamespaces.map(ns => `${ns}.*`).join(', ')
+      : '(empty)'
+
+    if (dir.layer === rootLayer || dir.layer === 'root') {
+      rules.push({
+        layer: dir.layer,
+        description: `Shared translations used across the project: ${nsDisplay}`,
+        when: 'The key is generic enough to be used in multiple apps or features (e.g., common actions, messages, navigation).',
+      })
+    } else {
+      const layerLabel = dir.layer.replace(/^app-/, '')
+      rules.push({
+        layer: dir.layer,
+        description: `Translations for ${dir.layer}: ${nsDisplay}`,
+        when: `The key is specific to ${layerLabel} functionality.`,
+      })
+    }
+  }
+
+  return rules
+}
+
+export function generateGlossary(
+  dataByLayer: Map<string, Record<string, unknown>>,
+  defaultLocale: string,
+): Record<string, string> {
+  const wordCounts = new Map<string, number>()
+
+  for (const data of dataByLayer.values()) {
+    const leafKeys = getLeafKeys(data)
+    for (const key of leafKeys) {
+      const value = getNestedValue(data, key)
+      if (typeof value !== 'string' || value.length === 0) continue
+
+      const words = value
+        .split(/[\s,.!?;:'"()\[\]{}<>\/\\|@#$%^&*+=~`]+/)
+        .filter(w => w.length >= 3)
+        .map(w => w.toLowerCase())
+
+      for (const word of words) {
+        if (STOP_WORDS.has(word)) continue
+        wordCounts.set(word, (wordCounts.get(word) ?? 0) + 1)
+      }
+    }
+  }
+
+  const sorted = [...wordCounts.entries()]
+    .filter(([, count]) => count >= 3)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+
+  const glossary: Record<string, string> = {}
+  for (const [word, count] of sorted) {
+    const capitalized = word.charAt(0).toUpperCase() + word.slice(1)
+    glossary[capitalized] = `Keep as '${capitalized}' — appears ${count} times in ${defaultLocale} translations`
+  }
+
+  return glossary
+}
+
+export function generateLocaleNotes(
+  locales: LocaleDefinition[],
+  fallbackLocale: Record<string, string[]>,
+): Record<string, string> {
+  const notes: Record<string, string> = {}
+
+  for (const locale of locales) {
+    const parts: string[] = []
+    const segments = locale.code.split('-')
+    const primaryLang = segments[0].toLowerCase()
+    const langName = LANGUAGE_NAMES[primaryLang] ?? primaryLang
+
+    const isFormal = locale.code.toLowerCase().includes('formal')
+      || locale.name?.toLowerCase().includes('formal')
+
+    if (isFormal) {
+      const baseLang = segments[0].toLowerCase()
+      if (baseLang === 'de') {
+        parts.push(`Formal German. Uses 'Sie' instead of 'du'.`)
+      } else {
+        parts.push(`Formal register variant of ${langName}.`)
+      }
+    } else {
+      const region = segments.find(s => s.length === 2 && s === s.toUpperCase())
+      const regionLabel = region ? REGION_NAMES[region] : undefined
+
+      if (regionLabel) {
+        parts.push(`${regionLabel} ${langName}.`)
+      } else {
+        parts.push(`${langName}.`)
+      }
+    }
+
+    const fallbacks = fallbackLocale[locale.code]
+    if (fallbacks && fallbacks.length > 0) {
+      parts.push(`Falls back to ${fallbacks.join(', ')}.`)
+    }
+
+    notes[locale.code] = parts.join(' ')
+  }
+
+  return notes
+}
+
+export function generateExamples(
+  defaultLocaleDataByLayer: Map<string, Record<string, unknown>>,
+  secondLocaleDataByLayer: Map<string, Record<string, unknown>>,
+  defaultLocaleCode: string,
+  secondLocaleCode: string,
+): Array<Record<string, string>> {
+  const examples: Array<Record<string, string>> = []
+
+  let layerData: Record<string, unknown> | undefined
+  let secondLayerData: Record<string, unknown> | undefined
+  let usedLayer: string | undefined
+
+  for (const [layer, data] of defaultLocaleDataByLayer) {
+    const secondData = secondLocaleDataByLayer.get(layer)
+    if (secondData && Object.keys(data).length > 0 && Object.keys(secondData).length > 0) {
+      layerData = data
+      secondLayerData = secondData
+      usedLayer = layer
+      break
+    }
+  }
+
+  if (!layerData || !secondLayerData || !usedLayer) return examples
+
+  const allKeys = getLeafKeys(layerData)
+  const commonKeys = allKeys.filter(k => k.startsWith('common.'))
+  const candidateKeys = commonKeys.length > 0 ? commonKeys : allKeys
+
+  let picked = 0
+  for (const key of candidateKeys) {
+    if (picked >= 3) break
+
+    const defaultValue = getNestedValue(layerData, key)
+    const secondValue = getNestedValue(secondLayerData, key)
+
+    if (
+      typeof defaultValue !== 'string' || defaultValue.length === 0 || defaultValue.length > 50
+      || typeof secondValue !== 'string' || secondValue.length === 0
+    ) continue
+
+    const example: Record<string, string> = {
+      key,
+      [defaultLocaleCode]: defaultValue,
+      [secondLocaleCode]: secondValue,
+    }
+
+    if (defaultValue.split(' ').length <= 2) {
+      example.note = 'Concise, single word/phrase'
+    } else if (defaultValue.endsWith('...') || defaultValue.endsWith('…')) {
+      example.note = 'Loading/progress indicator'
+    } else if (defaultValue.includes('{')) {
+      example.note = 'Contains placeholder — preserve {variable} names'
+    } else {
+      example.note = 'Natural, professional tone'
+    }
+
+    examples.push(example)
+    picked++
+  }
+
+  return examples
+}
+
+export function generateContext(
+  localeDirs: LocaleDir[],
+  locales: LocaleDefinition[],
+): string {
+  const nonAliasLayers = localeDirs.filter(d => !d.aliasOf)
+  const aliasLayers = localeDirs.filter(d => d.aliasOf)
+  const layerNames = nonAliasLayers.map(d => d.layer)
+
+  let context = `This project uses ${locales.length} locale${locales.length === 1 ? '' : 's'} across ${nonAliasLayers.length} layer${nonAliasLayers.length === 1 ? '' : 's'}. Layers: ${layerNames.join(', ')}.`
+
+  if (aliasLayers.length > 0) {
+    const aliasList = aliasLayers.map(d => `${d.layer} → ${d.aliasOf}`).join(', ')
+    context += ` Aliases: ${aliasList}.`
+  }
+
+  return context
+}
+
+export function generateTranslationPrompt(): string {
+  return 'Preserve all {placeholders} and @:linked.message references. Keep translations concise — UI space is limited.'
+}
+
+// ─── Internal helpers ────────────────────────────────────────────
+
+function extractTopLevelNamespaces(keys: string[]): string[] {
+  const namespaces = new Set<string>()
+  for (const key of keys) {
+    const firstDot = key.indexOf('.')
+    if (firstDot > 0) {
+      namespaces.add(key.substring(0, firstDot))
+    } else {
+      namespaces.add(key)
+    }
+  }
+  return [...namespaces].sort()
+}

--- a/src/generator/config-generator.ts
+++ b/src/generator/config-generator.ts
@@ -78,12 +78,11 @@ export async function generateProjectConfig(
 
   if (secondLocaleDef) {
     secondLocaleDataByLayer = new Map()
-    const firstLayer = nonAliasLayers[0]
-    if (firstLayer) {
-      const filePath = join(firstLayer.path, secondLocaleDef.file)
+    for (const layer of nonAliasLayers) {
+      const filePath = join(layer.path, secondLocaleDef.file)
       try {
         const data = await readLocaleFile(filePath)
-        secondLocaleDataByLayer.set(firstLayer.layer, data)
+        secondLocaleDataByLayer.set(layer.layer, data)
       } catch {
         log.warn(`Could not read second locale for examples: ${filePath}`)
       }
@@ -124,12 +123,17 @@ export function generateLayerRules(
 ): Array<{ layer: string; description: string; when: string }> {
   const rules: Array<{ layer: string; description: string; when: string }> = []
 
+  const hasExplicitRoot = localeDirs.some(d => !d.aliasOf && d.layer === 'root')
   let rootLayer = ''
-  let maxKeys = 0
-  for (const [layer, keys] of keysByLayer) {
-    if (keys.length > maxKeys) {
-      maxKeys = keys.length
-      rootLayer = layer
+  if (hasExplicitRoot) {
+    rootLayer = 'root'
+  } else {
+    let maxKeys = 0
+    for (const [layer, keys] of keysByLayer) {
+      if (keys.length > maxKeys) {
+        maxKeys = keys.length
+        rootLayer = layer
+      }
     }
   }
 
@@ -185,7 +189,10 @@ export function generateLocaleNotes(
 
   for (const locale of locales) {
     const parts: string[] = []
-    const segments = locale.code.split('-')
+    // Use locale.language (BCP-47 tag like "de-DE", "en-US") for region detection,
+    // falling back to locale.code for projects where both are identical.
+    const bcp47 = locale.language || locale.code
+    const segments = bcp47.split('-')
     const primaryLang = segments[0].toLowerCase()
     const langName = LANGUAGE_NAMES[primaryLang] ?? primaryLang
 
@@ -203,7 +210,7 @@ export function generateLocaleNotes(
       const region = segments.find(s => s.length === 2 && s === s.toUpperCase())
       const regionLabel = region ? REGION_NAMES[region] : undefined
 
-      if (regionLabel) {
+      if (regionLabel && regionLabel !== langName) {
         parts.push(`${regionLabel} ${langName}.`)
       } else {
         parts.push(`${langName}.`)

--- a/src/generator/config-generator.ts
+++ b/src/generator/config-generator.ts
@@ -4,42 +4,6 @@ import { readLocaleFile } from '../io/json-reader.js'
 import { getLeafKeys, getNestedValue } from '../io/key-operations.js'
 import { log } from '../utils/logger.js'
 
-// ─── Stop words for glossary extraction ──────────────────────────
-
-const STOP_WORDS = new Set([
-  // English
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
-  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
-  'should', 'may', 'might', 'shall', 'can', 'need', 'must', 'ought',
-  'and', 'but', 'or', 'nor', 'not', 'so', 'yet', 'for', 'with',
-  'about', 'against', 'between', 'through', 'during', 'before', 'after',
-  'above', 'below', 'to', 'from', 'up', 'down', 'in', 'out', 'on',
-  'off', 'over', 'under', 'again', 'further', 'then', 'once', 'here',
-  'there', 'when', 'where', 'why', 'how', 'all', 'each', 'every',
-  'both', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'only',
-  'own', 'same', 'than', 'too', 'very', 'just', 'because', 'as', 'if',
-  'into', 'it', 'its', 'this', 'that', 'these', 'those', 'what', 'which',
-  'who', 'whom', 'of', 'at', 'by', 'any', 'also', 'you', 'your',
-  'we', 'our', 'they', 'their', 'he', 'she', 'him', 'her', 'his',
-  'my', 'me', 'i',
-  // German
-  'der', 'die', 'das', 'ein', 'eine', 'ist', 'sind', 'war', 'waren',
-  'und', 'oder', 'aber', 'nicht', 'mit', 'von', 'zu', 'für', 'auf',
-  'dem', 'den', 'des', 'sich', 'als', 'auch', 'es', 'im', 'ich',
-  'wir', 'sie', 'er', 'ihr', 'noch', 'nach', 'wird', 'bei', 'aus',
-  'wie', 'nur', 'noch', 'werden', 'hat', 'über', 'hab', 'am', 'bis',
-  'wenn', 'an', 'um', 'kann', 'dann', 'so', 'da', 'schon', 'vor',
-  'mal', 'mir', 'dir', 'dich', 'mich', 'uns', 'was', 'einem', 'einer',
-  // French
-  'le', 'la', 'les', 'un', 'une', 'des', 'du', 'de', 'est', 'sont',
-  'et', 'ou', 'mais', 'pas', 'avec', 'pour', 'sur', 'dans', 'par',
-  'en', 'au', 'aux', 'ce', 'cette', 'ces', 'il', 'elle', 'on', 'nous',
-  'vous', 'ils', 'elles', 'qui', 'que', 'ne', 'se', 'sa', 'son', 'ses',
-  // Spanish
-  'el', 'los', 'del', 'al', 'es', 'son', 'fue', 'con', 'para',
-  'por', 'como', 'más', 'pero', 'sus', 'está', 'hay',
-])
-
 // ─── BCP-47 primary subtag → human-readable language name ────────
 
 const LANGUAGE_NAMES: Record<string, string> = {
@@ -68,10 +32,23 @@ const REGION_NAMES: Record<string, string> = {
 // ─── Public API ──────────────────────────────────────────────────
 
 /**
+ * Optional user-provided context collected via MCP elicitation.
+ */
+export interface ElicitedProjectInfo {
+  /** Free-form project description (e.g. "B2B SaaS booking platform") */
+  description?: string
+  /** Desired translation tone */
+  tone?: 'formal' | 'informal' | 'mixed'
+}
+
+/**
  * Reads locale files and generates a complete ProjectConfig.
  * Only function with I/O — all others are pure.
  */
-export async function generateProjectConfig(config: I18nConfig): Promise<ProjectConfig> {
+export async function generateProjectConfig(
+  config: I18nConfig,
+  elicited?: ElicitedProjectInfo,
+): Promise<ProjectConfig> {
   const { localeDirs, locales, defaultLocale, fallbackLocale } = config
   const nonAliasLayers = localeDirs.filter(d => !d.aliasOf)
 
@@ -113,10 +90,10 @@ export async function generateProjectConfig(config: I18nConfig): Promise<Project
     }
   }
 
-  const context = generateContext(localeDirs, locales)
+  const context = generateContext(localeDirs, locales, elicited?.description)
   const layerRules = generateLayerRules(localeDirs, keysByLayer)
-  const glossary = generateGlossary(defaultLocaleDataByLayer, defaultLocale)
-  const translationPrompt = generateTranslationPrompt()
+  const glossary = generateGlossary()
+  const translationPrompt = generateTranslationPrompt(elicited?.tone)
   const localeNotes = generateLocaleNotes(locales, fallbackLocale)
 
   let examples: Array<Record<string, string>> = []
@@ -191,42 +168,13 @@ export function generateLayerRules(
   return rules
 }
 
-export function generateGlossary(
-  dataByLayer: Map<string, Record<string, unknown>>,
-  defaultLocale: string,
-): Record<string, string> {
-  const wordCounts = new Map<string, number>()
-
-  for (const data of dataByLayer.values()) {
-    const leafKeys = getLeafKeys(data)
-    for (const key of leafKeys) {
-      const value = getNestedValue(data, key)
-      if (typeof value !== 'string' || value.length === 0) continue
-
-      const words = value
-        .split(/[\s,.!?;:'"()\[\]{}<>\/\\|@#$%^&*+=~`]+/)
-        .filter(w => w.length >= 3)
-        .map(w => w.toLowerCase())
-
-      for (const word of words) {
-        if (STOP_WORDS.has(word)) continue
-        wordCounts.set(word, (wordCounts.get(word) ?? 0) + 1)
-      }
-    }
-  }
-
-  const sorted = [...wordCounts.entries()]
-    .filter(([, count]) => count >= 3)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 15)
-
-  const glossary: Record<string, string> = {}
-  for (const [word, count] of sorted) {
-    const capitalized = word.charAt(0).toUpperCase() + word.slice(1)
-    glossary[capitalized] = `Keep as '${capitalized}' — appears ${count} times in ${defaultLocale} translations`
-  }
-
-  return glossary
+/**
+ * Returns an empty glossary — glossary entries require domain knowledge
+ * that only a human or an AI agent with project context can provide.
+ * The generated config leaves this empty for manual or agent-assisted refinement.
+ */
+export function generateGlossary(): Record<string, string> {
+  return {}
 }
 
 export function generateLocaleNotes(
@@ -339,23 +287,38 @@ export function generateExamples(
 export function generateContext(
   localeDirs: LocaleDir[],
   locales: LocaleDefinition[],
+  projectDescription?: string,
 ): string {
+  const parts: string[] = []
+
+  if (projectDescription) {
+    parts.push(projectDescription)
+  }
+
   const nonAliasLayers = localeDirs.filter(d => !d.aliasOf)
   const aliasLayers = localeDirs.filter(d => d.aliasOf)
   const layerNames = nonAliasLayers.map(d => d.layer)
 
-  let context = `This project uses ${locales.length} locale${locales.length === 1 ? '' : 's'} across ${nonAliasLayers.length} layer${nonAliasLayers.length === 1 ? '' : 's'}. Layers: ${layerNames.join(', ')}.`
+  parts.push(`This project uses ${locales.length} locale${locales.length === 1 ? '' : 's'} across ${nonAliasLayers.length} layer${nonAliasLayers.length === 1 ? '' : 's'}. Layers: ${layerNames.join(', ')}.`)
 
   if (aliasLayers.length > 0) {
     const aliasList = aliasLayers.map(d => `${d.layer} → ${d.aliasOf}`).join(', ')
-    context += ` Aliases: ${aliasList}.`
+    parts[parts.length - 1] += ` Aliases: ${aliasList}.`
   }
 
-  return context
+  return parts.join(' ')
 }
 
-export function generateTranslationPrompt(): string {
-  return 'Preserve all {placeholders} and @:linked.message references. Keep translations concise — UI space is limited.'
+export function generateTranslationPrompt(tone?: 'formal' | 'informal' | 'mixed'): string {
+  const base = 'Preserve all {placeholders} and @:linked.message references. Keep translations concise — UI space is limited.'
+
+  if (!tone || tone === 'mixed') return base
+
+  const toneInstruction = tone === 'formal'
+    ? 'Use a formal, professional tone.'
+    : 'Use a friendly, informal tone.'
+
+  return `${toneInstruction} ${base}`
 }
 
 // ─── Internal helpers ────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,8 +16,10 @@ import {
 import { scanSourceFiles, toRelativePath } from './scanner/code-scanner.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
+import { generateProjectConfig } from './generator/config-generator.js'
 import { join } from 'node:path'
-import { readdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { readdir, writeFile } from 'node:fs/promises'
 
 // ─── Shared helpers ───────────────────────────────────────────────
 
@@ -1692,6 +1694,82 @@ export function createServer(): McpServer {
         }
       } catch (error) {
         return toolErrorResponse('cleaning up unused translations', error)
+      }
+    },
+  )
+
+  // ─── Tool: generate_config ──────────────────────────────────────
+
+  server.registerTool(
+    'generate_config',
+    {
+      title: 'Generate Project Config',
+      description:
+        'Analyze the project\'s i18n setup and generate a .i18n-mcp.json config file with glossary, layer rules, locale notes, examples, and translation prompt. The generated config is a starting point — refine it to match your project.',
+      inputSchema: {
+        projectDir: z
+          .string()
+          .optional()
+          .describe('Absolute path to the Nuxt project root. Defaults to server cwd.'),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe('If true, overwrite existing .i18n-mcp.json. Default: false.'),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe('If true, return generated config without writing to disk. Default: false.'),
+      },
+    },
+    async ({ projectDir, overwrite, dryRun }) => {
+      try {
+        const dir = projectDir ?? process.cwd()
+        const configPath = join(dir, '.i18n-mcp.json')
+
+        if (!dryRun && !overwrite && existsSync(configPath)) {
+          throw new ToolError(
+            `Config already exists at ${configPath}. Use overwrite: true to replace, or dryRun: true to preview.`,
+            'CONFIG_EXISTS',
+          )
+        }
+
+        const i18nConfig = await detectI18nConfig(dir)
+        const generatedConfig = await generateProjectConfig(i18nConfig)
+
+        const output: Record<string, unknown> = {
+          $schema: 'node_modules/nuxt-i18n-mcp/schema.json',
+          ...generatedConfig,
+        }
+
+        if (!dryRun) {
+          await writeFile(configPath, JSON.stringify(output, null, 2) + '\n', 'utf-8')
+        }
+
+        const layerCount = i18nConfig.localeDirs.filter(d => !d.aliasOf).length
+        const localeCount = i18nConfig.locales.length
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              config: output,
+              summary: {
+                dryRun: dryRun ?? false,
+                configPath,
+                layersDetected: layerCount,
+                localesDetected: localeCount,
+                fieldsGenerated: Object.keys(generatedConfig).filter(k => {
+                  const val = generatedConfig[k as keyof typeof generatedConfig]
+                  if (Array.isArray(val)) return val.length > 0
+                  if (typeof val === 'object' && val !== null) return Object.keys(val).length > 0
+                  return val !== undefined && val !== ''
+                }),
+              },
+            }, null, 2),
+          }],
+        }
+      } catch (error) {
+        return toolErrorResponse('generating project config', error)
       }
     },
   )

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,6 @@ import { ToolError } from './utils/errors.js'
 import { generateProjectConfig } from './generator/config-generator.js'
 import type { ElicitedProjectInfo } from './generator/config-generator.js'
 import { join } from 'node:path'
-import { existsSync } from 'node:fs'
 import { readdir, writeFile } from 'node:fs/promises'
 
 // ─── Shared helpers ───────────────────────────────────────────────
@@ -1727,13 +1726,6 @@ export function createServer(): McpServer {
         const dir = projectDir ?? process.cwd()
         const configPath = join(dir, '.i18n-mcp.json')
 
-        if (!dryRun && !overwrite && existsSync(configPath)) {
-          throw new ToolError(
-            `Config already exists at ${configPath}. Use overwrite: true to replace, or dryRun: true to preview.`,
-            'CONFIG_EXISTS',
-          )
-        }
-
         const i18nConfig = await detectI18nConfig(dir)
 
         let elicited: ElicitedProjectInfo | undefined
@@ -1781,7 +1773,18 @@ export function createServer(): McpServer {
         }
 
         if (!dryRun) {
-          await writeFile(configPath, JSON.stringify(output, null, 2) + '\n', 'utf-8')
+          const content = JSON.stringify(output, null, 2) + '\n'
+          try {
+            await writeFile(configPath, content, { encoding: 'utf-8', flag: overwrite ? 'w' : 'wx' })
+          } catch (err: unknown) {
+            if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EEXIST') {
+              throw new ToolError(
+                `Config already exists at ${configPath}. Use overwrite: true to replace, or dryRun: true to preview.`,
+                'CONFIG_EXISTS',
+              )
+            }
+            throw err
+          }
         }
 
         const layerCount = i18nConfig.localeDirs.filter(d => !d.aliasOf).length

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { scanSourceFiles, toRelativePath } from './scanner/code-scanner.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
 import { generateProjectConfig } from './generator/config-generator.js'
+import type { ElicitedProjectInfo } from './generator/config-generator.js'
 import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { readdir, writeFile } from 'node:fs/promises'
@@ -1705,7 +1706,7 @@ export function createServer(): McpServer {
     {
       title: 'Generate Project Config',
       description:
-        'Analyze the project\'s i18n setup and generate a .i18n-mcp.json config file with glossary, layer rules, locale notes, examples, and translation prompt. The generated config is a starting point — refine it to match your project.',
+        'Analyze the project\'s i18n setup and generate a .i18n-mcp.json config file. Detects layers, locales, key namespaces, and generates layer rules, locale notes, examples, and a translation prompt. If the host supports MCP elicitation, asks the user for project description and tone to enrich the config. The glossary field is left empty for manual or agent-assisted refinement.',
       inputSchema: {
         projectDir: z
           .string()
@@ -1734,7 +1735,45 @@ export function createServer(): McpServer {
         }
 
         const i18nConfig = await detectI18nConfig(dir)
-        const generatedConfig = await generateProjectConfig(i18nConfig)
+
+        let elicited: ElicitedProjectInfo | undefined
+        const clientCapabilities = server.server.getClientCapabilities()
+        if (clientCapabilities?.elicitation) {
+          try {
+            const result = await server.server.elicitInput({
+              message: 'Provide optional project details to generate a better config. You can skip this.',
+              requestedSchema: {
+                type: 'object' as const,
+                properties: {
+                  description: {
+                    type: 'string' as const,
+                    title: 'Project Description',
+                    description: 'What does your app do? (e.g. "B2B SaaS booking platform for desk and room reservations")',
+                  },
+                  tone: {
+                    type: 'string' as const,
+                    title: 'Translation Tone',
+                    description: 'What tone should translations use?',
+                    enum: ['formal', 'informal', 'mixed'],
+                  },
+                },
+              },
+            })
+
+            if (result.action === 'accept' && result.content) {
+              elicited = {
+                description: typeof result.content.description === 'string' ? result.content.description : undefined,
+                tone: ['formal', 'informal', 'mixed'].includes(result.content.tone as string)
+                  ? result.content.tone as ElicitedProjectInfo['tone']
+                  : undefined,
+              }
+            }
+          } catch {
+            log.warn('Elicitation failed — proceeding without user input')
+          }
+        }
+
+        const generatedConfig = await generateProjectConfig(i18nConfig, elicited)
 
         const output: Record<string, unknown> = {
           $schema: 'node_modules/nuxt-i18n-mcp/schema.json',
@@ -1957,6 +1996,74 @@ Follow these steps:
 3. For each locale with missing keys, call \`translate_missing\` to auto-fill gaps using the reference locale.
    - If auto-translation is not available, translate the keys yourself using the glossary and style guidelines above, then call \`add_translations\`.
 4. Report a summary of what was translated, organized by layer and locale.`
+
+      return {
+        messages: [
+          {
+            role: 'user' as const,
+            content: { type: 'text' as const, text: promptText },
+          },
+        ],
+      }
+    },
+  )
+
+  server.registerPrompt(
+    'create-config',
+    {
+      title: 'Create or Refine Project Config',
+      description: 'Guide an agent through creating or refining a .i18n-mcp.json config file by analyzing the project\'s i18n setup.',
+      argsSchema: {
+        projectDir: z.string().optional().describe('Absolute path to the Nuxt project root. Defaults to server cwd.'),
+      },
+    },
+    async ({ projectDir }) => {
+      const dir = projectDir ?? process.cwd()
+      let detectedInfo = ''
+
+      try {
+        const config = await detectI18nConfig(dir)
+        const layers = config.localeDirs.filter(d => !d.aliasOf).map(d => d.layer)
+        const aliases = config.localeDirs.filter(d => d.aliasOf).map(d => `${d.layer} → ${d.aliasOf}`)
+        const localeCodes = config.locales.map(l => l.code)
+
+        detectedInfo = `
+DETECTED PROJECT SETUP:
+- Layers: ${layers.join(', ')}${aliases.length > 0 ? `\n- Aliases: ${aliases.join(', ')}` : ''}
+- Locales: ${localeCodes.join(', ')}
+- Default locale: ${config.defaultLocale}
+- Fallback chain: ${JSON.stringify(config.fallbackLocale)}`
+      } catch {
+        detectedInfo = '\nCould not auto-detect i18n config. Ask the user for project details.'
+      }
+
+      const promptText = `Create or refine a .i18n-mcp.json config file for this project.
+${detectedInfo}
+
+Follow these steps:
+
+1. Call \`detect_i18n_config\` to understand the full project setup if not shown above.
+2. Ask the user about their project:
+   - What does the app do? (e.g. "B2B booking platform", "e-commerce store")
+   - What tone should translations use? (formal, informal, or mixed across locales)
+   - Are there any terms that should never be translated? (brand names, product terms)
+   - Are there terms that need consistent translation? (domain-specific vocabulary)
+3. Call \`generate_config\` with dryRun: true to get a baseline config.
+4. Review the generated config and enhance it:
+   - Rewrite \`context\` to include the user's project description.
+   - Update \`translationPrompt\` with the user's tone and style preferences.
+   - Add \`layerRules\` that match the project's architecture.
+   - Populate \`glossary\` with terms the user provided.
+   - Refine \`localeNotes\` based on any locale-specific instructions (formal registers, regional preferences).
+   - Add or update \`examples\` with real key-value pairs from the project.
+5. Write the final config to .i18n-mcp.json (call \`generate_config\` with the refined content, or write the file directly).
+6. Present the final config to the user for review.
+
+IMPORTANT:
+- The glossary is the most valuable part — populate it with domain terms, not common words.
+- Locale notes should mention formality registers (e.g. "Formal German using 'Sie'").
+- The translation prompt should be specific to the project's voice and constraints.
+- Preserve the $schema field for IDE autocompletion.`
 
       return {
         messages: [

--- a/tests/generator/config-generator.test.ts
+++ b/tests/generator/config-generator.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { LocaleDefinition, LocaleDir, I18nConfig } from '../../src/config/types.js'
+import {
+  generateLayerRules,
+  generateGlossary,
+  generateLocaleNotes,
+  generateExamples,
+  generateContext,
+  generateTranslationPrompt,
+  generateProjectConfig,
+} from '../../src/generator/config-generator.js'
+
+vi.mock('../../src/io/json-reader.js', () => ({
+  readLocaleFile: vi.fn(),
+}))
+
+vi.mock('../../src/utils/logger.js', () => ({
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+const mockReadLocaleFile = vi.mocked(
+  (await import('../../src/io/json-reader.js')).readLocaleFile,
+)
+
+describe('generateLayerRules', () => {
+  const baseDirs: LocaleDir[] = [
+    { path: '/project/i18n', layer: 'root', layerRootDir: '/project' },
+    { path: '/project/app-admin/i18n', layer: 'app-admin', layerRootDir: '/project/app-admin' },
+    { path: '/project/app-outlook/i18n', layer: 'app-outlook', layerRootDir: '/project/app-outlook', aliasOf: 'app-shop' },
+  ]
+
+  it('marks root/shared layer with generic description', () => {
+    const keysByLayer = new Map([
+      ['root', ['common.actions.save', 'common.messages.ok']],
+      ['app-admin', ['admin.users.title']],
+    ])
+    const rules = generateLayerRules(baseDirs, keysByLayer)
+
+    const rootRule = rules.find(r => r.layer === 'root')!
+    expect(rootRule.description).toContain('Shared translations')
+    expect(rootRule.description).toContain('common.*')
+    expect(rootRule.when).toContain('generic')
+  })
+
+  it('generates named layer rules with namespace info', () => {
+    const keysByLayer = new Map([
+      ['root', ['common.actions.save', 'common.actions.cancel', 'common.messages.ok']],
+      ['app-admin', ['admin.users.title', 'admin.settings.name']],
+    ])
+    const rules = generateLayerRules(baseDirs, keysByLayer)
+
+    const adminRule = rules.find(r => r.layer === 'app-admin')!
+    expect(adminRule.description).toContain('admin.*')
+    expect(adminRule.when).toContain('admin')
+  })
+
+  it('annotates alias layers', () => {
+    const keysByLayer = new Map([
+      ['root', ['common.save']],
+      ['app-admin', ['admin.title']],
+    ])
+    const rules = generateLayerRules(baseDirs, keysByLayer)
+
+    const aliasRule = rules.find(r => r.layer === 'app-outlook')!
+    expect(aliasRule.description).toContain('Alias of app-shop')
+    expect(aliasRule.when).toContain('Do not add keys here')
+  })
+
+  it('uses layer with most keys as root when none is named "root"', () => {
+    const dirs: LocaleDir[] = [
+      { path: '/p/shared/i18n', layer: 'shared', layerRootDir: '/p/shared' },
+      { path: '/p/admin/i18n', layer: 'app-admin', layerRootDir: '/p/admin' },
+    ]
+    const keysByLayer = new Map([
+      ['shared', ['a', 'b', 'c', 'd', 'e']],
+      ['app-admin', ['x']],
+    ])
+    const rules = generateLayerRules(dirs, keysByLayer)
+
+    const sharedRule = rules.find(r => r.layer === 'shared')!
+    expect(sharedRule.description).toContain('Shared translations')
+  })
+})
+
+describe('generateGlossary', () => {
+  it('extracts frequently occurring words', () => {
+    const data = new Map([
+      ['root', {
+        a: { save: 'Save booking' },
+        b: { edit: 'Edit booking' },
+        c: { delete: 'Delete booking' },
+        d: { view: 'View booking details' },
+      }],
+    ])
+    const glossary = generateGlossary(data, 'en')
+
+    expect(glossary).toHaveProperty('Booking')
+    expect(glossary.Booking).toContain('4 times')
+  })
+
+  it('filters out stop words and short words', () => {
+    const data = new Map([
+      ['root', {
+        a: 'the booking is here',
+        b: 'the booking is there',
+        c: 'the booking is everywhere',
+      }],
+    ])
+    const glossary = generateGlossary(data, 'en')
+
+    expect(glossary).not.toHaveProperty('The')
+    expect(glossary).toHaveProperty('Booking')
+  })
+
+  it('returns empty glossary when no words appear 3+ times', () => {
+    const data = new Map([
+      ['root', { a: 'hello', b: 'world' }],
+    ])
+    const glossary = generateGlossary(data, 'en')
+    expect(Object.keys(glossary)).toHaveLength(0)
+  })
+
+  it('limits to top 15 terms', () => {
+    const entries: Record<string, string> = {}
+    for (let i = 0; i < 20; i++) {
+      entries[`key${i}`] = `word${i} word${i} word${i} extra${i} extra${i} extra${i}`
+    }
+    const data = new Map([['root', entries]])
+    const glossary = generateGlossary(data, 'en')
+    expect(Object.keys(glossary).length).toBeLessThanOrEqual(15)
+  })
+})
+
+describe('generateLocaleNotes', () => {
+  const locales: LocaleDefinition[] = [
+    { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+    { code: 'de-formal', language: 'de-DE-formal', file: 'de-DE-formal.json' },
+    { code: 'en', language: 'en-US', file: 'en-US.json' },
+    { code: 'uk', language: 'uk-UA', file: 'uk-UA.json' },
+  ]
+
+  const fallbacks: Record<string, string[]> = {
+    'de-formal': ['de'],
+    'uk': ['ru'],
+    'default': ['en'],
+  }
+
+  it('detects formal German variant', () => {
+    const notes = generateLocaleNotes(locales, fallbacks)
+    expect(notes['de-formal']).toContain('Formal German')
+    expect(notes['de-formal']).toContain('Sie')
+  })
+
+  it('adds fallback chain info', () => {
+    const notes = generateLocaleNotes(locales, fallbacks)
+    expect(notes['de-formal']).toContain('Falls back to de')
+    expect(notes['uk']).toContain('Falls back to ru')
+  })
+
+  it('generates basic language note for simple locales', () => {
+    const notes = generateLocaleNotes(locales, fallbacks)
+    expect(notes['de']).toContain('German')
+    expect(notes['en']).toContain('English')
+  })
+
+  it('detects region from BCP-47 tag', () => {
+    const localeDefs: LocaleDefinition[] = [
+      { code: 'en-US', language: 'en-US', file: 'en-US.json' },
+      { code: 'en-GB', language: 'en-GB', file: 'en-GB.json' },
+    ]
+    const notes = generateLocaleNotes(localeDefs, {})
+    expect(notes['en-US']).toContain('American')
+    expect(notes['en-GB']).toContain('British')
+  })
+
+  it('handles formal variant of non-German language', () => {
+    const localeDefs: LocaleDefinition[] = [
+      { code: 'fr-formal', language: 'fr-FR', file: 'fr-FR-formal.json' },
+    ]
+    const notes = generateLocaleNotes(localeDefs, {})
+    expect(notes['fr-formal']).toContain('Formal register variant')
+    expect(notes['fr-formal']).toContain('French')
+  })
+})
+
+describe('generateExamples', () => {
+  it('picks examples from common.* namespace when available', () => {
+    const defaultData = new Map([
+      ['root', {
+        common: { actions: { save: 'Save', cancel: 'Cancel', delete: 'Delete' } },
+        admin: { title: 'Admin Panel' },
+      }],
+    ])
+    const secondData = new Map([
+      ['root', {
+        common: { actions: { save: 'Speichern', cancel: 'Abbrechen', delete: 'Löschen' } },
+        admin: { title: 'Admin-Bereich' },
+      }],
+    ])
+
+    const examples = generateExamples(defaultData, secondData, 'en', 'de')
+
+    expect(examples.length).toBeGreaterThanOrEqual(1)
+    expect(examples.length).toBeLessThanOrEqual(3)
+    expect(examples[0].key).toMatch(/^common\./)
+    expect(examples[0].en).toBeDefined()
+    expect(examples[0].de).toBeDefined()
+    expect(examples[0].note).toBeDefined()
+  })
+
+  it('falls back to any namespace when no common.* exists', () => {
+    const defaultData = new Map([
+      ['root', { admin: { title: 'Dashboard' } }],
+    ])
+    const secondData = new Map([
+      ['root', { admin: { title: 'Übersicht' } }],
+    ])
+
+    const examples = generateExamples(defaultData, secondData, 'en', 'de')
+    expect(examples.length).toBe(1)
+    expect(examples[0].key).toBe('admin.title')
+  })
+
+  it('skips values longer than 50 chars', () => {
+    const longValue = 'A'.repeat(51)
+    const defaultData = new Map([
+      ['root', { a: longValue, b: 'Short' }],
+    ])
+    const secondData = new Map([
+      ['root', { a: 'Lang', b: 'Kurz' }],
+    ])
+
+    const examples = generateExamples(defaultData, secondData, 'en', 'de')
+    expect(examples).toHaveLength(1)
+    expect(examples[0].key).toBe('b')
+  })
+
+  it('skips keys missing in second locale', () => {
+    const defaultData = new Map([
+      ['root', { a: 'Hello', b: 'World' }],
+    ])
+    const secondData = new Map([
+      ['root', { a: 'Hallo' }],
+    ])
+
+    const examples = generateExamples(defaultData, secondData, 'en', 'de')
+    expect(examples).toHaveLength(1)
+    expect(examples[0].key).toBe('a')
+  })
+
+  it('returns empty when no matching layer data exists', () => {
+    const defaultData = new Map([['root', { a: 'Hello' }]])
+    const secondData = new Map<string, Record<string, unknown>>()
+
+    const examples = generateExamples(defaultData, secondData, 'en', 'de')
+    expect(examples).toHaveLength(0)
+  })
+})
+
+describe('generateContext', () => {
+  it('summarizes locales and layers', () => {
+    const dirs: LocaleDir[] = [
+      { path: '/p/i18n', layer: 'root', layerRootDir: '/p' },
+      { path: '/p/admin/i18n', layer: 'app-admin', layerRootDir: '/p/admin' },
+    ]
+    const locales: LocaleDefinition[] = [
+      { code: 'en', language: 'en-US', file: 'en-US.json' },
+      { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+    ]
+
+    const context = generateContext(dirs, locales)
+    expect(context).toContain('2 locales')
+    expect(context).toContain('2 layers')
+    expect(context).toContain('root')
+    expect(context).toContain('app-admin')
+  })
+
+  it('includes alias info', () => {
+    const dirs: LocaleDir[] = [
+      { path: '/p/i18n', layer: 'root', layerRootDir: '/p' },
+      { path: '/p/outlook/i18n', layer: 'app-outlook', layerRootDir: '/p/outlook', aliasOf: 'app-shop' },
+    ]
+    const locales: LocaleDefinition[] = [
+      { code: 'en', language: 'en-US', file: 'en-US.json' },
+    ]
+
+    const context = generateContext(dirs, locales)
+    expect(context).toContain('1 layer')
+    expect(context).toContain('Aliases: app-outlook → app-shop')
+  })
+
+  it('uses singular for 1 locale/layer', () => {
+    const dirs: LocaleDir[] = [
+      { path: '/p/i18n', layer: 'root', layerRootDir: '/p' },
+    ]
+    const locales: LocaleDefinition[] = [
+      { code: 'en', language: 'en-US', file: 'en-US.json' },
+    ]
+    const context = generateContext(dirs, locales)
+    expect(context).toContain('1 locale ')
+    expect(context).toContain('1 layer.')
+  })
+})
+
+describe('generateTranslationPrompt', () => {
+  it('returns a prompt mentioning placeholders and linked messages', () => {
+    const prompt = generateTranslationPrompt()
+    expect(prompt).toContain('{placeholders}')
+    expect(prompt).toContain('@:linked')
+  })
+})
+
+describe('generateProjectConfig', () => {
+  it('generates a complete config from mock data', async () => {
+    mockReadLocaleFile.mockImplementation(async (filePath: string) => {
+      if (filePath.includes('en-US.json') && filePath.includes('root')) {
+        return {
+          common: {
+            actions: { save: 'Save', cancel: 'Cancel', delete: 'Delete' },
+            messages: { success: 'Operation successful', error: 'An error occurred' },
+          },
+        }
+      }
+      if (filePath.includes('de-DE.json') && filePath.includes('root')) {
+        return {
+          common: {
+            actions: { save: 'Speichern', cancel: 'Abbrechen', delete: 'Löschen' },
+            messages: { success: 'Vorgang erfolgreich', error: 'Ein Fehler ist aufgetreten' },
+          },
+        }
+      }
+      if (filePath.includes('en-US.json') && filePath.includes('admin')) {
+        return {
+          admin: { users: { title: 'Users' }, settings: { title: 'Settings' } },
+        }
+      }
+      return {}
+    })
+
+    const config: I18nConfig = {
+      rootDir: '/project',
+      defaultLocale: 'en',
+      fallbackLocale: { 'de-formal': ['de'], default: ['en'] },
+      locales: [
+        { code: 'en', language: 'en-US', file: 'en-US.json' },
+        { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+        { code: 'de-formal', language: 'de-DE-formal', file: 'de-DE-formal.json' },
+      ],
+      localeDirs: [
+        { path: '/project/root/i18n', layer: 'root', layerRootDir: '/project/root' },
+        { path: '/project/admin/i18n', layer: 'app-admin', layerRootDir: '/project/admin' },
+      ],
+    }
+
+    const result = await generateProjectConfig(config)
+
+    expect(result.context).toContain('3 locales')
+    expect(result.context).toContain('2 layers')
+    expect(result.layerRules).toBeDefined()
+    expect(result.layerRules!.length).toBe(2)
+    expect(result.glossary).toBeDefined()
+    expect(result.translationPrompt).toBeDefined()
+    expect(result.localeNotes).toBeDefined()
+    expect(result.localeNotes!['de-formal']).toContain('Formal German')
+    expect(result.examples).toBeDefined()
+  })
+
+  it('throws when default locale is not found', async () => {
+    const config: I18nConfig = {
+      rootDir: '/project',
+      defaultLocale: 'xx',
+      fallbackLocale: {},
+      locales: [{ code: 'en', language: 'en-US', file: 'en-US.json' }],
+      localeDirs: [],
+    }
+
+    await expect(generateProjectConfig(config)).rejects.toThrow('Default locale')
+  })
+
+  it('handles unreadable locale files gracefully', async () => {
+    mockReadLocaleFile.mockRejectedValue(new Error('File not found'))
+
+    const config: I18nConfig = {
+      rootDir: '/project',
+      defaultLocale: 'en',
+      fallbackLocale: {},
+      locales: [{ code: 'en', language: 'en-US', file: 'en-US.json' }],
+      localeDirs: [
+        { path: '/project/i18n', layer: 'root', layerRootDir: '/project' },
+      ],
+    }
+
+    const result = await generateProjectConfig(config)
+    expect(result.context).toBeDefined()
+    expect(result.layerRules).toBeDefined()
+    expect(result.glossary).toEqual({})
+    expect(result.examples).toEqual([])
+  })
+})

--- a/tests/generator/config-generator.test.ts
+++ b/tests/generator/config-generator.test.ts
@@ -124,11 +124,11 @@ describe('generateLocaleNotes', () => {
 
   it('detects region from BCP-47 tag', () => {
     const localeDefs: LocaleDefinition[] = [
-      { code: 'en-US', language: 'en-US', file: 'en-US.json' },
+      { code: 'en', language: 'en-US', file: 'en-US.json' },
       { code: 'en-GB', language: 'en-GB', file: 'en-GB.json' },
     ]
     const notes = generateLocaleNotes(localeDefs, {})
-    expect(notes['en-US']).toContain('American')
+    expect(notes['en']).toContain('American')
     expect(notes['en-GB']).toContain('British')
   })
 
@@ -139,6 +139,15 @@ describe('generateLocaleNotes', () => {
     const notes = generateLocaleNotes(localeDefs, {})
     expect(notes['fr-formal']).toContain('Formal register variant')
     expect(notes['fr-formal']).toContain('French')
+  })
+
+  it('suppresses redundant region label when it matches language name', () => {
+    const localeDefs: LocaleDefinition[] = [
+      { code: 'fr', language: 'fr-FR', file: 'fr-FR.json' },
+    ]
+    const notes = generateLocaleNotes(localeDefs, {})
+    expect(notes['fr']).toBe('French.')
+    expect(notes['fr']).not.toContain('French French')
   })
 })
 

--- a/tests/generator/config-generator.test.ts
+++ b/tests/generator/config-generator.test.ts
@@ -9,6 +9,7 @@ import {
   generateTranslationPrompt,
   generateProjectConfig,
 } from '../../src/generator/config-generator.js'
+import type { ElicitedProjectInfo } from '../../src/generator/config-generator.js'
 
 vi.mock('../../src/io/json-reader.js', () => ({
   readLocaleFile: vi.fn(),
@@ -83,51 +84,9 @@ describe('generateLayerRules', () => {
 })
 
 describe('generateGlossary', () => {
-  it('extracts frequently occurring words', () => {
-    const data = new Map([
-      ['root', {
-        a: { save: 'Save booking' },
-        b: { edit: 'Edit booking' },
-        c: { delete: 'Delete booking' },
-        d: { view: 'View booking details' },
-      }],
-    ])
-    const glossary = generateGlossary(data, 'en')
-
-    expect(glossary).toHaveProperty('Booking')
-    expect(glossary.Booking).toContain('4 times')
-  })
-
-  it('filters out stop words and short words', () => {
-    const data = new Map([
-      ['root', {
-        a: 'the booking is here',
-        b: 'the booking is there',
-        c: 'the booking is everywhere',
-      }],
-    ])
-    const glossary = generateGlossary(data, 'en')
-
-    expect(glossary).not.toHaveProperty('The')
-    expect(glossary).toHaveProperty('Booking')
-  })
-
-  it('returns empty glossary when no words appear 3+ times', () => {
-    const data = new Map([
-      ['root', { a: 'hello', b: 'world' }],
-    ])
-    const glossary = generateGlossary(data, 'en')
+  it('returns empty glossary for manual refinement', () => {
+    const glossary = generateGlossary()
     expect(Object.keys(glossary)).toHaveLength(0)
-  })
-
-  it('limits to top 15 terms', () => {
-    const entries: Record<string, string> = {}
-    for (let i = 0; i < 20; i++) {
-      entries[`key${i}`] = `word${i} word${i} word${i} extra${i} extra${i} extra${i}`
-    }
-    const data = new Map([['root', entries]])
-    const glossary = generateGlossary(data, 'en')
-    expect(Object.keys(glossary).length).toBeLessThanOrEqual(15)
   })
 })
 
@@ -300,6 +259,18 @@ describe('generateContext', () => {
     expect(context).toContain('1 locale ')
     expect(context).toContain('1 layer.')
   })
+
+  it('prepends project description when provided', () => {
+    const dirs: LocaleDir[] = [
+      { path: '/p/i18n', layer: 'root', layerRootDir: '/p' },
+    ]
+    const locales: LocaleDefinition[] = [
+      { code: 'en', language: 'en-US', file: 'en-US.json' },
+    ]
+    const context = generateContext(dirs, locales, 'B2B SaaS booking platform')
+    expect(context).toMatch(/^B2B SaaS booking platform/)
+    expect(context).toContain('1 locale')
+  })
 })
 
 describe('generateTranslationPrompt', () => {
@@ -307,6 +278,25 @@ describe('generateTranslationPrompt', () => {
     const prompt = generateTranslationPrompt()
     expect(prompt).toContain('{placeholders}')
     expect(prompt).toContain('@:linked')
+  })
+
+  it('prepends formal tone instruction', () => {
+    const prompt = generateTranslationPrompt('formal')
+    expect(prompt).toMatch(/^Use a formal/)
+    expect(prompt).toContain('{placeholders}')
+  })
+
+  it('prepends informal tone instruction', () => {
+    const prompt = generateTranslationPrompt('informal')
+    expect(prompt).toMatch(/^Use a friendly/)
+    expect(prompt).toContain('{placeholders}')
+  })
+
+  it('returns base prompt for mixed tone', () => {
+    const prompt = generateTranslationPrompt('mixed')
+    expect(prompt).not.toContain('formal')
+    expect(prompt).not.toContain('friendly')
+    expect(prompt).toContain('{placeholders}')
   })
 })
 
@@ -358,7 +348,7 @@ describe('generateProjectConfig', () => {
     expect(result.context).toContain('2 layers')
     expect(result.layerRules).toBeDefined()
     expect(result.layerRules!.length).toBe(2)
-    expect(result.glossary).toBeDefined()
+    expect(result.glossary).toEqual({})
     expect(result.translationPrompt).toBeDefined()
     expect(result.localeNotes).toBeDefined()
     expect(result.localeNotes!['de-formal']).toContain('Formal German')
@@ -395,5 +385,30 @@ describe('generateProjectConfig', () => {
     expect(result.layerRules).toBeDefined()
     expect(result.glossary).toEqual({})
     expect(result.examples).toEqual([])
+  })
+
+  it('merges elicited project info into context and translationPrompt', async () => {
+    mockReadLocaleFile.mockResolvedValue({
+      common: { save: 'Save' },
+    })
+
+    const config: I18nConfig = {
+      rootDir: '/project',
+      defaultLocale: 'en',
+      fallbackLocale: {},
+      locales: [{ code: 'en', language: 'en-US', file: 'en-US.json' }],
+      localeDirs: [
+        { path: '/project/i18n', layer: 'root', layerRootDir: '/project' },
+      ],
+    }
+
+    const elicited: ElicitedProjectInfo = {
+      description: 'B2B SaaS booking platform',
+      tone: 'formal',
+    }
+
+    const result = await generateProjectConfig(config, elicited)
+    expect(result.context).toContain('B2B SaaS booking platform')
+    expect(result.translationPrompt).toContain('formal')
   })
 })


### PR DESCRIPTION
## Summary

- Adds a `generate_config` MCP tool that analyzes a Nuxt project's i18n setup and auto-generates a `.i18n-mcp.json` configuration file
- Uses **MCP elicitation** to ask the user for project description and tone when the host supports it (Cursor, VS Code Insiders), falls back gracefully otherwise
- Adds a `create-config` MCP prompt that guides agents through building/refining `.i18n-mcp.json` interactively
- Glossary is left empty for manual or agent-assisted refinement (no more STOP_WORDS-based word frequency extraction)

## What it generates

The tool reads the project's detected i18n config and produces:

- **Context** — project description (from elicitation if available) + detected layers/locales summary
- **Layer rules** — per-layer namespace restrictions with `when` conditions
- **Glossary** — empty `{}` (domain terms require human/agent knowledge, not word frequency)
- **Translation prompt** — base instructions + optional tone from elicitation (formal/informal/mixed)
- **Locale notes** — formality, region, and fallback guidance per locale (e.g. `de-formal` → "Formal German using 'Sie'")
- **Examples** — real key/value pairs pulled from existing translations

## Elicitation flow

When the MCP host supports elicitation (`clientCapabilities.elicitation`), the tool presents a form:
1. **Project Description** — free-text ("B2B SaaS booking platform")
2. **Translation Tone** — enum (formal / informal / mixed)

The user can skip the form — the tool generates a config either way. User input enriches the `context` and `translationPrompt` fields.

## Architecture

- Pure generator functions in `src/generator/config-generator.ts` (no I/O side effects except `generateProjectConfig`)
- `ElicitedProjectInfo` interface flows user input from server handler → generator
- `generateContext()` and `generateTranslationPrompt()` accept optional elicited params
- 27 unit tests covering all generator functions including elicitation paths

## Files changed

| File | Change |
|---|---|
| `src/generator/config-generator.ts` | Generator functions, `ElicitedProjectInfo` type, elicitation-aware context/prompt |
| `src/server.ts` | `generate_config` tool with elicitation + `create-config` prompt registration |
| `tests/generator/config-generator.test.ts` | 27 tests including tone, description, and elicited data paths |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate project config for i18n with optional elicited project description and tone
  * Tool to create/write project config with overwrite protection and dry-run support
  * Guided prompt to detect i18n setup and assist config creation
  * Auto-generates translation examples, locale notes, layer rules, context, and a tone-aware translation prompt

* **Tests**
  * Comprehensive test suite covering config generation logic, examples, locale notes, prompts, and error handling

* **Documentation**
  * Clarified behavior for the missing-translations tool (reference vs target baseline)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->