### PR TITLE
fix: walk up directory tree to find .i18n-mcp.json in monorepos

### DIFF
--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import type { ProjectConfig } from './types.js'
 import { ConfigError } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
@@ -8,17 +8,37 @@ import { log } from '../utils/logger.js'
 const CONFIG_FILENAME = '.i18n-mcp.json'
 
 /**
+ * Walk up the directory tree from `startDir` to find the nearest config file.
+ * Returns the full path if found, null otherwise.
+ */
+export function findConfigFile(startDir: string): string | null {
+  let dir = startDir
+  while (true) {
+    const candidate = join(dir, CONFIG_FILENAME)
+    if (existsSync(candidate)) {
+      return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break // filesystem root
+    dir = parent
+  }
+  return null
+}
+
+/**
  * Load the optional project config file (.i18n-mcp.json).
- * Returns null if the file does not exist.
- * Throws ConfigError if the file exists but is invalid.
+ * Walks up from projectDir to find the nearest config file,
+ * similar to how ESLint, Prettier, and tsconfig resolve configs.
+ * Returns null if no config file is found in any ancestor.
+ * Throws ConfigError if a file is found but is invalid.
  */
 export async function loadProjectConfig(projectDir: string): Promise<ProjectConfig | null> {
-  const configPath = join(projectDir, CONFIG_FILENAME)
+  log.debug(`Searching for ${CONFIG_FILENAME} starting from: ${projectDir}`)
 
-  log.debug(`Looking for project config at: ${configPath}`)
+  const configPath = findConfigFile(projectDir)
 
-  if (!existsSync(configPath)) {
-    log.info(`No project config found at ${configPath} — skipping`)
+  if (!configPath) {
+    log.info(`No ${CONFIG_FILENAME} found in ${projectDir} or any parent directory — skipping`)
     return null
   }
 

--- a/tests/config/project-config.test.ts
+++ b/tests/config/project-config.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { resolve } from 'node:path'
-import { writeFile, unlink, mkdir } from 'node:fs/promises'
+import { writeFile, unlink, mkdir, rm } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { loadProjectConfig } from '../../src/config/project-config.js'
+import { loadProjectConfig, findConfigFile } from '../../src/config/project-config.js'
 
 const playgroundDir = resolve(import.meta.dirname, '../../playground')
 const tmpDir = resolve(import.meta.dirname, '../../.tmp-test')
+const traversalDir = resolve(import.meta.dirname, '../../.tmp-traversal')
 
 describe('loadProjectConfig', () => {
   // Test 1: loads config from playground (we just created the file above)
@@ -170,5 +171,114 @@ describe('loadProjectConfig', () => {
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
+  })
+})
+
+describe('parent directory traversal', () => {
+  afterEach(async () => {
+    if (existsSync(traversalDir)) {
+      await rm(traversalDir, { recursive: true })
+    }
+  })
+
+  it('finds config in parent directory when projectDir is a subdirectory', async () => {
+    const childDir = resolve(traversalDir, 'apps/admin')
+    await mkdir(childDir, { recursive: true })
+    await writeFile(
+      resolve(traversalDir, '.i18n-mcp.json'),
+      JSON.stringify({ context: 'from-parent' }),
+      'utf-8',
+    )
+
+    const config = await loadProjectConfig(childDir)
+    expect(config).not.toBeNull()
+    expect(config!.context).toBe('from-parent')
+  })
+
+  it('finds config in grandparent directory', async () => {
+    const deepChild = resolve(traversalDir, 'apps/admin/layers/dashboard')
+    await mkdir(deepChild, { recursive: true })
+    await writeFile(
+      resolve(traversalDir, '.i18n-mcp.json'),
+      JSON.stringify({ context: 'from-grandparent' }),
+      'utf-8',
+    )
+
+    const config = await loadProjectConfig(deepChild)
+    expect(config).not.toBeNull()
+    expect(config!.context).toBe('from-grandparent')
+  })
+
+  it('nearest config wins over higher ancestor', async () => {
+    const childDir = resolve(traversalDir, 'apps/admin')
+    await mkdir(childDir, { recursive: true })
+
+    await writeFile(
+      resolve(traversalDir, '.i18n-mcp.json'),
+      JSON.stringify({ context: 'root-config' }),
+      'utf-8',
+    )
+    await writeFile(
+      resolve(traversalDir, 'apps', '.i18n-mcp.json'),
+      JSON.stringify({ context: 'apps-config' }),
+      'utf-8',
+    )
+
+    const config = await loadProjectConfig(childDir)
+    expect(config).not.toBeNull()
+    expect(config!.context).toBe('apps-config')
+  })
+
+  it('still loads config from exact projectDir (no regression)', async () => {
+    await mkdir(traversalDir, { recursive: true })
+    await writeFile(
+      resolve(traversalDir, '.i18n-mcp.json'),
+      JSON.stringify({ context: 'exact-dir' }),
+      'utf-8',
+    )
+
+    const config = await loadProjectConfig(traversalDir)
+    expect(config).not.toBeNull()
+    expect(config!.context).toBe('exact-dir')
+  })
+
+  it('returns null when no config exists in any ancestor', async () => {
+    const deepDir = resolve(traversalDir, 'a/b/c')
+    await mkdir(deepDir, { recursive: true })
+
+    const config = await loadProjectConfig(deepDir)
+    expect(config).toBeNull()
+  })
+})
+
+describe('findConfigFile', () => {
+  afterEach(async () => {
+    if (existsSync(traversalDir)) {
+      await rm(traversalDir, { recursive: true })
+    }
+  })
+
+  it('returns path when config exists in startDir', async () => {
+    await mkdir(traversalDir, { recursive: true })
+    const configPath = resolve(traversalDir, '.i18n-mcp.json')
+    await writeFile(configPath, '{}', 'utf-8')
+
+    expect(findConfigFile(traversalDir)).toBe(configPath)
+  })
+
+  it('returns path from parent when not in startDir', async () => {
+    const childDir = resolve(traversalDir, 'sub')
+    await mkdir(childDir, { recursive: true })
+    const configPath = resolve(traversalDir, '.i18n-mcp.json')
+    await writeFile(configPath, '{}', 'utf-8')
+
+    expect(findConfigFile(childDir)).toBe(configPath)
+  })
+
+  it('returns null when no config exists', async () => {
+    const deepDir = resolve(traversalDir, 'x/y/z')
+    await mkdir(deepDir, { recursive: true })
+
+    expect(findConfigFile(deepDir)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

`loadProjectConfig()` now traverses parent directories from `projectDir` to find the nearest `.i18n-mcp.json`, matching the standard config resolution pattern used by ESLint, Prettier, and tsconfig.

## Problem

In monorepos where `projectDir` points to an app subdirectory (e.g. `app-admin/`) but `.i18n-mcp.json` lives at the workspace root, the config was silently ignored — disabling `orphanScan`, `glossary`, `translationPrompt`, and all other project config features.

## Changes

- **`src/config/project-config.ts`**: Extract `findConfigFile()` that walks up from `startDir` until it finds `.i18n-mcp.json` or hits filesystem root. `loadProjectConfig()` now uses this instead of checking only the exact `projectDir`.
- **`tests/config/project-config.test.ts`**: 8 new tests covering parent traversal, grandparent traversal, nearest-wins semantics, no-regression for exact dir, and `findConfigFile()` directly.

## Testing

- `pnpm typecheck` ✅
- `pnpm test` ✅ (216 tests pass)
- `pnpm lint` ✅

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files can now be automatically discovered in parent directories, enabling hierarchical configuration management across project subdirectories.

* **Tests**
  * Enhanced test coverage for configuration file resolution across directory hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->