### PR TITLE
feat: add ignorePatterns for orphan key detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ For IDE autocompletion, point to the schema:
 | `translationPrompt` | System prompt prepended to all translation requests |
 | `localeNotes` | Per-locale instructions (e.g., "Formal German using 'Sie'") |
 | `examples` | Few-shot translation examples demonstrating your project's style |
+| `orphanScan` | Per-layer config for orphan key detection: `scanDirs` to scan and `ignorePatterns` to exclude keys by glob pattern |
 
 <details>
 <summary><strong>Full example</strong></summary>
@@ -170,7 +171,16 @@ For IDE autocompletion, point to the schema:
       "en-US": "Save",
       "note": "Concise, imperative"
     }
-  ]
+  ],
+  "orphanScan": {
+    "shared": {
+      "scanDirs": ["apps/shop", "apps/admin", "packages/shared"],
+      "ignorePatterns": ["common.datetime.**", "common.countries.*"]
+    },
+    "app-admin": {
+      "scanDirs": ["apps/admin"]
+    }
+  }
 }
 ```
 

--- a/schema.json
+++ b/schema.json
@@ -96,6 +96,13 @@
             "items": {
               "type": "string"
             }
+          },
+          "ignorePatterns": {
+            "type": "array",
+            "description": "Glob patterns for translation keys to exclude from orphan detection (e.g., \"common.datetime.months.*\"). Use * to match a single key segment, ** to match any depth.",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -165,6 +165,16 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
           throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.scanDirs[${i}]" must be a string`)
         }
       }
+      if ('ignorePatterns' in layerObj) {
+        if (!Array.isArray(layerObj.ignorePatterns)) {
+          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns" must be an array of strings`)
+        }
+        for (let i = 0; i < layerObj.ignorePatterns.length; i++) {
+          if (typeof layerObj.ignorePatterns[i] !== 'string') {
+            throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns[${i}]" must be a string`)
+          }
+        }
+      }
     }
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,9 +47,12 @@ export interface ProjectConfig {
   localeNotes?: Record<string, string>
   /** Few-shot translation examples */
   examples?: Array<Record<string, string>>
-  /** Per-layer scan directories for orphan key detection. Keys are layer names, scanDirs are paths relative to the project root. */
+  /** Per-layer scan directories and ignore patterns for orphan key detection. Keys are layer names. */
   orphanScan?: Record<string, {
+    /** Directories to scan for key usage (relative to project root). */
     scanDirs: string[]
+    /** Glob patterns for translation keys to exclude from orphan detection (e.g., "common.datetime.months.*"). */
+    ignorePatterns?: string[]
   }>
 }
 

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -221,3 +221,33 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[]): 
 export function toRelativePath(filePath: string, rootDir: string): string {
   return relative(rootDir, filePath)
 }
+
+/**
+ * Convert dot-path glob patterns (e.g., "common.datetime.**", "pages.*.title")
+ * into RegExp objects for matching translation keys.
+ *
+ * - `**` matches any number of dot-separated segments (including zero)
+ * - `*` matches exactly one segment (no dots)
+ */
+export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
+  return patterns.map((pattern) => {
+    let regexStr = ''
+    let i = 0
+    while (i < pattern.length) {
+      if (pattern[i] === '*' && pattern[i + 1] === '*') {
+        regexStr += '.*'
+        i += 2
+      } else if (pattern[i] === '*') {
+        regexStr += '[^.]*'
+        i += 1
+      } else if ('.+?^${}()|[]\\'.includes(pattern[i])) {
+        regexStr += '\\' + pattern[i]
+        i += 1
+      } else {
+        regexStr += pattern[i]
+        i += 1
+      }
+    }
+    return new RegExp(`^${regexStr}$`)
+  })
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import {
   renameNestedKey,
   validateTranslationValue,
 } from './io/key-operations.js'
-import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes } from './scanner/code-scanner.js'
+import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from './scanner/code-scanner.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
 import { join, resolve } from 'node:path'
@@ -27,6 +27,16 @@ function resolveOrphanScanDirs(
   const layerConfig = config.projectConfig.orphanScan[layer]
   if (!layerConfig) return undefined
   return layerConfig.scanDirs.map(d => resolve(config.rootDir, d))
+}
+
+function resolveOrphanIgnorePatterns(
+  config: I18nConfig,
+  layer: string | undefined,
+): string[] | undefined {
+  if (!layer || !config.projectConfig?.orphanScan) return undefined
+  const layerConfig = config.projectConfig.orphanScan[layer]
+  if (!layerConfig?.ignorePatterns?.length) return undefined
+  return layerConfig.ignorePatterns
 }
 
 // ─── Shared helpers ───────────────────────────────────────────────
@@ -1460,13 +1470,18 @@ export function createServer(): McpServer {
 
         // Find orphan keys: translation keys not referenced in source code
         const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeys)
+        const ignorePatterns = resolveOrphanIgnorePatterns(config, layer)
+        const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
 
         const orphanKeys: Array<{ key: string; layer: string }> = []
         let dynamicMatchedCount = 0
+        let ignoredCount = 0
         for (const [key, keyLayer] of allTranslationKeys) {
           if (!combinedUniqueKeys.has(key)) {
             if (dynamicKeyRegexes.some(re => re.test(key))) {
               dynamicMatchedCount++
+            } else if (ignoreRegexes.length > 0 && ignoreRegexes.some(re => re.test(key))) {
+              ignoredCount++
             } else {
               orphanKeys.push({ key, layer: keyLayer })
             }
@@ -1489,6 +1504,7 @@ export function createServer(): McpServer {
             totalKeys: allTranslationKeys.size,
             orphanCount: orphanKeys.length,
             dynamicMatchedCount,
+            ignoredCount,
             usedCount: allTranslationKeys.size - orphanKeys.length,
             filesScanned: totalFilesScanned,
             layersChecked: layersToCheck.map(d => d.layer),
@@ -1724,15 +1740,22 @@ export function createServer(): McpServer {
 
         // Find orphan keys per layer
         const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeys)
+        const ignorePatterns = resolveOrphanIgnorePatterns(config, layer)
+        const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
 
         const orphansByLayer: Record<string, string[]> = {}
         let orphanCount = 0
         let dynamicMatchedCount = 0
+        let ignoredCount = 0
         for (const [layerName, keys] of keysByLayer) {
           const orphans = keys.filter((k) => {
             if (combinedUniqueKeys.has(k)) return false
             if (dynamicKeyRegexes.some(re => re.test(k))) {
               dynamicMatchedCount++
+              return false
+            }
+            if (ignoreRegexes.length > 0 && ignoreRegexes.some(re => re.test(k))) {
+              ignoredCount++
               return false
             }
             return true
@@ -1744,15 +1767,16 @@ export function createServer(): McpServer {
         }
 
         if (orphanCount === 0) {
-          const message = dynamicMatchedCount > 0
-            ? `No orphan keys found. ${dynamicMatchedCount} key(s) were excluded by dynamic pattern matching.`
-            : 'No orphan keys found. All translation keys are referenced in code.'
+          const messageParts: string[] = ['No orphan keys found.']
+          if (dynamicMatchedCount > 0) messageParts.push(`${dynamicMatchedCount} key(s) were excluded by dynamic pattern matching.`)
+          if (ignoredCount > 0) messageParts.push(`${ignoredCount} key(s) were excluded by ignore patterns.`)
+          if (dynamicMatchedCount === 0 && ignoredCount === 0) messageParts.push('All translation keys are referenced in code.')
           return {
             content: [{
               type: 'text' as const,
               text: JSON.stringify({
                 orphanKeys: {},
-                summary: { totalKeys, orphanCount: 0, dynamicMatchedCount, filesScanned: totalFilesScanned, message },
+                summary: { totalKeys, orphanCount: 0, dynamicMatchedCount, ignoredCount, filesScanned: totalFilesScanned, message: messageParts.join(' ') },
               }, null, 2),
             }],
           }
@@ -1767,9 +1791,10 @@ export function createServer(): McpServer {
               totalKeys,
               orphanCount,
               dynamicMatchedCount,
+              ignoredCount,
               usedCount: totalKeys - orphanCount,
               filesScanned: totalFilesScanned,
-              message: `Found ${orphanCount} orphan key(s). ${dynamicMatchedCount > 0 ? `${dynamicMatchedCount} key(s) matched dynamic patterns and were excluded. ` : ''}Call again with dryRun: false to remove them.`,
+              message: `Found ${orphanCount} orphan key(s). ${dynamicMatchedCount > 0 ? `${dynamicMatchedCount} key(s) matched dynamic patterns and were excluded. ` : ''}${ignoredCount > 0 ? `${ignoredCount} key(s) matched ignore patterns and were excluded. ` : ''}Call again with dryRun: false to remove them.`,
             },
           }
           if (allDynamicKeys.length > 0) {
@@ -1818,6 +1843,7 @@ export function createServer(): McpServer {
                 totalKeys,
                 removedCount: orphanCount,
                 dynamicMatchedCount,
+                ignoredCount,
                 remainingCount: totalKeys - orphanCount,
                 filesWritten: totalFilesWritten,
                 filesScanned: totalFilesScanned,

--- a/tests/config/project-config.test.ts
+++ b/tests/config/project-config.test.ts
@@ -172,6 +172,66 @@ describe('loadProjectConfig', () => {
       if (existsSync(configPath)) await unlink(configPath)
     }
   })
+
+  it('accepts valid orphanScan config with ignorePatterns', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({
+        orphanScan: {
+          root: {
+            scanDirs: ['apps/shop'],
+            ignorePatterns: ['common.datetime.**', 'pages.*.title']
+          }
+        }
+      }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config).not.toBeNull()
+      expect(config!.orphanScan!.root.ignorePatterns).toEqual(['common.datetime.**', 'pages.*.title'])
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  it('accepts orphanScan without ignorePatterns (optional field)', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({
+        orphanScan: { root: { scanDirs: ['src'] } }
+      }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config!.orphanScan!.root.ignorePatterns).toBeUndefined()
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  it('throws when ignorePatterns is not an array', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({
+        orphanScan: { root: { scanDirs: ['src'], ignorePatterns: 'not-an-array' } }
+      }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns" must be an array of strings')
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  it('throws when ignorePatterns contains non-strings', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({
+        orphanScan: { root: { scanDirs: ['src'], ignorePatterns: ['valid.*', 123] } }
+      }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns[1]" must be a string')
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
 })
 
 describe('parent directory traversal', () => {

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes } from '../../src/scanner/code-scanner.js'
+import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
@@ -368,6 +368,70 @@ describe('buildDynamicKeyRegexes', () => {
     expect(regexes).toHaveLength(1)
     expect(regexes[0].test('prefix.computed.title')).toBe(true)
     expect(regexes[0].test('prefix.computed.title.extra')).toBe(false)
+  })
+})
+
+describe('buildIgnorePatternRegexes', () => {
+  it('matches single-segment wildcard (*)', () => {
+    const [re] = buildIgnorePatternRegexes(['common.actions.*'])
+    expect(re.test('common.actions.save')).toBe(true)
+    expect(re.test('common.actions.delete')).toBe(true)
+    expect(re.test('common.actions.nested.key')).toBe(false)
+    expect(re.test('common.actions.')).toBe(true)
+  })
+
+  it('matches multi-segment wildcard (**)', () => {
+    const [re] = buildIgnorePatternRegexes(['common.datetime.**'])
+    expect(re.test('common.datetime.months.january')).toBe(true)
+    expect(re.test('common.datetime.days')).toBe(true)
+    expect(re.test('common.datetime.')).toBe(true)
+    expect(re.test('common.other.months')).toBe(false)
+  })
+
+  it('matches wildcard in middle of pattern', () => {
+    const [re] = buildIgnorePatternRegexes(['pages.*.title'])
+    expect(re.test('pages.home.title')).toBe(true)
+    expect(re.test('pages.admin.title')).toBe(true)
+    expect(re.test('pages.deep.nested.title')).toBe(false)
+    expect(re.test('pages..title')).toBe(true)
+  })
+
+  it('matches ** in middle of pattern', () => {
+    const [re] = buildIgnorePatternRegexes(['pages.**.title'])
+    expect(re.test('pages.home.title')).toBe(true)
+    expect(re.test('pages.deep.nested.title')).toBe(true)
+    expect(re.test('pages.title')).toBe(false)
+  })
+
+  it('matches exact pattern without wildcards', () => {
+    const [re] = buildIgnorePatternRegexes(['common.actions.save'])
+    expect(re.test('common.actions.save')).toBe(true)
+    expect(re.test('common.actions.saves')).toBe(false)
+    expect(re.test('common.actions.sav')).toBe(false)
+  })
+
+  it('handles multiple patterns', () => {
+    const regexes = buildIgnorePatternRegexes(['common.datetime.**', 'pages.*.title'])
+    expect(regexes).toHaveLength(2)
+    expect(regexes[0].test('common.datetime.months.jan')).toBe(true)
+    expect(regexes[1].test('pages.home.title')).toBe(true)
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(buildIgnorePatternRegexes([])).toHaveLength(0)
+  })
+
+  it('escapes special regex characters', () => {
+    const [re] = buildIgnorePatternRegexes(['path.with+special.key'])
+    expect(re.test('path.with+special.key')).toBe(true)
+    expect(re.test('path.withXspecial.key')).toBe(false)
+  })
+
+  it('anchors patterns (no partial matches)', () => {
+    const [re] = buildIgnorePatternRegexes(['common.*'])
+    expect(re.test('common.save')).toBe(true)
+    expect(re.test('prefix.common.save')).toBe(false)
+    expect(re.test('common.save.extra')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Implements #22 — adds `ignorePatterns` support to `orphanScan` in `.i18n-mcp.json`, allowing users to exclude translation keys from orphan detection using glob patterns.

## Changes

- **`src/config/types.ts`** — Added optional `ignorePatterns?: string[]` to the `orphanScan` per-layer config type
- **`schema.json`** — Added `ignorePatterns` array property to the JSON schema for IDE autocompletion
- **`src/config/project-config.ts`** — Added validation: `ignorePatterns` must be an array of strings
- **`src/scanner/code-scanner.ts`** — Added `buildIgnorePatternRegexes()` — converts dot-path glob patterns (`*` = single segment, `**` = multi-segment) to anchored RegExp objects
- **`src/server.ts`** — Added `resolveOrphanIgnorePatterns()` helper; integrated ignore filtering into both `find_orphan_keys` and `cleanup_unused_translations` tools; added `ignoredCount` to all summary outputs
- **`tests/scanner/code-scanner.test.ts`** — 9 unit tests for `buildIgnorePatternRegexes` (wildcards, anchoring, escaping, edge cases)
- **`tests/config/project-config.test.ts`** — 4 validation tests (valid config, optional field, invalid type, non-string items)
- **`README.md`** — Documented `orphanScan` field (including `ignorePatterns`) in the Project Config table and full example

## Usage

```json
{
  "orphanScan": {
    "shared": {
      "scanDirs": ["apps/shop", "apps/admin"],
      "ignorePatterns": ["common.datetime.**", "common.countries.*"]
    }
  }
}
```

- `*` matches a single key segment (no dots): `common.actions.*` matches `common.actions.save` but not `common.actions.nested.key`
- `**` matches any number of segments: `common.datetime.**` matches `common.datetime.months.january`

## Verification

- ✅ `pnpm run typecheck` — passes
- ✅ `pnpm test` — 229/229 tests pass (13 new)
- ✅ `pnpm run build` — passes
- ✅ `pnpm run lint` — passes (pre-commit hook)

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ignorePatterns` option to `orphanScan` configuration, enabling glob-based exclusion of translation keys from orphan detection.

* **Documentation**
  * Updated schema and README documentation to document the new ignore patterns feature.

* **Tests**
  * Added comprehensive test coverage for ignore patterns validation and glob pattern matching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->