### PR TITLE
fix: use source-level shebang for proper npx execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "schema.json"
   ],
   "scripts": {
-    "build": "tsdown && chmod +x dist/index.js",
+    "build": "tsdown",
     "dev": "tsdown --watch",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createServer } from './server.js'
 import { log } from './utils/logger.js'

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,7 +7,4 @@ export default defineConfig({
   clean: true,
   dts: true,
   sourcemap: true,
-  banner: {
-    js: '#!/usr/bin/env node',
-  },
 })


### PR DESCRIPTION
## Summary

- Moves the `#!/usr/bin/env node` shebang from `tsdown.config.ts` `banner` config (which was silently ignored by tsdown v0.12.9) into `src/index.ts` as a source-level shebang
- tsdown's built-in `ShebangPlugin` detects the shebang in source files, preserves it in `dist/index.js`, and auto-sets the executable bit — so the manual `chmod +x` in the build script is removed
- Fixes `npx nuxt-i18n-mcp` failing with `env: node\r: No such file or directory` or missing executable bit

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Added `#!/usr/bin/env node` as first line |
| `tsdown.config.ts` | Removed `banner: { js: '#!/usr/bin/env node' }` (was silently ignored) |
| `package.json` | Simplified build script from `tsdown && chmod +x dist/index.js` to `tsdown` |

## Verification

- `pnpm build` produces `dist/index.js` with shebang on first line ✅
- File has executable permission (`-rwxr-xr-x`) via ShebangPlugin ✅
- All 247 tests pass ✅
- Lint + typecheck clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by consolidating shebang handling and removing redundant setup steps from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->