### PR TITLE
feat: add dryRun support to add_translations and update_translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Every write tool requires a `layer` parameter (e.g., `"root"`, `"app-admin"`). U
 | `detect_i18n_config` | Loads Nuxt config, returns locales, layers, directories, and project config. **Call first.** |
 | `list_locale_dirs` | Lists locale directories grouped by layer, with file counts and top-level key namespaces |
 | `get_translations` | Reads values for dot-path keys from a locale/layer. Use `"*"` as locale for all locales |
-| `add_translations` | Adds new keys to a **layer** across locales. Fails if key already exists |
-| `update_translations` | Updates existing keys in a **layer**. Fails if key doesn't exist |
+| `add_translations` | Adds new keys to a **layer** across locales. Fails if key already exists. Supports `dryRun` |
+| `update_translations` | Updates existing keys in a **layer**. Fails if key doesn't exist. Supports `dryRun` |
 | `remove_translations` | Removes keys from ALL locale files in a **layer**. Supports `dryRun` |
 | `rename_translation_key` | Renames/moves a key across all locales in a **layer**. Conflict detection + `dryRun` |
 | `get_missing_translations` | Finds keys present in reference locale but missing/empty in targets. `""` counts as missing |

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,6 +95,7 @@ function toolErrorResponse(context: string, error: unknown) {
  * Shared logic for add_translations and update_translations.
  * - mode 'add': fails if key already exists
  * - mode 'update': fails if key does not exist
+ * - dryRun: when true, reads files to check what would happen but does not write
  */
 async function applyTranslations(
   config: I18nConfig,
@@ -103,14 +104,15 @@ async function applyTranslations(
   mode: 'add' | 'update',
   findLocale: (config: I18nConfig, ref: string) => ReturnType<typeof findLocaleImpl>,
   resolveLocaleFilePath: (config: I18nConfig, layer: string, file: string) => string | null,
-): Promise<{ applied: string[]; skipped: string[]; warnings: string[]; filesWritten: number }> {
+  dryRun = false,
+): Promise<{ applied: string[]; skipped: string[]; warnings: string[]; filesWritten: number; preview?: Array<{ locale: string; key: string; value: string }> }> {
   const applied: string[] = []
   const skipped: string[] = []
   const warnings: string[] = []
   const filesWritten = new Set<string>()
+  const preview: Array<{ locale: string; key: string; value: string }> = []
 
-  // Group translations by locale file
-  const byFile = new Map<string, Array<{ key: string; value: string }>>()
+  const byFile = new Map<string, Array<{ key: string; value: string; localeCode: string }>>()
 
   for (const [key, localeValues] of Object.entries(translations)) {
     for (const [localeRef, value] of Object.entries(localeValues)) {
@@ -133,34 +135,59 @@ async function applyTranslations(
       if (!byFile.has(filePath)) {
         byFile.set(filePath, [])
       }
-      byFile.get(filePath)!.push({ key, value })
+      byFile.get(filePath)!.push({ key, value, localeCode: locale.code })
     }
   }
 
-  // Apply changes per file
   for (const [filePath, entries] of byFile) {
-    await mutateLocaleFile(filePath, (data) => {
-      for (const { key, value } of entries) {
+    if (dryRun) {
+      let data: Record<string, unknown> = {}
+      try {
+        data = await readLocaleFile(filePath)
+      } catch {
+        // File doesn't exist yet — treat all keys as applicable
+      }
+      for (const { key, value, localeCode } of entries) {
         const exists = hasNestedKey(data, key)
         if (mode === 'add' && exists) {
           skipped.push(key)
         } else if (mode === 'update' && !exists) {
           skipped.push(key)
         } else {
-          setNestedValue(data, key, value)
           applied.push(key)
+          preview.push({ locale: localeCode, key, value })
         }
       }
-    })
-    filesWritten.add(filePath)
+    } else {
+      await mutateLocaleFile(filePath, (data) => {
+        for (const { key, value } of entries) {
+          const exists = hasNestedKey(data, key)
+          if (mode === 'add' && exists) {
+            skipped.push(key)
+          } else if (mode === 'update' && !exists) {
+            skipped.push(key)
+          } else {
+            setNestedValue(data, key, value)
+            applied.push(key)
+          }
+        }
+      })
+      filesWritten.add(filePath)
+    }
   }
 
-  return {
+  const result: { applied: string[]; skipped: string[]; warnings: string[]; filesWritten: number; preview?: Array<{ locale: string; key: string; value: string }> } = {
     applied: [...new Set(applied)],
     skipped: [...new Set(skipped)],
     warnings,
     filesWritten: filesWritten.size,
   }
+
+  if (dryRun) {
+    result.preview = preview
+  }
+
+  return result
 }
 
 // ─── Sampling prompt helpers ──────────────────────────────────────
@@ -491,20 +518,46 @@ export function createServer(): McpServer {
             ),
           )
           .describe('Map of key paths to locale-value pairs'),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe('If true, return a preview of what would be added without writing. Default: false.'),
         projectDir: z
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd.'),
       },
     },
-    async ({ layer, translations, projectDir }) => {
+    async ({ layer, translations, dryRun, projectDir }) => {
       try {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
+        const isDryRun = dryRun ?? false
 
-        const { applied, skipped, warnings, filesWritten } = await applyTranslations(
-          config, layer, translations, 'add', findLocale, resolveLocaleFilePath,
+        const { applied, skipped, warnings, filesWritten, preview } = await applyTranslations(
+          config, layer, translations, 'add', findLocale, resolveLocaleFilePath, isDryRun,
         )
+
+        if (isDryRun) {
+          const result: Record<string, unknown> = {
+            dryRun: true,
+            wouldAdd: preview,
+            summary: {
+              keysToAdd: applied.length,
+              keysSkipped: skipped.length,
+              message: 'Call again with dryRun: false to apply these changes.',
+            },
+          }
+          if (skipped.length > 0) {
+            result.skippedKeys = skipped
+          }
+          if (warnings.length > 0) {
+            result.warnings = warnings
+          }
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          }
+        }
 
         const summary: Record<string, unknown> = {
           added: applied,
@@ -548,20 +601,43 @@ export function createServer(): McpServer {
             ),
           )
           .describe('Map of key paths to locale-value pairs'),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe('If true, return a preview of what would be updated without writing. Default: false.'),
         projectDir: z
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd.'),
       },
     },
-    async ({ layer, translations, projectDir }) => {
+    async ({ layer, translations, dryRun, projectDir }) => {
       try {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
+        const isDryRun = dryRun ?? false
 
-        const { applied, skipped, filesWritten } = await applyTranslations(
-          config, layer, translations, 'update', findLocale, resolveLocaleFilePath,
+        const { applied, skipped, filesWritten, preview } = await applyTranslations(
+          config, layer, translations, 'update', findLocale, resolveLocaleFilePath, isDryRun,
         )
+
+        if (isDryRun) {
+          const result: Record<string, unknown> = {
+            dryRun: true,
+            wouldUpdate: preview,
+            summary: {
+              keysToUpdate: applied.length,
+              keysSkipped: skipped.length,
+              message: 'Call again with dryRun: false to apply these changes.',
+            },
+          }
+          if (skipped.length > 0) {
+            result.skippedKeys = skipped
+          }
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          }
+        }
 
         return {
           content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import {
 } from './io/key-operations.js'
 import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from './scanner/code-scanner.js'
 import { log } from './utils/logger.js'
-import { ToolError } from './utils/errors.js'
+import { FileIOError, ToolError } from './utils/errors.js'
 import { join, resolve } from 'node:path'
 import { readdir } from 'node:fs/promises'
 
@@ -144,8 +144,15 @@ async function applyTranslations(
       let data: Record<string, unknown> = {}
       try {
         data = await readLocaleFile(filePath)
-      } catch {
-        // File doesn't exist yet — treat all keys as applicable
+      } catch (err) {
+        if (err instanceof FileIOError && err.message.startsWith('File not found')) {
+          // File doesn't exist yet — treat all keys as applicable
+        } else {
+          throw new ToolError(
+            `Failed to read locale file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+            'LOCALE_READ_ERROR',
+          )
+        }
       }
       for (const { key, value, localeCode } of entries) {
         const exists = hasNestedKey(data, key)

--- a/tests/tools/add-update-dry-run.test.ts
+++ b/tests/tools/add-update-dry-run.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { resolve, join } from 'node:path'
+import { cp, rm, readFile, mkdir } from 'node:fs/promises'
+import { readLocaleFile } from '../../src/io/json-reader.js'
+import { mutateLocaleFile } from '../../src/io/json-writer.js'
+import {
+  getNestedValue,
+  hasNestedKey,
+  setNestedValue,
+} from '../../src/io/key-operations.js'
+
+const playgroundDir = resolve(import.meta.dirname, '../../playground')
+const playgroundRootLocales = resolve(playgroundDir, 'i18n/locales')
+
+const tmpDir = resolve(import.meta.dirname, '../../.tmp-add-update')
+const tmpRootLocales = resolve(tmpDir, 'root')
+
+const localeFiles = ['de-DE.json', 'en-US.json', 'fr-FR.json', 'es-ES.json']
+
+async function copyLocaleFiles() {
+  await mkdir(tmpRootLocales, { recursive: true })
+  await cp(playgroundRootLocales, tmpRootLocales, { recursive: true })
+}
+
+async function snapshotFiles(): Promise<Record<string, string>> {
+  const snapshot: Record<string, string> = {}
+  for (const file of localeFiles) {
+    snapshot[file] = await readFile(join(tmpRootLocales, file), 'utf-8')
+  }
+  return snapshot
+}
+
+// ─── add_translations dry-run behaviour ─────────────────────────
+
+describe('add_translations dryRun', () => {
+  beforeEach(async () => {
+    await copyLocaleFiles()
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('previews new keys without writing to disk', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const newKey = 'common.actions.submit'
+    const value = 'Submit'
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      const exists = hasNestedKey(data, newKey)
+
+      if (exists) {
+        skipped.push(newKey)
+      } else {
+        applied.push(newKey)
+        preview.push({ locale: file, key: newKey, value })
+      }
+    }
+
+    expect(applied).toHaveLength(localeFiles.length)
+    expect(skipped).toHaveLength(0)
+    expect(preview).toHaveLength(localeFiles.length)
+    for (const entry of preview) {
+      expect(entry.key).toBe('common.actions.submit')
+      expect(entry.value).toBe('Submit')
+    }
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('skips existing keys in add mode', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const existingKey = 'common.actions.save'
+    const value = 'Save Updated'
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      const exists = hasNestedKey(data, existingKey)
+
+      if (exists) {
+        skipped.push(existingKey)
+      } else {
+        applied.push(existingKey)
+        preview.push({ locale: file, key: existingKey, value })
+      }
+    }
+
+    expect(skipped).toHaveLength(localeFiles.length)
+    expect(applied).toHaveLength(0)
+    expect(preview).toHaveLength(0)
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('handles mixed keys: some new, some existing', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const keys = [
+      { key: 'common.actions.save', value: 'Save' },
+      { key: 'common.actions.submit', value: 'Submit' },
+    ]
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+
+      for (const { key, value } of keys) {
+        const exists = hasNestedKey(data, key)
+        if (exists) {
+          skipped.push(key)
+        } else {
+          applied.push(key)
+          preview.push({ locale: file, key, value })
+        }
+      }
+    }
+
+    expect(skipped).toHaveLength(localeFiles.length)
+    expect(applied).toHaveLength(localeFiles.length)
+    expect(preview).toHaveLength(localeFiles.length)
+    expect(preview.every(p => p.key === 'common.actions.submit')).toBe(true)
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('actually writes when dryRun is false (control test)', async () => {
+    const newKey = 'common.actions.submit'
+    const value = 'Submit'
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      await mutateLocaleFile(filePath, (data) => {
+        if (!hasNestedKey(data, newKey)) {
+          setNestedValue(data, newKey, value)
+        }
+      })
+    }
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      expect(hasNestedKey(data, newKey)).toBe(true)
+      expect(getNestedValue(data, newKey)).toBe(value)
+    }
+  })
+})
+
+// ─── update_translations dry-run behaviour ──────────────────────
+
+describe('update_translations dryRun', () => {
+  beforeEach(async () => {
+    await copyLocaleFiles()
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('previews existing key updates without writing to disk', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const existingKey = 'common.actions.save'
+    const newValue = 'Save Changes'
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      const exists = hasNestedKey(data, existingKey)
+
+      if (!exists) {
+        skipped.push(existingKey)
+      } else {
+        applied.push(existingKey)
+        preview.push({ locale: file, key: existingKey, value: newValue })
+      }
+    }
+
+    expect(applied).toHaveLength(localeFiles.length)
+    expect(skipped).toHaveLength(0)
+    expect(preview).toHaveLength(localeFiles.length)
+    for (const entry of preview) {
+      expect(entry.value).toBe('Save Changes')
+    }
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('skips non-existent keys in update mode', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const nonExistentKey = 'common.actions.submit'
+    const value = 'Submit'
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      const exists = hasNestedKey(data, nonExistentKey)
+
+      if (!exists) {
+        skipped.push(nonExistentKey)
+      } else {
+        applied.push(nonExistentKey)
+        preview.push({ locale: file, key: nonExistentKey, value })
+      }
+    }
+
+    expect(skipped).toHaveLength(localeFiles.length)
+    expect(applied).toHaveLength(0)
+    expect(preview).toHaveLength(0)
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('handles mixed keys: some existing, some not', async () => {
+    const before = await snapshotFiles()
+
+    const preview: Array<{ locale: string; key: string; value: string }> = []
+    const applied: string[] = []
+    const skipped: string[] = []
+
+    const keys = [
+      { key: 'common.actions.save', value: 'Save Changes' },
+      { key: 'common.actions.submit', value: 'Submit' },
+    ]
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+
+      for (const { key, value } of keys) {
+        const exists = hasNestedKey(data, key)
+        if (!exists) {
+          skipped.push(key)
+        } else {
+          applied.push(key)
+          preview.push({ locale: file, key, value })
+        }
+      }
+    }
+
+    expect(applied).toHaveLength(localeFiles.length)
+    expect(skipped).toHaveLength(localeFiles.length)
+    expect(preview).toHaveLength(localeFiles.length)
+    expect(preview.every(p => p.key === 'common.actions.save')).toBe(true)
+
+    const after = await snapshotFiles()
+    for (const file of localeFiles) {
+      expect(after[file]).toBe(before[file])
+    }
+  })
+
+  it('actually writes when dryRun is false (control test)', async () => {
+    const existingKey = 'common.actions.save'
+    const newValue = 'Save Changes'
+
+    const originalValues: Record<string, unknown> = {}
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      originalValues[file] = getNestedValue(data, existingKey)
+    }
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      await mutateLocaleFile(filePath, (data) => {
+        if (hasNestedKey(data, existingKey)) {
+          setNestedValue(data, existingKey, newValue)
+        }
+      })
+    }
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const data = await readLocaleFile(filePath)
+      expect(getNestedValue(data, existingKey)).toBe(newValue)
+      expect(getNestedValue(data, existingKey)).not.toBe(originalValues[file])
+    }
+  })
+
+  it('preserves file formatting after read-only dryRun', async () => {
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const raw = await readFile(filePath, 'utf-8')
+      expect(() => JSON.parse(raw)).not.toThrow()
+      expect(raw.endsWith('\n')).toBe(true)
+    }
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      await readLocaleFile(filePath)
+    }
+
+    for (const file of localeFiles) {
+      const filePath = join(tmpRootLocales, file)
+      const raw = await readFile(filePath, 'utf-8')
+      expect(() => JSON.parse(raw)).not.toThrow()
+      expect(raw.endsWith('\n')).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `dryRun` parameter to `add_translations` and `update_translations` tools
- When `dryRun=true`, reads locale files to determine what would change but skips all writes
- Returns a preview array with `{ locale, key, value }` for each applicable change, plus a summary of keys to add/update and keys that would be skipped

## Changes

- **`src/server.ts`**: Extended `applyTranslations()` with a `dryRun` parameter. When true, reads files via `readLocaleFile()` to check key existence, populates a `preview` array, and returns early without calling `mutateLocaleFile()`. Both tool handlers (`add_translations`, `update_translations`) expose `dryRun` in their input schema and return structured dry-run responses.
- **`README.md`**: Updated tool table to note `dryRun` support for both tools.
- **`tests/tools/add-update-dry-run.test.ts`**: 9 tests covering preview output for new/existing keys, skip logic for both modes, mixed key scenarios, control tests for actual writes, and file integrity.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run option for translation tools so you can preview per-locale adds/updates without writing files; responses include a detailed preview and summary. Add still fails if key exists; update still fails if key is missing.

* **Tests**
  * Added end-to-end tests verifying dry-run previews, skipped keys, and that files remain unchanged.

* **Documentation**
  * Updated documentation to describe the dry-run option and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->