### PR TITLE
fix: discover sub-apps when root has nuxt.config with i18n

### DIFF
--- a/src/config/detector.ts
+++ b/src/config/detector.ts
@@ -33,22 +33,30 @@ export async function detectI18nConfig(projectDir: string): Promise<I18nConfig> 
 
   log.info(`Detecting i18n config from: ${projectDir}`)
 
-  const isNuxtApp = findNuxtConfig(projectDir) !== null
+  const appDirs = await discoverNuxtApps(projectDir)
 
-  if (isNuxtApp) {
-    const config = await loadSingleApp(projectDir, projectDir)
-    configCache.set(canonDir, config)
-    lastConfig = config
-    log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)
-    return config
+  // discoverNuxtApps stops descending at nuxt.config dirs, so the root is
+  // included when it has i18n. Guard against root having a config without i18n.
+  if (findNuxtConfig(projectDir) && !appDirs.includes(projectDir)) {
+    appDirs.unshift(projectDir)
   }
 
-  const appDirs = await discoverNuxtApps(projectDir)
   if (appDirs.length === 0) {
     throw new ConfigError(
       `No Nuxt apps with i18n configuration found under ${projectDir}. `
       + 'Make sure your Nuxt apps have a nuxt.config.ts with i18n configured.',
     )
+  }
+
+  if (appDirs.length === 1) {
+    const config = await loadSingleApp(appDirs[0], projectDir)
+    if (appDirs[0] !== projectDir) {
+      config.rootDir = projectDir
+    }
+    configCache.set(canonDir, config)
+    lastConfig = config
+    log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)
+    return config
   }
 
   log.info(`Discovered ${appDirs.length} Nuxt app(s) with i18n: ${appDirs.map(d => relative(projectDir, d) || '.').join(', ')}`)

--- a/src/config/discovery.ts
+++ b/src/config/discovery.ts
@@ -49,13 +49,13 @@ async function hasI18nConfig(configPath: string): Promise<boolean> {
  */
 export async function discoverNuxtApps(rootDir: string): Promise<string[]> {
   const apps: string[] = []
-  await scanForApps(rootDir, 0, apps)
+  await scanForApps(rootDir, 0, apps, true)
   const root = resolve(rootDir)
   apps.sort((a, b) => relative(root, a).localeCompare(relative(root, b)))
   return apps
 }
 
-async function scanForApps(dir: string, depth: number, results: string[]): Promise<void> {
+async function scanForApps(dir: string, depth: number, results: string[], isRoot = false): Promise<void> {
   if (depth > MAX_DISCOVERY_DEPTH) return
 
   const configFile = findNuxtConfig(dir)
@@ -64,7 +64,7 @@ async function scanForApps(dir: string, depth: number, results: string[]): Promi
     if (await hasI18nConfig(configPath)) {
       results.push(dir)
     }
-    return
+    if (!isRoot) return
   }
 
   let entries: string[]

--- a/tests/config/detector-integration.test.ts
+++ b/tests/config/detector-integration.test.ts
@@ -71,3 +71,35 @@ describe('discoverNuxtApps returns deterministic order', () => {
     expect(first).toEqual(sorted)
   })
 })
+
+describe('detectI18nConfig when root has nuxt.config with i18n (issue #37)', () => {
+  let config: I18nConfig
+
+  beforeAll(async () => {
+    clearConfigCache()
+    config = await detectI18nConfig(playgroundDir)
+  }, 60_000)
+
+  afterAll(() => {
+    clearConfigCache()
+  })
+
+  it('discovers both root and sub-app locale directories', () => {
+    const layers = config.localeDirs.map(d => d.layer)
+    expect(layers.length).toBeGreaterThanOrEqual(2)
+
+    const hasAppAdmin = config.localeDirs.some(d =>
+      d.path === resolve(appAdminDir, 'i18n/locales'),
+    )
+    const hasPlayground = config.localeDirs.some(d =>
+      d.path === resolve(playgroundDir, 'i18n/locales'),
+    )
+    expect(hasAppAdmin).toBe(true)
+    expect(hasPlayground).toBe(true)
+  })
+
+  it('includes layerRootDirs for both root and sub-app', () => {
+    expect(config.layerRootDirs).toContain(playgroundDir)
+    expect(config.layerRootDirs).toContain(appAdminDir)
+  })
+})

--- a/tests/config/detector.test.ts
+++ b/tests/config/detector.test.ts
@@ -211,7 +211,7 @@ describe('discoverNuxtApps (real filesystem)', () => {
     expect(apps).toContain(playgroundDir)
   })
 
-  it('does not descend into playground to find app-admin separately', async () => {
+  it('does not descend into playground to find app-admin from project root', async () => {
     const apps = await discoverNuxtApps(monorepoDir)
     expect(apps).not.toContain(appAdminDir)
   })
@@ -223,6 +223,12 @@ describe('discoverNuxtApps (real filesystem)', () => {
 
   it('finds app-admin when given its directory directly (not via parent discovery)', async () => {
     const apps = await discoverNuxtApps(appAdminDir)
+    expect(apps).toContain(appAdminDir)
+  })
+
+  it('finds both root and sub-apps when root itself has a nuxt.config with i18n', async () => {
+    const apps = await discoverNuxtApps(playgroundDir)
+    expect(apps).toContain(playgroundDir)
     expect(apps).toContain(appAdminDir)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #37 — monorepo detection was skipped when the root directory itself had a `nuxt.config.ts` with i18n config. Sub-apps (e.g. `app-admin`, `app-shop`) were never discovered.

## Changes

- **`discovery.ts`**: `scanForApps` now continues scanning subdirectories when processing the root dir (`isRoot` flag), instead of returning immediately after finding the root's config.
- **`detector.ts`**: `detectI18nConfig` always runs `discoverNuxtApps()` first, then routes to `loadSingleApp` (1 app) or `loadAndMergeApps` (2+ apps). The previous `isNuxtApp` short-circuit is removed.
- **Tests**: Added unit test for `discoverNuxtApps(playgroundDir)` finding both root and `app-admin`, plus integration test validating the full `detectI18nConfig` path discovers locale directories from both apps.

## Testing

- `pnpm typecheck` ✅
- `pnpm test` ✅ (277 passed)
- `pnpm build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced internationalization configuration detection to properly support and identify all layers in nested Nuxt applications
  * Fixed an issue where root-level internationalization configurations prevented the system from discovering and cataloging nested sub-applications
  * Improved handling of complex multi-layer application structures with internationalization settings across the entire application hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->