### PR TITLE
refactor: adapter interface + registry + Nuxt extraction

### DIFF
--- a/src/adapters/nuxt/index.ts
+++ b/src/adapters/nuxt/index.ts
@@ -1,0 +1,330 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { resolve, relative } from 'node:path'
+import type { FrameworkAdapter, LocaleFileFormat } from '../types'
+import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import { findNuxtConfig, discoverNuxtApps, deriveLayerName } from '../../config/discovery'
+import { loadKit } from '../../config/nuxt-loader'
+import { loadProjectConfig } from '../../config/project-config'
+import { log } from '../../utils/logger'
+import { ConfigError } from '../../utils/errors'
+
+export class NuxtAdapter implements FrameworkAdapter {
+  readonly name = 'nuxt'
+  readonly label = 'Nuxt'
+  readonly localeFileFormat: LocaleFileFormat = 'json'
+
+  async detect(projectDir: string): Promise<number> {
+    const configFile = findNuxtConfig(projectDir)
+    if (configFile) {
+      try {
+        const content = await readFile(resolve(projectDir, configFile), 'utf-8')
+        return /\bi18n\b/.test(content) ? 2 : 1
+      }
+      catch {
+        return 1
+      }
+    }
+
+    const appDirs = await discoverNuxtApps(projectDir)
+    return appDirs.length > 0 ? 2 : 0
+  }
+
+  async resolve(projectDir: string): Promise<I18nConfig> {
+    const appDirs = await discoverNuxtApps(projectDir)
+
+    if (findNuxtConfig(projectDir) && !appDirs.includes(projectDir)) {
+      appDirs.unshift(projectDir)
+    }
+
+    if (appDirs.length === 0) {
+      throw new ConfigError(
+        `No Nuxt apps with i18n configuration found under ${projectDir}. `
+        + 'Make sure your Nuxt apps have a nuxt.config.ts with i18n configured.',
+      )
+    }
+
+    if (appDirs.length === 1) {
+      const config = await loadSingleApp(appDirs[0], projectDir)
+      if (appDirs[0] !== projectDir) {
+        config.rootDir = projectDir
+      }
+      log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)
+      return config
+    }
+
+    log.info(`Discovered ${appDirs.length} Nuxt app(s) with i18n: ${appDirs.map(d => relative(projectDir, d) || '.').join(', ')}`)
+    const config = await loadAndMergeApps(appDirs, projectDir)
+    log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories from ${appDirs.length} app(s)`)
+    return config
+  }
+}
+
+async function loadSingleApp(appDir: string, discoveryRoot: string): Promise<I18nConfig> {
+  const kit = await loadKit(appDir)
+
+  let nuxt: Awaited<ReturnType<typeof kit.loadNuxt>>
+
+  try {
+    nuxt = await kit.loadNuxt({
+      cwd: appDir,
+      dotenv: { cwd: appDir },
+      overrides: {
+        logLevel: 'silent' as const,
+        vite: { clearScreen: false },
+      },
+    })
+  }
+  catch (_error) {
+    log.warn(`Initial loadNuxt failed for ${appDir}, retrying with ready:false...`)
+    try {
+      nuxt = await kit.loadNuxt({
+        cwd: appDir,
+        dotenv: { cwd: appDir },
+        ready: false,
+        overrides: {
+          logLevel: 'silent' as const,
+          vite: { clearScreen: false },
+        },
+      })
+    }
+    catch (retryError) {
+      throw new ConfigError(
+        `Failed to load Nuxt config from ${appDir}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
+      )
+    }
+  }
+
+  try {
+    return await extractI18nConfig(nuxt as unknown as { options: Record<string, unknown> }, appDir, discoveryRoot)
+  }
+  finally {
+    await nuxt.close()
+  }
+}
+
+async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promise<I18nConfig> {
+  const projectConfig = await loadProjectConfig(discoveryRoot)
+
+  const allLocaleDirs: LocaleDir[] = []
+  const allLocales: LocaleDefinition[] = []
+  const allLayerRootDirs: string[] = []
+  const seenLocalePaths = new Map<string, string>()
+  const seenLocaleCodes = new Set<string>()
+  const usedLayerNames = new Set<string>()
+  let defaultLocale = 'en'
+  let fallbackLocale: Record<string, string[]> = { default: ['en'] }
+
+  for (const appDir of appDirs) {
+    log.info(`Loading Nuxt app: ${relative(discoveryRoot, appDir) || '.'}`)
+    let appConfig: I18nConfig
+    try {
+      appConfig = await loadSingleApp(appDir, discoveryRoot)
+    }
+    catch (error) {
+      log.warn(`Failed to load app at ${appDir}: ${error instanceof Error ? error.message : String(error)}`)
+      continue
+    }
+
+    if (allLocaleDirs.length === 0) {
+      defaultLocale = appConfig.defaultLocale
+      fallbackLocale = appConfig.fallbackLocale
+    }
+
+    for (const dir of appConfig.localeDirs) {
+      const existingLayer = seenLocalePaths.get(dir.path)
+      if (existingLayer) {
+        if (dir.layer !== existingLayer) {
+          allLocaleDirs.push({
+            ...dir,
+            aliasOf: existingLayer,
+          })
+          log.debug(`Layer '${dir.layer}' is alias of '${existingLayer}' (same path: ${dir.path})`)
+        }
+        continue
+      }
+
+      let layerName = dir.layer
+      if (usedLayerNames.has(layerName)) {
+        layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
+      }
+      usedLayerNames.add(layerName)
+      seenLocalePaths.set(dir.path, layerName)
+      allLocaleDirs.push({ ...dir, layer: layerName })
+    }
+
+    for (const locale of appConfig.locales) {
+      if (!seenLocaleCodes.has(locale.code)) {
+        seenLocaleCodes.add(locale.code)
+        allLocales.push(locale)
+      }
+    }
+
+    for (const rootDir of appConfig.layerRootDirs) {
+      if (!allLayerRootDirs.includes(rootDir)) {
+        allLayerRootDirs.push(rootDir)
+      }
+    }
+  }
+
+  if (allLocaleDirs.length === 0) {
+    throw new ConfigError(
+      `No locale directories found in any Nuxt app under ${discoveryRoot}. `
+      + 'Make sure your Nuxt apps have i18n/locales/ directories with JSON files.',
+    )
+  }
+
+  return {
+    rootDir: discoveryRoot,
+    defaultLocale,
+    fallbackLocale,
+    locales: allLocales,
+    localeDirs: allLocaleDirs,
+    layerRootDirs: allLayerRootDirs,
+    projectConfig: projectConfig ?? undefined,
+  }
+}
+
+async function extractI18nConfig(
+  nuxt: { options: Record<string, unknown> },
+  appDir: string,
+  discoveryRoot: string,
+): Promise<I18nConfig> {
+  const projectConfig = await loadProjectConfig(appDir)
+
+  const nuxtOptions = nuxt.options as Record<string, unknown>
+  const i18nOptions = nuxtOptions.i18n as Record<string, unknown> | undefined
+  const layers = (nuxtOptions._layers ?? []) as Array<{
+    config: {
+      rootDir: string
+      i18n?: Record<string, unknown>
+    }
+  }>
+
+  if (!i18nOptions) {
+    throw new ConfigError(
+      `No i18n configuration found in nuxt.config at ${appDir}. Make sure @nuxtjs/i18n is configured.`,
+    )
+  }
+
+  const defaultLocale = (i18nOptions.defaultLocale as string) ?? 'en'
+  log.debug(`Default locale: ${defaultLocale}`)
+
+  const rawLocales = (i18nOptions.locales ?? []) as Array<Record<string, unknown>>
+  const locales: LocaleDefinition[] = rawLocales
+    .filter(l => typeof l === 'object' && l !== null)
+    .map(l => ({
+      code: String(l.code ?? ''),
+      language: String(l.language ?? l.iso ?? ''),
+      file: String(l.file ?? ''),
+      name: l.name ? String(l.name) : undefined,
+    }))
+    .filter(l => l.code && l.file)
+
+  if (locales.length === 0) {
+    throw new ConfigError(
+      'No locales found in i18n configuration. Make sure locales are defined with code and file properties.',
+    )
+  }
+
+  const fallbackLocale = extractFallbackLocale(i18nOptions)
+  const localeDirs = await discoverLocaleDirs(layers, i18nOptions, discoveryRoot)
+
+  const layerRootDirs = [...new Set(layers.map(l => l.config.rootDir))]
+  if (layerRootDirs.length === 0) {
+    layerRootDirs.push(appDir)
+  }
+
+  return {
+    rootDir: appDir,
+    defaultLocale,
+    fallbackLocale,
+    locales,
+    localeDirs,
+    layerRootDirs,
+    projectConfig: projectConfig ?? undefined,
+  }
+}
+
+function extractFallbackLocale(
+  i18nOptions: Record<string, unknown>,
+): Record<string, string[]> {
+  const fallback = i18nOptions.fallbackLocale
+  if (fallback && typeof fallback === 'object' && !Array.isArray(fallback)) {
+    const result: Record<string, string[]> = {}
+    for (const [key, value] of Object.entries(fallback as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        result[key] = value.map(String)
+      }
+      else if (typeof value === 'string') {
+        result[key] = [value]
+      }
+    }
+    return result
+  }
+
+  const defaultLocale = (i18nOptions.defaultLocale as string) ?? 'en'
+  return { default: [defaultLocale] }
+}
+
+async function discoverLocaleDirs(
+  layers: Array<{ config: { rootDir: string; i18n?: Record<string, unknown> } }>,
+  i18nOptions: Record<string, unknown>,
+  discoveryRoot: string,
+): Promise<LocaleDir[]> {
+  const dirs: LocaleDir[] = []
+  const resolvedPaths = new Map<string, string>()
+  const usedLayerNames = new Set<string>()
+
+  for (const layer of layers) {
+    const layerRootDir = layer.config.rootDir
+    const layerName = deriveLayerName(layerRootDir, discoveryRoot, usedLayerNames)
+    usedLayerNames.add(layerName)
+    const layerI18n = layer.config.i18n ?? i18nOptions
+
+    const langDir = (layerI18n.langDir as string) ?? 'locales'
+    const restructureDir = (layerI18n.restructureDir as string) ?? 'i18n'
+    const resolvedDir = resolve(layerRootDir, restructureDir, langDir)
+
+    if (!existsSync(resolvedDir)) {
+      log.debug(`Locale dir not found for layer '${layerName}': ${resolvedDir}`)
+      continue
+    }
+
+    const existingLayer = resolvedPaths.get(resolvedDir)
+    if (existingLayer) {
+      dirs.push({
+        path: resolvedDir,
+        layer: layerName,
+        layerRootDir,
+        aliasOf: existingLayer,
+      })
+      log.debug(`Layer '${layerName}' is alias of '${existingLayer}'`)
+      continue
+    }
+
+    const files = await readdir(resolvedDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+    if (jsonFiles.length === 0) {
+      log.debug(`No JSON files in locale dir for layer '${layerName}': ${resolvedDir}`)
+      continue
+    }
+
+    resolvedPaths.set(resolvedDir, layerName)
+    dirs.push({
+      path: resolvedDir,
+      layer: layerName,
+      layerRootDir,
+    })
+
+    log.debug(`Found locale dir for layer '${layerName}': ${resolvedDir} (${jsonFiles.length} files)`)
+  }
+
+  if (dirs.length === 0) {
+    throw new ConfigError(
+      'No locale directories found. Make sure your Nuxt layers have i18n/locales/ directories with JSON files.',
+    )
+  }
+
+  return dirs
+}

--- a/src/adapters/nuxt/index.ts
+++ b/src/adapters/nuxt/index.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir, readFile, realpath } from 'node:fs/promises'
 import { resolve, relative } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
@@ -19,11 +19,15 @@ export class NuxtAdapter implements FrameworkAdapter {
     if (configFile) {
       try {
         const content = await readFile(resolve(projectDir, configFile), 'utf-8')
-        return /\bi18n\b/.test(content) ? 2 : 1
+        if (/\bi18n\b/.test(content)) return 2
       }
       catch {
-        return 1
+        // Fall through to child app scan
       }
+
+      // Root config exists but has no i18n — check child apps
+      const appDirs = await discoverNuxtApps(projectDir)
+      return appDirs.length > 0 ? 2 : 1
     }
 
     const appDirs = await discoverNuxtApps(projectDir)
@@ -132,7 +136,8 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
     }
 
     for (const dir of appConfig.localeDirs) {
-      const existingLayer = seenLocalePaths.get(dir.path)
+      const realPath = await realpath(dir.path).catch(() => dir.path)
+      const existingLayer = seenLocalePaths.get(realPath)
       if (existingLayer) {
         if (dir.layer !== existingLayer) {
           allLocaleDirs.push({
@@ -144,12 +149,13 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
         continue
       }
 
+      // Disambiguate layer name if already used by a different path
       let layerName = dir.layer
       if (usedLayerNames.has(layerName)) {
         layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
       }
       usedLayerNames.add(layerName)
-      seenLocalePaths.set(dir.path, layerName)
+      seenLocalePaths.set(realPath, layerName)
       allLocaleDirs.push({ ...dir, layer: layerName })
     }
 
@@ -190,7 +196,7 @@ async function extractI18nConfig(
   appDir: string,
   discoveryRoot: string,
 ): Promise<I18nConfig> {
-  const projectConfig = await loadProjectConfig(appDir)
+  const projectConfig = await loadProjectConfig(discoveryRoot)
 
   const nuxtOptions = nuxt.options as Record<string, unknown>
   const i18nOptions = nuxtOptions.i18n as Record<string, unknown> | undefined
@@ -291,7 +297,8 @@ async function discoverLocaleDirs(
       continue
     }
 
-    const existingLayer = resolvedPaths.get(resolvedDir)
+    const realDir = await realpath(resolvedDir).catch(() => resolvedDir)
+    const existingLayer = resolvedPaths.get(realDir)
     if (existingLayer) {
       dirs.push({
         path: resolvedDir,
@@ -310,7 +317,7 @@ async function discoverLocaleDirs(
       continue
     }
 
-    resolvedPaths.set(resolvedDir, layerName)
+    resolvedPaths.set(realDir, layerName)
     dirs.push({
       path: resolvedDir,
       layer: layerName,

--- a/src/adapters/nuxt/index.ts
+++ b/src/adapters/nuxt/index.ts
@@ -256,7 +256,16 @@ function extractFallbackLocale(
   i18nOptions: Record<string, unknown>,
 ): Record<string, string[]> {
   const fallback = i18nOptions.fallbackLocale
-  if (fallback && typeof fallback === 'object' && !Array.isArray(fallback)) {
+
+  if (typeof fallback === 'string') {
+    return { default: [fallback] }
+  }
+
+  if (Array.isArray(fallback)) {
+    return { default: (fallback as unknown[]).map(String) }
+  }
+
+  if (fallback && typeof fallback === 'object') {
     const result: Record<string, string[]> = {}
     for (const [key, value] of Object.entries(fallback as Record<string, unknown>)) {
       if (Array.isArray(value)) {

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { FrameworkAdapter } from './types'
 import { ConfigError } from '../utils/errors'
+import { log } from '../utils/logger'
 
 const adapters: FrameworkAdapter[] = []
 
@@ -35,10 +36,15 @@ export async function detectFramework(
   }
 
   const scores = await Promise.all(
-    adapters.map(async (adapter) => ({
-      adapter,
-      confidence: await adapter.detect(projectDir),
-    })),
+    adapters.map(async (adapter) => {
+      try {
+        return { adapter, confidence: await adapter.detect(projectDir) }
+      }
+      catch (error) {
+        log.warn(`Adapter '${adapter.name}' detection failed: ${error instanceof Error ? error.message : String(error)}`)
+        return { adapter, confidence: 0 }
+      }
+    }),
   )
 
   const best = scores.reduce((a, b) => (b.confidence > a.confidence ? b : a))

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,0 +1,54 @@
+import type { FrameworkAdapter } from './types'
+import { ConfigError } from '../utils/errors'
+
+const adapters: FrameworkAdapter[] = []
+
+export function registerAdapter(adapter: FrameworkAdapter): void {
+  adapters.push(adapter)
+}
+
+export function getRegisteredAdapters(): readonly FrameworkAdapter[] {
+  return adapters
+}
+
+export function resetRegistry(): void {
+  adapters.length = 0
+}
+
+export async function detectFramework(
+  projectDir: string,
+  hint?: string,
+): Promise<FrameworkAdapter> {
+  if (adapters.length === 0) {
+    throw new ConfigError('No framework adapters registered.')
+  }
+
+  if (hint) {
+    const match = adapters.find(a => a.name === hint)
+    if (!match) {
+      throw new ConfigError(
+        `Framework hint "${hint}" does not match any registered adapter. `
+        + `Available: ${adapters.map(a => a.name).join(', ')}`,
+      )
+    }
+    return match
+  }
+
+  const scores = await Promise.all(
+    adapters.map(async (adapter) => ({
+      adapter,
+      confidence: await adapter.detect(projectDir),
+    })),
+  )
+
+  const best = scores.reduce((a, b) => (b.confidence > a.confidence ? b : a))
+
+  if (best.confidence === 0) {
+    throw new ConfigError(
+      `No framework detected for ${projectDir}. `
+      + `Registered adapters: ${adapters.map(a => a.name).join(', ')}`,
+    )
+  }
+
+  return best.adapter
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,0 +1,11 @@
+import type { I18nConfig } from '../config/types'
+
+export type LocaleFileFormat = 'json' | 'php-array'
+
+export interface FrameworkAdapter {
+  readonly name: string
+  readonly label: string
+  readonly localeFileFormat: LocaleFileFormat
+  detect(projectDir: string): Promise<number>
+  resolve(projectDir: string): Promise<I18nConfig>
+}

--- a/src/config/detector.ts
+++ b/src/config/detector.ts
@@ -1,28 +1,18 @@
-import { existsSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
-import { resolve, relative } from 'node:path'
-import { loadKit } from './nuxt-loader'
-import type { I18nConfig, LocaleDefinition, LocaleDir } from './types'
+import type { I18nConfig } from './types'
+import { registerAdapter, detectFramework } from '../adapters/registry'
+import { NuxtAdapter } from '../adapters/nuxt/index'
 import { loadProjectConfig } from './project-config'
 import { log } from '../utils/logger'
-import { ConfigError } from '../utils/errors'
-import { canonicalPath, findNuxtConfig, discoverNuxtApps, deriveLayerName } from './discovery'
+import { canonicalPath } from './discovery'
 
 export { discoverNuxtApps } from './discovery'
 
-/** Per-project config cache keyed by canonical absolute path. */
+registerAdapter(new NuxtAdapter())
+
 const configCache = new Map<string, I18nConfig>()
 
-/** Most recently detected config (for getCachedConfig). */
 let lastConfig: I18nConfig | null = null
 
-/**
- * Detect the i18n configuration from a Nuxt project or monorepo root.
- *
- * When `projectDir` is a single Nuxt app, loads it directly (backwards compatible).
- * When `projectDir` is a monorepo root containing multiple Nuxt apps with i18n,
- * discovers all apps, loads each independently, and merges into a unified config.
- */
 export async function detectI18nConfig(projectDir: string): Promise<I18nConfig> {
   const canonDir = canonicalPath(projectDir)
   const cached = configCache.get(canonDir)
@@ -33,38 +23,17 @@ export async function detectI18nConfig(projectDir: string): Promise<I18nConfig> 
 
   log.info(`Detecting i18n config from: ${projectDir}`)
 
-  const appDirs = await discoverNuxtApps(projectDir)
+  const projectConfig = await loadProjectConfig(projectDir)
+  const hint = projectConfig?.framework
 
-  // discoverNuxtApps stops descending at nuxt.config dirs, so the root is
-  // included when it has i18n. Guard against root having a config without i18n.
-  if (findNuxtConfig(projectDir) && !appDirs.includes(projectDir)) {
-    appDirs.unshift(projectDir)
-  }
+  const adapter = await detectFramework(projectDir, hint)
+  log.info(`Detected framework: ${adapter.label}`)
 
-  if (appDirs.length === 0) {
-    throw new ConfigError(
-      `No Nuxt apps with i18n configuration found under ${projectDir}. `
-      + 'Make sure your Nuxt apps have a nuxt.config.ts with i18n configured.',
-    )
-  }
-
-  if (appDirs.length === 1) {
-    const config = await loadSingleApp(appDirs[0], projectDir)
-    if (appDirs[0] !== projectDir) {
-      config.rootDir = projectDir
-    }
-    configCache.set(canonDir, config)
-    lastConfig = config
-    log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)
-    return config
-  }
-
-  log.info(`Discovered ${appDirs.length} Nuxt app(s) with i18n: ${appDirs.map(d => relative(projectDir, d) || '.').join(', ')}`)
-
-  const config = await loadAndMergeApps(appDirs, projectDir)
+  const config = await adapter.resolve(projectDir)
   configCache.set(canonDir, config)
   lastConfig = config
-  log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories from ${appDirs.length} app(s)`)
+
+  log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)
   return config
 }
 
@@ -74,281 +43,6 @@ export function clearConfigCache(): void {
   log.debug('Config cache cleared')
 }
 
-/**
- * Get the currently cached config without triggering detection.
- * Returns null if no config has been detected yet.
- * Used by MCP resources which can't pass a projectDir parameter.
- */
 export function getCachedConfig(): I18nConfig | null {
   return lastConfig
-}
-
-async function loadSingleApp(appDir: string, discoveryRoot: string): Promise<I18nConfig> {
-  const kit = await loadKit(appDir)
-
-  let nuxt: Awaited<ReturnType<typeof kit.loadNuxt>>
-
-  try {
-    nuxt = await kit.loadNuxt({
-      cwd: appDir,
-      dotenv: { cwd: appDir },
-      overrides: {
-        logLevel: 'silent' as const,
-        vite: { clearScreen: false },
-      },
-    })
-  }
-  catch (_error) {
-    log.warn(`Initial loadNuxt failed for ${appDir}, retrying with ready:false...`)
-    try {
-      nuxt = await kit.loadNuxt({
-        cwd: appDir,
-        dotenv: { cwd: appDir },
-        ready: false,
-        overrides: {
-          logLevel: 'silent' as const,
-          vite: { clearScreen: false },
-        },
-      })
-    }
-    catch (retryError) {
-      throw new ConfigError(
-        `Failed to load Nuxt config from ${appDir}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
-      )
-    }
-  }
-
-  try {
-    return await extractI18nConfig(nuxt as unknown as { options: Record<string, unknown> }, appDir, discoveryRoot)
-  }
-  finally {
-    await nuxt.close()
-  }
-}
-
-async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promise<I18nConfig> {
-  const projectConfig = await loadProjectConfig(discoveryRoot)
-
-  const allLocaleDirs: LocaleDir[] = []
-  const allLocales: LocaleDefinition[] = []
-  const allLayerRootDirs: string[] = []
-  const seenLocalePaths = new Map<string, string>()
-  const seenLocaleCodes = new Set<string>()
-  const usedLayerNames = new Set<string>()
-  let defaultLocale = 'en'
-  let fallbackLocale: Record<string, string[]> = { default: ['en'] }
-
-  for (const appDir of appDirs) {
-    log.info(`Loading Nuxt app: ${relative(discoveryRoot, appDir) || '.'}`)
-    let appConfig: I18nConfig
-    try {
-      appConfig = await loadSingleApp(appDir, discoveryRoot)
-    }
-    catch (error) {
-      log.warn(`Failed to load app at ${appDir}: ${error instanceof Error ? error.message : String(error)}`)
-      continue
-    }
-
-    if (allLocaleDirs.length === 0) {
-      defaultLocale = appConfig.defaultLocale
-      fallbackLocale = appConfig.fallbackLocale
-    }
-
-    for (const dir of appConfig.localeDirs) {
-      const existingLayer = seenLocalePaths.get(dir.path)
-      if (existingLayer) {
-        if (dir.layer !== existingLayer) {
-          allLocaleDirs.push({
-            ...dir,
-            aliasOf: existingLayer,
-          })
-          log.debug(`Layer '${dir.layer}' is alias of '${existingLayer}' (same path: ${dir.path})`)
-        }
-        continue
-      }
-
-      // Disambiguate layer name if already used by a different path
-      let layerName = dir.layer
-      if (usedLayerNames.has(layerName)) {
-        layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
-      }
-      usedLayerNames.add(layerName)
-      seenLocalePaths.set(dir.path, layerName)
-      allLocaleDirs.push({ ...dir, layer: layerName })
-    }
-
-    for (const locale of appConfig.locales) {
-      if (!seenLocaleCodes.has(locale.code)) {
-        seenLocaleCodes.add(locale.code)
-        allLocales.push(locale)
-      }
-    }
-
-    for (const rootDir of appConfig.layerRootDirs) {
-      if (!allLayerRootDirs.includes(rootDir)) {
-        allLayerRootDirs.push(rootDir)
-      }
-    }
-  }
-
-  if (allLocaleDirs.length === 0) {
-    throw new ConfigError(
-      `No locale directories found in any Nuxt app under ${discoveryRoot}. `
-      + 'Make sure your Nuxt apps have i18n/locales/ directories with JSON files.',
-    )
-  }
-
-  return {
-    rootDir: discoveryRoot,
-    defaultLocale,
-    fallbackLocale,
-    locales: allLocales,
-    localeDirs: allLocaleDirs,
-    layerRootDirs: allLayerRootDirs,
-    projectConfig: projectConfig ?? undefined,
-  }
-}
-
-async function extractI18nConfig(
-  nuxt: { options: Record<string, unknown> },
-  appDir: string,
-  discoveryRoot: string,
-): Promise<I18nConfig> {
-  const projectConfig = await loadProjectConfig(appDir)
-
-  const nuxtOptions = nuxt.options as Record<string, unknown>
-  const i18nOptions = nuxtOptions.i18n as Record<string, unknown> | undefined
-  const layers = (nuxtOptions._layers ?? []) as Array<{
-    config: {
-      rootDir: string
-      i18n?: Record<string, unknown>
-    }
-  }>
-
-  if (!i18nOptions) {
-    throw new ConfigError(
-      `No i18n configuration found in nuxt.config at ${appDir}. Make sure @nuxtjs/i18n is configured.`,
-    )
-  }
-
-  const defaultLocale = (i18nOptions.defaultLocale as string) ?? 'en'
-  log.debug(`Default locale: ${defaultLocale}`)
-
-  const rawLocales = (i18nOptions.locales ?? []) as Array<Record<string, unknown>>
-  const locales: LocaleDefinition[] = rawLocales
-    .filter(l => typeof l === 'object' && l !== null)
-    .map(l => ({
-      code: String(l.code ?? ''),
-      language: String(l.language ?? l.iso ?? ''),
-      file: String(l.file ?? ''),
-      name: l.name ? String(l.name) : undefined,
-    }))
-    .filter(l => l.code && l.file)
-
-  if (locales.length === 0) {
-    throw new ConfigError(
-      'No locales found in i18n configuration. Make sure locales are defined with code and file properties.',
-    )
-  }
-
-  const fallbackLocale = extractFallbackLocale(i18nOptions)
-  const localeDirs = await discoverLocaleDirs(layers, i18nOptions, discoveryRoot)
-
-  const layerRootDirs = [...new Set(layers.map(l => l.config.rootDir))]
-  if (layerRootDirs.length === 0) {
-    layerRootDirs.push(appDir)
-  }
-
-  return {
-    rootDir: appDir,
-    defaultLocale,
-    fallbackLocale,
-    locales,
-    localeDirs,
-    layerRootDirs,
-    projectConfig: projectConfig ?? undefined,
-  }
-}
-
-function extractFallbackLocale(
-  i18nOptions: Record<string, unknown>,
-): Record<string, string[]> {
-  const fallback = i18nOptions.fallbackLocale
-  if (fallback && typeof fallback === 'object' && !Array.isArray(fallback)) {
-    const result: Record<string, string[]> = {}
-    for (const [key, value] of Object.entries(fallback as Record<string, unknown>)) {
-      if (Array.isArray(value)) {
-        result[key] = value.map(String)
-      }
-      else if (typeof value === 'string') {
-        result[key] = [value]
-      }
-    }
-    return result
-  }
-
-  const defaultLocale = (i18nOptions.defaultLocale as string) ?? 'en'
-  return { default: [defaultLocale] }
-}
-
-async function discoverLocaleDirs(
-  layers: Array<{ config: { rootDir: string; i18n?: Record<string, unknown> } }>,
-  i18nOptions: Record<string, unknown>,
-  discoveryRoot: string,
-): Promise<LocaleDir[]> {
-  const dirs: LocaleDir[] = []
-  const resolvedPaths = new Map<string, string>()
-  const usedLayerNames = new Set<string>()
-
-  for (const layer of layers) {
-    const layerRootDir = layer.config.rootDir
-    const layerName = deriveLayerName(layerRootDir, discoveryRoot, usedLayerNames)
-    usedLayerNames.add(layerName)
-    const layerI18n = layer.config.i18n ?? i18nOptions
-
-    const langDir = (layerI18n.langDir as string) ?? 'locales'
-    const restructureDir = (layerI18n.restructureDir as string) ?? 'i18n'
-    const resolvedDir = resolve(layerRootDir, restructureDir, langDir)
-
-    if (!existsSync(resolvedDir)) {
-      log.debug(`Locale dir not found for layer '${layerName}': ${resolvedDir}`)
-      continue
-    }
-
-    const existingLayer = resolvedPaths.get(resolvedDir)
-    if (existingLayer) {
-      dirs.push({
-        path: resolvedDir,
-        layer: layerName,
-        layerRootDir,
-        aliasOf: existingLayer,
-      })
-      log.debug(`Layer '${layerName}' is alias of '${existingLayer}'`)
-      continue
-    }
-
-    const files = await readdir(resolvedDir)
-    const jsonFiles = files.filter(f => f.endsWith('.json'))
-    if (jsonFiles.length === 0) {
-      log.debug(`No JSON files in locale dir for layer '${layerName}': ${resolvedDir}`)
-      continue
-    }
-
-    resolvedPaths.set(resolvedDir, layerName)
-    dirs.push({
-      path: resolvedDir,
-      layer: layerName,
-      layerRootDir,
-    })
-
-    log.debug(`Found locale dir for layer '${layerName}': ${resolvedDir} (${jsonFiles.length} files)`)
-  }
-
-  if (dirs.length === 0) {
-    throw new ConfigError(
-      'No locale directories found. Make sure your Nuxt layers have i18n/locales/ directories with JSON files.',
-    )
-  }
-
-  return dirs
 }

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -68,7 +68,10 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
 
   const config = parsed as Record<string, unknown>
 
-  // Validate context
+  if ('framework' in config && typeof config.framework !== 'string') {
+    throw new ConfigError(`${CONFIG_FILENAME}: "framework" must be a string`)
+  }
+
   if ('context' in config && typeof config.context !== 'string') {
     throw new ConfigError(`${CONFIG_FILENAME}: "context" must be a string`)
   }
@@ -189,6 +192,7 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
   log.debug(`Project config loaded successfully from ${configPath}`)
 
   return {
+    framework: config.framework as string | undefined,
     context: config.context as string | undefined,
     layerRules: config.layerRules as ProjectConfig['layerRules'],
     glossary: config.glossary as Record<string, string> | undefined,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -31,6 +31,8 @@ export interface LocaleDir {
  * All fields are optional — the server passes them to the agent as-is.
  */
 export interface ProjectConfig {
+  /** Framework hint to bypass auto-detection (e.g., 'nuxt', 'laravel') */
+  framework?: string
   /** Free-form project background for the agent */
   context?: string
   /** Rules for deciding which layer a key belongs to */

--- a/tests/adapter-registry.test.ts
+++ b/tests/adapter-registry.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { FrameworkAdapter } from '../src/adapters/types'
+import { registerAdapter, detectFramework, resetRegistry } from '../src/adapters/registry'
+
+function createFakeAdapter(
+  name: string,
+  confidence: number,
+): FrameworkAdapter {
+  return {
+    name,
+    label: name.charAt(0).toUpperCase() + name.slice(1),
+    localeFileFormat: 'json',
+    detect: async () => confidence,
+    resolve: async () => ({
+      rootDir: '/fake',
+      defaultLocale: 'en',
+      fallbackLocale: { default: ['en'] },
+      locales: [],
+      localeDirs: [],
+      layerRootDirs: [],
+    }),
+  }
+}
+
+describe('adapter registry', () => {
+  beforeEach(() => {
+    resetRegistry()
+  })
+
+  it('picks the adapter with the highest confidence score', async () => {
+    const low = createFakeAdapter('low', 1)
+    const high = createFakeAdapter('high', 2)
+
+    registerAdapter(low)
+    registerAdapter(high)
+
+    const winner = await detectFramework('/some/dir')
+    expect(winner.name).toBe('high')
+  })
+
+  it('uses framework hint to bypass detection', async () => {
+    const nuxt = createFakeAdapter('nuxt', 0)
+    const laravel = createFakeAdapter('laravel', 2)
+
+    registerAdapter(nuxt)
+    registerAdapter(laravel)
+
+    const winner = await detectFramework('/some/dir', 'nuxt')
+    expect(winner.name).toBe('nuxt')
+  })
+
+  it('throws when hint names an unknown adapter', async () => {
+    registerAdapter(createFakeAdapter('nuxt', 2))
+
+    await expect(detectFramework('/some/dir', 'unknown'))
+      .rejects.toThrow(/unknown/)
+  })
+
+  it('throws ConfigError when all adapters return confidence 0', async () => {
+    registerAdapter(createFakeAdapter('a', 0))
+    registerAdapter(createFakeAdapter('b', 0))
+
+    await expect(detectFramework('/some/dir'))
+      .rejects.toThrow(/No framework detected/)
+  })
+
+  it('calls detect on all registered adapters', async () => {
+    let aCalled = false
+    let bCalled = false
+
+    const a: FrameworkAdapter = {
+      ...createFakeAdapter('a', 1),
+      detect: async () => { aCalled = true; return 1 },
+    }
+    const b: FrameworkAdapter = {
+      ...createFakeAdapter('b', 2),
+      detect: async () => { bCalled = true; return 2 },
+    }
+
+    registerAdapter(a)
+    registerAdapter(b)
+
+    await detectFramework('/some/dir')
+
+    expect(aCalled).toBe(true)
+    expect(bCalled).toBe(true)
+  })
+})

--- a/tests/adapters/nuxt-adapter.test.ts
+++ b/tests/adapters/nuxt-adapter.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { NuxtAdapter } from '../../src/adapters/nuxt/index'
+
+describe('NuxtAdapter.detect', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `nuxt-adapter-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns 2 for a directory with nuxt.config.ts containing i18n', async () => {
+    writeFileSync(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ i18n: { defaultLocale: "en" } })',
+    )
+
+    const adapter = new NuxtAdapter()
+    const confidence = await adapter.detect(tempDir)
+    expect(confidence).toBe(2)
+  })
+
+  it('returns 0 for an empty directory without nuxt.config or child apps', async () => {
+    const adapter = new NuxtAdapter()
+    const confidence = await adapter.detect(tempDir)
+    expect(confidence).toBe(0)
+  })
+
+  it('returns 2 for a monorepo root containing child Nuxt apps with i18n', async () => {
+    const childApp = join(tempDir, 'apps', 'web')
+    mkdirSync(childApp, { recursive: true })
+    writeFileSync(
+      join(childApp, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ i18n: { defaultLocale: "en" } })',
+    )
+
+    const adapter = new NuxtAdapter()
+    const confidence = await adapter.detect(tempDir)
+    expect(confidence).toBe(2)
+  })
+
+  it('returns 1 for a directory with nuxt.config but no i18n reference', async () => {
+    writeFileSync(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ devtools: { enabled: true } })',
+    )
+
+    const adapter = new NuxtAdapter()
+    const confidence = await adapter.detect(tempDir)
+    expect(confidence).toBe(1)
+  })
+
+  it('has correct static properties', () => {
+    const adapter = new NuxtAdapter()
+    expect(adapter.name).toBe('nuxt')
+    expect(adapter.label).toBe('Nuxt')
+    expect(adapter.localeFileFormat).toBe('json')
+  })
+})


### PR DESCRIPTION
## Summary

Introduces the `FrameworkAdapter` interface and adapter registry, then moves all Nuxt-specific code behind this interface. Pure refactor — zero behavior change for Nuxt users.

## Changes

- **New `FrameworkAdapter` interface** (`src/adapters/types.ts`): `detect(dir) → confidence` and `resolve(dir) → I18nConfig` pattern with `LocaleFileFormat` type
- **Adapter registry** (`src/adapters/registry.ts`): Orchestrates detection across registered adapters — picks highest confidence, supports `framework` hint to bypass auto-detection, runs adapters in parallel
- **`NuxtAdapter`** (`src/adapters/nuxt/index.ts`): Wraps existing Nuxt detection + resolution logic (loadSingleApp, loadAndMergeApps, extractI18nConfig) in a FrameworkAdapter
- **Thin orchestrator** (`src/config/detector.ts`): Now delegates to the registry instead of containing Nuxt logic directly. Public API unchanged: `detectI18nConfig`, `clearConfigCache`, `getCachedConfig`, `discoverNuxtApps`
- **`framework` hint** in `.i18n-mcp.json` (`ProjectConfig.framework`): Optional field to bypass auto-detection
- **10 new unit tests** covering registry confidence scoring, hint bypass, error cases, and NuxtAdapter.detect behavior (single app, monorepo, no config)

## Testing

- `pnpm typecheck` ✅
- `pnpm build` ✅  
- `pnpm test` ✅ (287 tests — 277 existing + 10 new, all passing)

## Related Issues

Closes #41 (parent: #40)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an adapter system for automatic i18n configuration detection across frameworks.
  * Added Nuxt support for detecting and resolving i18n configuration.
  * Project config accepts an optional framework hint to guide detection.

* **Refactor**
  * Detection logic now delegates framework-specific work to the new adapter architecture.

* **Tests**
  * Added tests for the adapter registry and Nuxt adapter detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->