### PR TITLE
feat: add laravel adapter for detection, discovery, and config resolution

### DIFF
--- a/src/adapters/laravel/index.ts
+++ b/src/adapters/laravel/index.ts
@@ -1,0 +1,196 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { FrameworkAdapter, LocaleFileFormat } from '../types'
+import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import { loadProjectConfig } from '../../config/project-config'
+import { log } from '../../utils/logger'
+import { ConfigError } from '../../utils/errors'
+
+export class LaravelAdapter implements FrameworkAdapter {
+  readonly name = 'laravel'
+  readonly label = 'Laravel'
+  readonly localeFileFormat: LocaleFileFormat = 'php-array'
+
+  async detect(projectDir: string): Promise<number> {
+    // Certain: artisan file is the hallmark of a Laravel project
+    if (existsSync(join(projectDir, 'artisan'))) {
+      return 2
+    }
+
+    // Certain: composer.json with laravel/framework dependency
+    try {
+      const raw = await readFile(join(projectDir, 'composer.json'), 'utf-8')
+      const composer = JSON.parse(raw) as Record<string, unknown>
+      const require = composer.require as Record<string, unknown> | undefined
+      if (require && 'laravel/framework' in require) {
+        return 2
+      }
+    }
+    catch {
+      // fall through
+    }
+
+    // Possible: lang/ directory with locale subdirectories
+    const langDir = findLangDir(projectDir)
+    if (langDir) {
+      const localeSubdirs = await findLocaleSubdirs(langDir)
+      if (localeSubdirs.length > 0) {
+        return 1
+      }
+    }
+
+    return 0
+  }
+
+  async resolve(projectDir: string): Promise<I18nConfig> {
+    const projectConfig = await loadProjectConfig(projectDir)
+
+    const langDir = findLangDir(projectDir)
+    if (!langDir) {
+      throw new ConfigError(
+        `No lang/ or resources/lang/ directory found in ${projectDir}. `
+        + 'Make sure your Laravel project has a locale directory.',
+      )
+    }
+
+    const localeSubdirs = await findLocaleSubdirs(langDir)
+    if (localeSubdirs.length === 0) {
+      throw new ConfigError(
+        `No locale subdirectories found in ${langDir}. `
+        + 'Expected directories like lang/en/, lang/de/, etc.',
+      )
+    }
+
+    const { defaultLocale, fallbackLocale } = await extractLocaleConfig(projectDir)
+
+    const locales: LocaleDefinition[] = localeSubdirs.map(code => ({
+      code,
+      language: code,
+    }))
+
+    const localeDirs: LocaleDir[] = [{
+      path: langDir,
+      layer: 'root',
+      layerRootDir: projectDir,
+    }]
+
+    log.info(
+      `Discovered ${locales.length} locale(s) in ${langDir}: `
+      + `${localeSubdirs.join(', ')}`,
+    )
+
+    return {
+      rootDir: projectDir,
+      defaultLocale,
+      fallbackLocale,
+      locales,
+      localeDirs,
+      layerRootDirs: [projectDir],
+      projectConfig: projectConfig ?? undefined,
+      localeFileFormat: 'php-array',
+    }
+  }
+}
+
+/**
+ * Laravel 9+ uses root-level `lang/`, older versions use `resources/lang/`.
+ */
+function findLangDir(projectDir: string): string | null {
+  const candidates = [
+    join(projectDir, 'lang'),
+    join(projectDir, 'resources', 'lang'),
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+async function findLocaleSubdirs(langDir: string): Promise<string[]> {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await readdir(langDir, { withFileTypes: true })
+  }
+  catch {
+    return []
+  }
+
+  const locales: string[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === 'vendor') continue
+    const files = await readdir(join(langDir, entry.name)).catch(() => [] as string[])
+    if (files.some(f => f.endsWith('.php'))) {
+      locales.push(entry.name)
+    }
+  }
+
+  return locales.sort()
+}
+
+/**
+ * Extract default and fallback locale from config/app.php.
+ * Uses regex to handle patterns like:
+ *   'locale' => 'en',
+ *   'locale' => env('APP_LOCALE', 'en'),
+ *   'fallback_locale' => 'en',
+ */
+async function extractLocaleConfig(projectDir: string): Promise<{
+  defaultLocale: string
+  fallbackLocale: Record<string, string[]>
+}> {
+  const configPath = join(projectDir, 'config', 'app.php')
+
+  let content: string
+  try {
+    content = await readFile(configPath, 'utf-8')
+  }
+  catch {
+    log.debug('No config/app.php found, using defaults')
+    return {
+      defaultLocale: 'en',
+      fallbackLocale: { default: ['en'] },
+    }
+  }
+
+  const defaultLocale = extractPhpConfigValue(content, 'locale') ?? 'en'
+  const fallbackValue = extractPhpConfigValue(content, 'fallback_locale') ?? defaultLocale
+
+  log.debug(`Extracted locale config: locale=${defaultLocale}, fallback=${fallbackValue}`)
+
+  return {
+    defaultLocale,
+    fallbackLocale: { default: [fallbackValue] },
+  }
+}
+
+/**
+ * Extract a string config value from a PHP config file.
+ * Handles both direct string values and env() calls with defaults:
+ *   'key' => 'value',
+ *   'key' => env('ENV_VAR', 'default'),
+ *   "key" => "value",
+ */
+function extractPhpConfigValue(content: string, key: string): string | null {
+  // Match: 'key' => env('...', 'default')  or  "key" => env("...", "default")
+  const envPattern = new RegExp(
+    `['"]${key}['"]\\s*=>\\s*env\\s*\\(\\s*['"][^'"]*['"]\\s*,\\s*['"]([^'"]+)['"]\\s*\\)`,
+  )
+  const envMatch = content.match(envPattern)
+  if (envMatch) {
+    return envMatch[1]
+  }
+
+  // Match: 'key' => 'value'  or  "key" => "value"
+  const directPattern = new RegExp(
+    `['"]${key}['"]\\s*=>\\s*['"]([^'"]+)['"]`,
+  )
+  const directMatch = content.match(directPattern)
+  if (directMatch) {
+    return directMatch[1]
+  }
+
+  return null
+}

--- a/src/adapters/laravel/index.ts
+++ b/src/adapters/laravel/index.ts
@@ -13,34 +13,36 @@ export class LaravelAdapter implements FrameworkAdapter {
   readonly localeFileFormat: LocaleFileFormat = 'php-array'
 
   async detect(projectDir: string): Promise<number> {
-    // Certain: artisan file is the hallmark of a Laravel project
+    let score = 0
+
+    // Strong signal: artisan file is the hallmark of a Laravel project
     if (existsSync(join(projectDir, 'artisan'))) {
-      return 2
+      score += 2
     }
 
-    // Certain: composer.json with laravel/framework dependency
+    // Strong signal: composer.json with laravel/framework dependency
     try {
       const raw = await readFile(join(projectDir, 'composer.json'), 'utf-8')
       const composer = JSON.parse(raw) as Record<string, unknown>
       const require = composer.require as Record<string, unknown> | undefined
       if (require && 'laravel/framework' in require) {
-        return 2
+        score += 2
       }
     }
     catch {
-      // fall through
+      // composer.json missing or malformed — skip
     }
 
-    // Possible: lang/ directory with locale subdirectories
+    // Weak signal: lang/ directory with locale subdirectories
     const langDir = findLangDir(projectDir)
     if (langDir) {
       const localeSubdirs = await findLocaleSubdirs(langDir)
       if (localeSubdirs.length > 0) {
-        return 1
+        score += 1
       }
     }
 
-    return 0
+    return score
   }
 
   async resolve(projectDir: string): Promise<I18nConfig> {

--- a/src/config/detector.ts
+++ b/src/config/detector.ts
@@ -1,6 +1,7 @@
 import type { I18nConfig } from './types'
 import { registerAdapter, detectFramework } from '../adapters/registry'
 import { NuxtAdapter } from '../adapters/nuxt/index'
+import { LaravelAdapter } from '../adapters/laravel/index'
 import { loadProjectConfig } from './project-config'
 import { log } from '../utils/logger'
 import { canonicalPath } from './discovery'
@@ -8,6 +9,7 @@ import { canonicalPath } from './discovery'
 export { discoverNuxtApps } from './discovery'
 
 registerAdapter(new NuxtAdapter())
+registerAdapter(new LaravelAdapter())
 
 const configCache = new Map<string, I18nConfig>()
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,13 +1,15 @@
+import type { LocaleFileFormat } from '../adapters/types'
+
 /**
- * A single locale definition as detected from the Nuxt i18n config.
+ * A single locale definition as detected from the framework config.
  */
 export interface LocaleDefinition {
   /** Locale code used in URLs and as identifier (e.g., 'de', 'en', 'en-us') */
   code: string
   /** BCP-47 language tag (e.g., 'de-DE', 'en-GB') */
   language: string
-  /** Locale JSON filename (e.g., 'de-DE.json') */
-  file: string
+  /** Locale filename (e.g., 'de-DE.json'). Optional for directory-per-locale layouts (Laravel). */
+  file?: string
   /** Human-readable name (e.g., 'Deutsch') */
   name?: string
 }
@@ -74,8 +76,10 @@ export interface I18nConfig {
   locales: LocaleDefinition[]
   /** All discovered locale directories, per layer */
   localeDirs: LocaleDir[]
-  /** Root directories of ALL Nuxt layers (including those without locale files). Used for source code scanning. */
+  /** Root directories of all framework layers/roots. Used for source code scanning. */
   layerRootDirs: string[]
   /** Optional project-specific config from .i18n-mcp.json */
   projectConfig?: ProjectConfig
+  /** Locale file format used by this project (default: 'json') */
+  localeFileFormat?: LocaleFileFormat
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,7 +103,7 @@ async function applyTranslations(
   translations: Record<string, Record<string, string>>,
   mode: 'add' | 'update',
   findLocale: (config: I18nConfig, ref: string) => ReturnType<typeof findLocaleImpl>,
-  resolveLocaleFilePath: (config: I18nConfig, layer: string, file: string) => string | null,
+  resolveLocaleFilePath: (config: I18nConfig, layer: string, file: string | undefined) => string | null,
   dryRun = false,
 ): Promise<{ applied: string[]; skipped: string[]; warnings: string[]; filesWritten: number; preview?: Array<{ locale: string; key: string; value: string }> }> {
   const applied: string[] = []
@@ -316,7 +316,8 @@ export function createServer(): McpServer {
   })
 
   // Helper: resolve locale file path for a layer + locale file name
-  function resolveLocaleFilePath(config: I18nConfig, layer: string, localeFile: string): string | null {
+  function resolveLocaleFilePath(config: I18nConfig, layer: string, localeFile: string | undefined): string | null {
+    if (!localeFile) return null
     const dir = config.localeDirs.find(d => d.layer === layer)
     if (!dir) return null
     // If this is an alias, resolve to the aliased layer's dir

--- a/tests/adapters/laravel-adapter.test.ts
+++ b/tests/adapters/laravel-adapter.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { LaravelAdapter } from '../../src/adapters/laravel/index'
+import { registerAdapter, resetRegistry, detectFramework } from '../../src/adapters/registry'
+import { NuxtAdapter } from '../../src/adapters/nuxt/index'
+
+function createLaravelProject(root: string, opts: {
+  artisan?: boolean
+  composer?: Record<string, unknown> | null
+  locales?: string[]
+  langDir?: 'modern' | 'legacy'
+  configAppPhp?: string | null
+} = {}) {
+  const {
+    artisan = true,
+    composer = { require: { 'laravel/framework': '^11.0' } },
+    locales = ['en'],
+    langDir = 'modern',
+    configAppPhp = `<?php\nreturn [\n    'locale' => 'en',\n    'fallback_locale' => 'en',\n];\n`,
+  } = opts
+
+  if (artisan) {
+    writeFileSync(join(root, 'artisan'), '#!/usr/bin/env php\n<?php\n')
+  }
+
+  if (composer) {
+    writeFileSync(join(root, 'composer.json'), JSON.stringify(composer, null, 2))
+  }
+
+  const langBase = langDir === 'modern'
+    ? join(root, 'lang')
+    : join(root, 'resources', 'lang')
+
+  mkdirSync(langBase, { recursive: true })
+
+  for (const locale of locales) {
+    const localeDir = join(langBase, locale)
+    mkdirSync(localeDir, { recursive: true })
+    writeFileSync(
+      join(localeDir, 'auth.php'),
+      `<?php\nreturn [\n    'failed' => 'These credentials do not match.',\n];\n`,
+    )
+  }
+
+  if (configAppPhp) {
+    mkdirSync(join(root, 'config'), { recursive: true })
+    writeFileSync(join(root, 'config', 'app.php'), configAppPhp)
+  }
+}
+
+describe('LaravelAdapter.detect', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `laravel-adapter-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('has correct static properties', () => {
+    const adapter = new LaravelAdapter()
+    expect(adapter.name).toBe('laravel')
+    expect(adapter.label).toBe('Laravel')
+    expect(adapter.localeFileFormat).toBe('php-array')
+  })
+
+  it('returns 2 when artisan file exists', async () => {
+    writeFileSync(join(tempDir, 'artisan'), '#!/usr/bin/env php')
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(2)
+  })
+
+  it('returns 2 when composer.json has laravel/framework', async () => {
+    writeFileSync(join(tempDir, 'composer.json'), JSON.stringify({
+      require: { 'laravel/framework': '^11.0' },
+    }))
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(2)
+  })
+
+  it('returns 1 when lang/ has locale subdirectories with .php files', async () => {
+    const enDir = join(tempDir, 'lang', 'en')
+    mkdirSync(enDir, { recursive: true })
+    writeFileSync(join(enDir, 'auth.php'), '<?php return [];')
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(1)
+  })
+
+  it('returns 0 for an empty directory', async () => {
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when lang/ exists but has no .php files in subdirs', async () => {
+    const enDir = join(tempDir, 'lang', 'en')
+    mkdirSync(enDir, { recursive: true })
+    writeFileSync(join(enDir, 'readme.txt'), 'not a php file')
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when lang/ has only a vendor directory', async () => {
+    mkdirSync(join(tempDir, 'lang', 'vendor', 'some-package'), { recursive: true })
+    writeFileSync(join(tempDir, 'lang', 'vendor', 'some-package', 'en.php'), '<?php return [];')
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when composer.json exists without laravel/framework', async () => {
+    writeFileSync(join(tempDir, 'composer.json'), JSON.stringify({
+      require: { 'symfony/console': '^6.0' },
+    }))
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when composer.json is malformed', async () => {
+    writeFileSync(join(tempDir, 'composer.json'), '{ invalid json }')
+    const adapter = new LaravelAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+})
+
+describe('LaravelAdapter.resolve', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `laravel-resolve-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves a standard Laravel 9+ project with lang/ at root', async () => {
+    createLaravelProject(tempDir, {
+      locales: ['en', 'de', 'fr'],
+      configAppPhp: `<?php\nreturn [\n    'locale' => 'de',\n    'fallback_locale' => 'en',\n];\n`,
+    })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.rootDir).toBe(tempDir)
+    expect(config.defaultLocale).toBe('de')
+    expect(config.fallbackLocale).toEqual({ default: ['en'] })
+    expect(config.locales).toHaveLength(3)
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr'])
+    expect(config.locales[0].language).toBe('de')
+    expect(config.locales[0].file).toBeUndefined()
+    expect(config.localeDirs).toHaveLength(1)
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'lang'))
+    expect(config.localeDirs[0].layer).toBe('root')
+    expect(config.localeDirs[0].layerRootDir).toBe(tempDir)
+    expect(config.layerRootDirs).toEqual([tempDir])
+    expect(config.localeFileFormat).toBe('php-array')
+  })
+
+  it('resolves a legacy Laravel project with resources/lang/', async () => {
+    createLaravelProject(tempDir, {
+      locales: ['en', 'es'],
+      langDir: 'legacy',
+    })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales).toHaveLength(2)
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'es'])
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'resources', 'lang'))
+  })
+
+  it('extracts locale from env() pattern in config/app.php', async () => {
+    createLaravelProject(tempDir, {
+      configAppPhp: `<?php\nreturn [\n    'locale' => env('APP_LOCALE', 'fr'),\n    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),\n];\n`,
+    })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.defaultLocale).toBe('fr')
+    expect(config.fallbackLocale).toEqual({ default: ['en'] })
+  })
+
+  it('defaults to "en" when config/app.php is missing', async () => {
+    createLaravelProject(tempDir, { configAppPhp: null })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.defaultLocale).toBe('en')
+    expect(config.fallbackLocale).toEqual({ default: ['en'] })
+  })
+
+  it('ignores vendor/ directory in lang/', async () => {
+    createLaravelProject(tempDir, { locales: ['en'] })
+    mkdirSync(join(tempDir, 'lang', 'vendor', 'notifications', 'en'), { recursive: true })
+    writeFileSync(
+      join(tempDir, 'lang', 'vendor', 'notifications', 'en', 'messages.php'),
+      '<?php return [];',
+    )
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales).toHaveLength(1)
+    expect(config.locales[0].code).toBe('en')
+  })
+
+  it('throws ConfigError when no lang directory exists', async () => {
+    writeFileSync(join(tempDir, 'artisan'), '#!/usr/bin/env php')
+
+    const adapter = new LaravelAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No lang/ or resources/lang/')
+  })
+
+  it('throws ConfigError when lang/ has no locale subdirectories', async () => {
+    mkdirSync(join(tempDir, 'lang'))
+
+    const adapter = new LaravelAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale subdirectories')
+  })
+
+  it('skips locale subdirectories that contain no .php files', async () => {
+    createLaravelProject(tempDir, { locales: ['en'] })
+    mkdirSync(join(tempDir, 'lang', 'empty-locale'), { recursive: true })
+    writeFileSync(join(tempDir, 'lang', 'empty-locale', 'readme.txt'), 'no php here')
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en'])
+  })
+
+  it('sorts locale codes alphabetically', async () => {
+    createLaravelProject(tempDir, { locales: ['fr', 'en', 'de', 'zh'] })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr', 'zh'])
+  })
+})
+
+describe('Adapter registry: Laravel vs Nuxt', () => {
+  beforeEach(() => {
+    resetRegistry()
+  })
+
+  afterEach(() => {
+    resetRegistry()
+  })
+
+  it('selects LaravelAdapter when Laravel signals are stronger', async () => {
+    const tempDir = join(tmpdir(), `registry-laravel-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    createLaravelProject(tempDir)
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new LaravelAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('laravel')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('selects NuxtAdapter when Nuxt signals are stronger', async () => {
+    const tempDir = join(tmpdir(), `registry-nuxt-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    writeFileSync(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ i18n: { defaultLocale: "en" } })',
+    )
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new LaravelAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('nuxt')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('respects framework hint from project config', async () => {
+    registerAdapter(new NuxtAdapter())
+    registerAdapter(new LaravelAdapter())
+
+    const adapter = await detectFramework('/any/dir', 'laravel')
+    expect(adapter.name).toBe('laravel')
+  })
+})

--- a/tests/adapters/laravel-adapter.test.ts
+++ b/tests/adapters/laravel-adapter.test.ts
@@ -124,6 +124,28 @@ describe('LaravelAdapter.detect', () => {
     const adapter = new LaravelAdapter()
     expect(await adapter.detect(tempDir)).toBe(0)
   })
+
+  it('accumulates confidence from multiple signals', async () => {
+    createLaravelProject(tempDir, {
+      artisan: true,
+      composer: { require: { 'laravel/framework': '^11.0' } },
+      locales: ['en'],
+    })
+    const adapter = new LaravelAdapter()
+    // artisan (2) + composer (2) + lang/ with .php (1) = 5
+    expect(await adapter.detect(tempDir)).toBe(5)
+  })
+
+  it('accumulates artisan + lang/ without composer', async () => {
+    createLaravelProject(tempDir, {
+      artisan: true,
+      composer: null,
+      locales: ['en'],
+    })
+    const adapter = new LaravelAdapter()
+    // artisan (2) + lang/ with .php (1) = 3
+    expect(await adapter.detect(tempDir)).toBe(3)
+  })
 })
 
 describe('LaravelAdapter.resolve', () => {


### PR DESCRIPTION
## Summary

- Add `LaravelAdapter` implementing `FrameworkAdapter` for auto-detecting Laravel projects and resolving their i18n configuration
- Detection uses confidence scoring: artisan file (2), composer.json laravel/framework (2), lang/ with locale subdirs (1)
- Resolution scans `lang/` (Laravel 9+) or `resources/lang/` (older), extracts default/fallback locale from `config/app.php` via regex, returns `I18nConfig` with `localeFileFormat: 'php-array'`
- Makes `LocaleDefinition.file` optional and adds `localeFileFormat` field to `I18nConfig` for framework-specific file format dispatch
- Registers `LaravelAdapter` in the adapter registry alongside `NuxtAdapter`

## Changes

| File | Change |
|------|--------|
| `src/adapters/laravel/index.ts` | New: `LaravelAdapter` class (196 lines) |
| `src/config/detector.ts` | Register `LaravelAdapter` in adapter registry |
| `src/config/types.ts` | `LocaleDefinition.file` → optional, add `localeFileFormat` to `I18nConfig` |
| `src/server.ts` | `resolveLocaleFilePath` accepts `string \| undefined` |
| `tests/adapters/laravel-adapter.test.ts` | New: 21 tests (detection, resolution, registry auto-selection) |

## Test Results

- **346/346 tests pass** (325 existing + 21 new, 0 regressions)
- Typecheck clean
- Lint clean
- Build clean

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Laravel projects, enabling automatic i18n configuration detection and resolution for both modern and legacy locale directory structures.

* **Tests**
  * Added comprehensive test coverage for Laravel framework adapter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->