### PR TITLE
feat: wire unified locale IO into all MCP tools for Laravel support

### DIFF
--- a/src/io/json-reader.ts
+++ b/src/io/json-reader.ts
@@ -21,7 +21,7 @@ export function clearFileCacheEntry(filePath: string): void {
  */
 export async function readLocaleFile(filePath: string): Promise<Record<string, unknown>> {
   if (!existsSync(filePath)) {
-    throw new FileIOError(`File not found: ${filePath}`, filePath)
+    throw new FileIOError(`File not found: ${filePath}`, filePath, 'FILE_NOT_FOUND')
   }
 
   try {
@@ -40,7 +40,7 @@ export async function readLocaleFile(filePath: string): Promise<Record<string, u
   } catch (error) {
     if (error instanceof FileIOError) throw error
     if (error instanceof SyntaxError) {
-      throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath)
+      throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath, 'INVALID_JSON')
     }
     throw new FileIOError(
       `Failed to read file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -91,7 +91,7 @@ export async function readLocaleFileWithMeta(filePath: string): Promise<{
   trailingNewline: boolean
 }> {
   if (!existsSync(filePath)) {
-    throw new FileIOError(`File not found: ${filePath}`, filePath)
+    throw new FileIOError(`File not found: ${filePath}`, filePath, 'FILE_NOT_FOUND')
   }
 
   try {
@@ -103,7 +103,7 @@ export async function readLocaleFileWithMeta(filePath: string): Promise<{
     return { data, rawContent, indent, trailingNewline }
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath)
+      throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath, 'INVALID_JSON')
     }
     throw new FileIOError(
       `Failed to read file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/io/locale-data.ts
+++ b/src/io/locale-data.ts
@@ -1,0 +1,177 @@
+import { join } from 'node:path'
+import { readdir, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { readLocale, writeLocale } from './locale-io'
+import type { I18nConfig, LocaleDefinition } from '../config/types'
+import { log } from '../utils/logger'
+import { FileIOError } from '../utils/errors'
+
+/**
+ * A single locale file entry with its path and optional namespace.
+ * - Nuxt: one entry with namespace = null (flat file)
+ * - Laravel: one entry per .php file, namespace = filename without extension
+ */
+export interface LocaleEntry {
+  /** Absolute path to the locale file */
+  path: string
+  /** Namespace for this entry (e.g., 'auth', 'validation'). null for flat file formats. */
+  namespace: string | null
+}
+
+/**
+ * Resolve all locale file entries for a given locale in a layer.
+ *
+ * - Nuxt (json): Returns a single entry `[{path: ".../en-US.json", namespace: null}]`
+ * - Laravel (php-array): Scans `{langDir}/{localeCode}/*.php` and returns one entry per file
+ *   e.g., `[{path: ".../en/auth.php", namespace: "auth"}, ...]`
+ *
+ * Returns an empty array if the locale directory doesn't exist (e.g., new locale).
+ */
+export async function resolveLocaleEntries(
+  config: I18nConfig,
+  layer: string,
+  locale: LocaleDefinition,
+): Promise<LocaleEntry[]> {
+  const localeDir = resolveLayerDir(config, layer)
+  if (!localeDir) return []
+
+  if (config.localeFileFormat === 'php-array') {
+    return resolvePhpEntries(localeDir, locale.code)
+  }
+
+  if (!locale.file) return []
+  return [{ path: join(localeDir, locale.file), namespace: null }]
+}
+
+/**
+ * Read all locale data for a locale in a layer, merged into a single object.
+ *
+ * - Nuxt: Returns the JSON file contents as-is
+ * - Laravel: Reads each namespace .php file and mounts under its namespace key
+ *   e.g., `{ auth: { failed: "..." }, validation: { required: "..." } }`
+ *
+ * Missing files are treated as empty objects (no error thrown).
+ */
+export async function readLocaleData(
+  config: I18nConfig,
+  layer: string,
+  locale: LocaleDefinition,
+): Promise<Record<string, unknown>> {
+  const entries = await resolveLocaleEntries(config, layer, locale)
+  if (entries.length === 0) return {}
+
+  const merged: Record<string, unknown> = {}
+
+  for (const entry of entries) {
+    let data: Record<string, unknown>
+    try {
+      data = await readLocale(entry.path)
+    }
+    catch (err) {
+      if (err instanceof FileIOError && err.message.startsWith('File not found')) {
+        data = {}
+      }
+      else {
+        throw err
+      }
+    }
+
+    if (entry.namespace === null) {
+      Object.assign(merged, data)
+    }
+    else {
+      merged[entry.namespace] = data
+    }
+  }
+
+  return merged
+}
+
+/**
+ * Read, mutate, and write back locale data for a locale in a layer.
+ *
+ * The mutation function receives the merged locale object (same shape as readLocaleData)
+ * and may modify it in-place. After mutation:
+ *
+ * - Nuxt: Writes the entire object back to the single JSON file
+ * - Laravel: Splits by top-level namespace keys and writes each to its .php file.
+ *   New namespaces create new files. Empty namespaces delete the content (write empty object).
+ *
+ * Returns the set of file paths that were written.
+ */
+export async function mutateLocaleData(
+  config: I18nConfig,
+  layer: string,
+  locale: LocaleDefinition,
+  mutate: (data: Record<string, unknown>) => void,
+): Promise<Set<string>> {
+  const data = await readLocaleData(config, layer, locale)
+  mutate(data)
+
+  const filesWritten = new Set<string>()
+
+  if (config.localeFileFormat === 'php-array') {
+    const localeDir = resolveLayerDir(config, layer)
+    if (!localeDir) return filesWritten
+
+    const localePath = join(localeDir, locale.code)
+
+    if (!existsSync(localePath)) {
+      await mkdir(localePath, { recursive: true })
+    }
+
+    for (const [namespace, nsData] of Object.entries(data)) {
+      if (typeof nsData !== 'object' || nsData === null) {
+        log.warn(`Skipping non-object namespace '${namespace}' for locale '${locale.code}'`)
+        continue
+      }
+      const filePath = join(localePath, `${namespace}.php`)
+      await writeLocale(filePath, nsData as Record<string, unknown>)
+      filesWritten.add(filePath)
+    }
+  }
+  else {
+    const entries = await resolveLocaleEntries(config, layer, locale)
+    if (entries.length === 0) return filesWritten
+
+    const filePath = entries[0].path
+    await writeLocale(filePath, data)
+    filesWritten.add(filePath)
+  }
+
+  return filesWritten
+}
+
+// ─── Internal helpers ───────────────────────────────────────────
+
+function resolveLayerDir(config: I18nConfig, layer: string): string | null {
+  const dir = config.localeDirs.find(d => d.layer === layer)
+  if (!dir) return null
+  if (dir.aliasOf) {
+    const aliasDir = config.localeDirs.find(d => d.layer === dir.aliasOf)
+    if (aliasDir) return aliasDir.path
+  }
+  return dir.path
+}
+
+async function resolvePhpEntries(langDir: string, localeCode: string): Promise<LocaleEntry[]> {
+  const localePath = join(langDir, localeCode)
+
+  if (!existsSync(localePath)) return []
+
+  let files: string[]
+  try {
+    files = await readdir(localePath)
+  }
+  catch {
+    return []
+  }
+
+  return files
+    .filter(f => f.endsWith('.php'))
+    .sort()
+    .map(f => ({
+      path: join(localePath, f),
+      namespace: f.replace(/\.php$/, ''),
+    }))
+}

--- a/src/io/locale-data.ts
+++ b/src/io/locale-data.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { readdir, mkdir } from 'node:fs/promises'
+import { readdir, mkdir, unlink } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { readLocale, writeLocale } from './locale-io'
 import type { I18nConfig, LocaleDefinition } from '../config/types'
@@ -68,7 +68,7 @@ export async function readLocaleData(
       data = await readLocale(entry.path)
     }
     catch (err) {
-      if (err instanceof FileIOError && err.message.startsWith('File not found')) {
+      if (err instanceof FileIOError && err.code === 'FILE_NOT_FOUND') {
         data = {}
       }
       else {
@@ -129,6 +129,21 @@ export async function mutateLocaleData(
       await writeLocale(filePath, nsData as Record<string, unknown>)
       filesWritten.add(filePath)
     }
+
+    const expectedFiles = new Set(
+      Object.keys(data)
+        .filter(ns => typeof data[ns] === 'object' && data[ns] !== null)
+        .map(ns => `${ns}.php`),
+    )
+    try {
+      const existingFiles = await readdir(localePath)
+      for (const file of existingFiles) {
+        if (file.endsWith('.php') && !expectedFiles.has(file)) {
+          await unlink(join(localePath, file))
+        }
+      }
+    }
+    catch {}
   }
   else {
     const entries = await resolveLocaleEntries(config, layer, locale)
@@ -163,7 +178,8 @@ async function resolvePhpEntries(langDir: string, localeCode: string): Promise<L
   try {
     files = await readdir(localePath)
   }
-  catch {
+  catch (err) {
+    log.debug(`Failed to read locale directory ${localePath}: ${err instanceof Error ? err.message : String(err)}`)
     return []
   }
 

--- a/src/io/php-reader.ts
+++ b/src/io/php-reader.ts
@@ -15,7 +15,7 @@ export function clearPhpFileCacheEntry(filePath: string): void {
 
 export async function readPhpLocaleFile(filePath: string): Promise<Record<string, unknown>> {
   if (!existsSync(filePath)) {
-    throw new FileIOError(`File not found: ${filePath}`, filePath)
+    throw new FileIOError(`File not found: ${filePath}`, filePath, 'FILE_NOT_FOUND')
   }
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,8 +2,9 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod'
 import { detectI18nConfig, getCachedConfig } from './config/detector.js'
 import type { I18nConfig, ProjectConfig } from './config/types.js'
-import { readLocaleFile } from './io/json-reader.js'
-import { mutateLocaleFile, writeReportFile } from './io/json-writer.js'
+import type { LocaleFileFormat } from './adapters/types.js'
+import { writeReportFile } from './io/json-writer.js'
+import { readLocaleData, mutateLocaleData, resolveLocaleEntries } from './io/locale-data.js'
 import {
   getNestedValue,
   setNestedValue,
@@ -15,8 +16,8 @@ import {
 } from './io/key-operations.js'
 import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from './scanner/code-scanner.js'
 import { log } from './utils/logger.js'
-import { FileIOError, ToolError } from './utils/errors.js'
-import { join, resolve } from 'node:path'
+import { ToolError } from './utils/errors.js'
+import { resolve } from 'node:path'
 import { readdir } from 'node:fs/promises'
 
 function resolveOrphanScanDirs(
@@ -103,7 +104,6 @@ async function applyTranslations(
   translations: Record<string, Record<string, string>>,
   mode: 'add' | 'update',
   findLocale: (config: I18nConfig, ref: string) => ReturnType<typeof findLocaleImpl>,
-  resolveLocaleFilePath: (config: I18nConfig, layer: string, file: string | undefined) => string | null,
   dryRun = false,
 ): Promise<{ applied: string[]; skipped: string[]; warnings: string[]; filesWritten: number; preview?: Array<{ locale: string; key: string; value: string }> }> {
   const applied: string[] = []
@@ -112,7 +112,7 @@ async function applyTranslations(
   const filesWritten = new Set<string>()
   const preview: Array<{ locale: string; key: string; value: string }> = []
 
-  const byFile = new Map<string, Array<{ key: string; value: string; localeCode: string }>>()
+  const byLocale = new Map<ReturnType<typeof findLocaleImpl>, Array<{ key: string; value: string }>>()
 
   for (const [key, localeValues] of Object.entries(translations)) {
     for (const [localeRef, value] of Object.entries(localeValues)) {
@@ -127,34 +127,18 @@ async function applyTranslations(
         log.warn(`Locale not found: ${localeRef}, skipping`)
         continue
       }
-      const filePath = resolveLocaleFilePath(config, layer, locale.file)
-      if (!filePath) {
-        log.warn(`No locale dir found for layer '${layer}', skipping`)
-        continue
+      if (!byLocale.has(locale)) {
+        byLocale.set(locale, [])
       }
-      if (!byFile.has(filePath)) {
-        byFile.set(filePath, [])
-      }
-      byFile.get(filePath)!.push({ key, value, localeCode: locale.code })
+      byLocale.get(locale)!.push({ key, value })
     }
   }
 
-  for (const [filePath, entries] of byFile) {
+  for (const [locale, entries] of byLocale) {
+    if (!locale) continue
     if (dryRun) {
-      let data: Record<string, unknown> = {}
-      try {
-        data = await readLocaleFile(filePath)
-      } catch (err) {
-        if (err instanceof FileIOError && err.message.startsWith('File not found')) {
-          // File doesn't exist yet — treat all keys as applicable
-        } else {
-          throw new ToolError(
-            `Failed to read locale file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
-            'LOCALE_READ_ERROR',
-          )
-        }
-      }
-      for (const { key, value, localeCode } of entries) {
+      const data = await readLocaleData(config, layer, locale)
+      for (const { key, value } of entries) {
         const exists = hasNestedKey(data, key)
         if (mode === 'add' && exists) {
           skipped.push(key)
@@ -162,11 +146,11 @@ async function applyTranslations(
           skipped.push(key)
         } else {
           applied.push(key)
-          preview.push({ locale: localeCode, key, value })
+          preview.push({ locale: locale.code, key, value })
         }
       }
     } else {
-      await mutateLocaleFile(filePath, (data) => {
+      const written = await mutateLocaleData(config, layer, locale, (data) => {
         for (const { key, value } of entries) {
           const exists = hasNestedKey(data, key)
           if (mode === 'add' && exists) {
@@ -179,7 +163,7 @@ async function applyTranslations(
           }
         }
       })
-      filesWritten.add(filePath)
+      for (const f of written) filesWritten.add(f)
     }
   }
 
@@ -202,18 +186,24 @@ async function applyTranslations(
 /**
  * Build a system prompt for translation sampling from project config.
  */
+function placeholderInstruction(format?: LocaleFileFormat): string {
+  if (format === 'php-array') {
+    return 'Preserve all :placeholder parameters exactly as-is.'
+  }
+  return 'Preserve all {placeholder} parameters and @:linked.message references.'
+}
+
 function buildTranslationSystemPrompt(
   projectConfig: ProjectConfig | undefined,
   targetLocaleCode: string,
+  localeFileFormat?: LocaleFileFormat,
 ): string {
   const parts: string[] = []
 
-  // 1. Translation prompt from project config
   if (projectConfig?.translationPrompt) {
     parts.push(projectConfig.translationPrompt)
   }
 
-  // 2. Glossary
   if (projectConfig?.glossary && Object.keys(projectConfig.glossary).length > 0) {
     const glossaryLines = Object.entries(projectConfig.glossary)
       .map(([term, definition]) => `- ${term} → ${definition}`)
@@ -221,12 +211,10 @@ function buildTranslationSystemPrompt(
     parts.push(`GLOSSARY — use these terms consistently:\n${glossaryLines}`)
   }
 
-  // 3. Locale-specific notes
   if (projectConfig?.localeNotes?.[targetLocaleCode]) {
     parts.push(`TARGET LOCALE NOTE (${targetLocaleCode}): ${projectConfig.localeNotes[targetLocaleCode]}`)
   }
 
-  // 4. Examples
   if (projectConfig?.examples && projectConfig.examples.length > 0) {
     const exampleLines = projectConfig.examples
       .map((ex) => {
@@ -242,7 +230,7 @@ function buildTranslationSystemPrompt(
   }
 
   if (parts.length === 0) {
-    return 'You are a professional translator for software UI strings. Preserve all {placeholder} parameters and @:linked.message references. Be concise — UI space is limited.'
+    return `You are a professional translator for software UI strings. ${placeholderInstruction(localeFileFormat)} Be concise — UI space is limited.`
   }
 
   return parts.join('\n\n')
@@ -255,10 +243,11 @@ function buildTranslationUserMessage(
   referenceLocaleCode: string,
   targetLocaleCode: string,
   keysAndValues: Record<string, string>,
+  localeFileFormat?: LocaleFileFormat,
 ): string {
   return [
     `Translate the following i18n key-value pairs from ${referenceLocaleCode} to ${targetLocaleCode}.`,
-    'Preserve all {placeholder} parameters and @:linked.message references.',
+    placeholderInstruction(localeFileFormat),
     'Return ONLY a JSON object mapping keys to translated values. No markdown, no explanation, no code fences.',
     '',
     JSON.stringify(keysAndValues, null, 2),
@@ -314,19 +303,6 @@ export function createServer(): McpServer {
     name: 'nuxt-i18n-mcp',
     version: '0.1.0',
   })
-
-  // Helper: resolve locale file path for a layer + locale file name
-  function resolveLocaleFilePath(config: I18nConfig, layer: string, localeFile: string | undefined): string | null {
-    if (!localeFile) return null
-    const dir = config.localeDirs.find(d => d.layer === layer)
-    if (!dir) return null
-    // If this is an alias, resolve to the aliased layer's dir
-    if (dir.aliasOf) {
-      const aliasDir = config.localeDirs.find(d => d.layer === dir.aliasOf)
-      if (aliasDir) return join(aliasDir.path, localeFile)
-    }
-    return join(dir.path, localeFile)
-  }
 
   // Helper: find locale definition by locale code or file name
   function findLocale(config: I18nConfig, localeRef: string) {
@@ -400,27 +376,45 @@ export function createServer(): McpServer {
             continue
           }
 
-          const files = await readdir(localeDir.path)
-          const jsonFiles = files.filter(f => f.endsWith('.json'))
+          if (config.localeFileFormat === 'php-array') {
+            let subDirs: string[] = []
+            try { subDirs = await readdir(localeDir.path) } catch {}
 
-          // Read first JSON file to get top-level keys
-          let topLevelKeys: string[] = []
-          if (jsonFiles.length > 0) {
-            try {
-              const sampleFile = join(localeDir.path, jsonFiles[0])
-              const data = await readLocaleFile(sampleFile)
-              topLevelKeys = Object.keys(data)
-            } catch {
-              // Ignore errors reading sample file
+            const sampleLocale = config.locales[0]
+            let namespaces: string[] = []
+            if (sampleLocale) {
+              try {
+                const entries = await resolveLocaleEntries(config, localeDir.layer, sampleLocale)
+                namespaces = entries.map(e => e.namespace).filter((n): n is string => n !== null)
+              } catch {}
             }
-          }
 
-          results.push({
-            layer: localeDir.layer,
-            path: localeDir.path,
-            fileCount: jsonFiles.length,
-            topLevelKeys,
-          })
+            results.push({
+              layer: localeDir.layer,
+              path: localeDir.path,
+              fileCount: subDirs.length,
+              namespaces,
+            })
+          } else {
+            const files = await readdir(localeDir.path)
+            const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+            let topLevelKeys: string[] = []
+            if (config.locales.length > 0 && jsonFiles.length > 0) {
+              try {
+                const sampleLocale = config.locales[0]
+                const data = await readLocaleData(config, localeDir.layer, sampleLocale)
+                topLevelKeys = Object.keys(data)
+              } catch {}
+            }
+
+            results.push({
+              layer: localeDir.layer,
+              path: localeDir.path,
+              fileCount: jsonFiles.length,
+              topLevelKeys,
+            })
+          }
         }
 
         return {
@@ -477,14 +471,8 @@ export function createServer(): McpServer {
         const results: Record<string, Record<string, unknown>> = {}
 
         for (const loc of localesToRead) {
-          const filePath = resolveLocaleFilePath(config, layer, loc.file)
-          if (!filePath) {
-            results[loc.code] = Object.fromEntries(keys.map(k => [k, null]))
-            continue
-          }
-
           try {
-            const data = await readLocaleFile(filePath)
+            const data = await readLocaleData(config, layer, loc)
             results[loc.code] = Object.fromEntries(
               keys.map(k => [k, getNestedValue(data, k) ?? null]),
             )
@@ -543,7 +531,7 @@ export function createServer(): McpServer {
         const isDryRun = dryRun ?? false
 
         const { applied, skipped, warnings, filesWritten, preview } = await applyTranslations(
-          config, layer, translations, 'add', findLocale, resolveLocaleFilePath, isDryRun,
+          config, layer, translations, 'add', findLocale, isDryRun,
         )
 
         if (isDryRun) {
@@ -626,7 +614,7 @@ export function createServer(): McpServer {
         const isDryRun = dryRun ?? false
 
         const { applied, skipped, filesWritten, preview } = await applyTranslations(
-          config, layer, translations, 'update', findLocale, resolveLocaleFilePath, isDryRun,
+          config, layer, translations, 'update', findLocale, isDryRun,
         )
 
         if (isDryRun) {
@@ -719,19 +707,14 @@ export function createServer(): McpServer {
         let totalMissing = 0
 
         for (const localeDir of layersToScan) {
-          // Read reference locale file for this layer
-          const refFilePath = resolveLocaleFilePath(config, localeDir.layer, refLocale.file)
-          if (!refFilePath) continue
-
           let refData: Record<string, unknown>
           try {
-            refData = await readLocaleFile(refFilePath)
+            refData = await readLocaleData(config, localeDir.layer, refLocale)
           } catch {
-            // Reference file doesn't exist in this layer, skip
             continue
           }
+          if (Object.keys(refData).length === 0) continue
 
-          // Only consider ref keys that have non-empty values
           const refKeys = getLeafKeys(refData).filter(k => {
             const v = getNestedValue(refData, k)
             return typeof v === 'string' ? v.length > 0 : v !== null && v !== undefined
@@ -739,18 +722,12 @@ export function createServer(): McpServer {
           if (refKeys.length === 0) continue
 
           for (const target of targets) {
-            const targetFilePath = resolveLocaleFilePath(config, localeDir.layer, target.file)
             let targetData: Record<string, unknown> = {}
 
-            if (targetFilePath) {
-              try {
-                targetData = await readLocaleFile(targetFilePath)
-              } catch {
-                // Target file doesn't exist — all ref keys are missing
-              }
-            }
+            try {
+              targetData = await readLocaleData(config, localeDir.layer, target)
+            } catch {}
 
-            // A key is missing if it doesn't exist OR its value is an empty string
             const missing = refKeys.filter(k => {
               const v = getNestedValue(targetData, k)
               return v === undefined || v === '' || v === null
@@ -854,15 +831,13 @@ export function createServer(): McpServer {
 
         for (const localeDir of layersToScan) {
           for (const loc of localesToCheck) {
-            const filePath = resolveLocaleFilePath(config, localeDir.layer, loc.file)
-            if (!filePath) continue
-
             let data: Record<string, unknown>
             try {
-              data = await readLocaleFile(filePath)
+              data = await readLocaleData(config, localeDir.layer, loc)
             } catch {
               continue
             }
+            if (Object.keys(data).length === 0) continue
 
             const leafKeys = getLeafKeys(data)
             const empty = leafKeys.filter(k => getNestedValue(data, k) === '')
@@ -960,16 +935,13 @@ export function createServer(): McpServer {
 
         for (const localeDir of layersToSearch) {
           for (const loc of localesToSearch) {
-            const filePath = resolveLocaleFilePath(config, localeDir.layer, loc.file)
-            if (!filePath) continue
-
             let data: Record<string, unknown>
             try {
-              data = await readLocaleFile(filePath)
+              data = await readLocaleData(config, localeDir.layer, loc)
             } catch {
-              // File doesn't exist in this layer, skip
               continue
             }
+            if (Object.keys(data).length === 0) continue
 
             const leafKeys = getLeafKeys(data)
 
@@ -1053,15 +1025,13 @@ export function createServer(): McpServer {
         const filesWritten = new Set<string>()
 
         for (const locale of config.locales) {
-          const filePath = resolveLocaleFilePath(config, layer, locale.file)
-          if (!filePath) continue
-
           let data: Record<string, unknown>
           try {
-            data = await readLocaleFile(filePath)
+            data = await readLocaleData(config, layer, locale)
           } catch {
             continue
           }
+          if (Object.keys(data).length === 0) continue
 
           if (isDryRun) {
             for (const key of keys) {
@@ -1071,7 +1041,7 @@ export function createServer(): McpServer {
               }
             }
           } else {
-            await mutateLocaleFile(filePath, (fileData) => {
+            const written = await mutateLocaleData(config, layer, locale, (fileData) => {
               for (const key of keys) {
                 if (removeNestedValue(fileData, key)) {
                   removed.push(`${locale.code}:${key}`)
@@ -1080,7 +1050,7 @@ export function createServer(): McpServer {
                 }
               }
             })
-            filesWritten.add(filePath)
+            for (const f of written) filesWritten.add(f)
           }
         }
 
@@ -1169,15 +1139,13 @@ export function createServer(): McpServer {
         const filesWritten = new Set<string>()
 
         for (const locale of config.locales) {
-          const filePath = resolveLocaleFilePath(config, layer, locale.file)
-          if (!filePath) continue
-
           let data: Record<string, unknown>
           try {
-            data = await readLocaleFile(filePath)
+            data = await readLocaleData(config, layer, locale)
           } catch {
             continue
           }
+          if (Object.keys(data).length === 0) continue
 
           const oldValue = getNestedValue(data, oldKey)
           if (oldValue === undefined) {
@@ -1193,11 +1161,11 @@ export function createServer(): McpServer {
           if (isDryRun) {
             preview.push({ locale: locale.code, oldKey, newKey, value: oldValue })
           } else {
-            await mutateLocaleFile(filePath, (fileData) => {
+            const written = await mutateLocaleData(config, layer, locale, (fileData) => {
               renameNestedKey(fileData, oldKey, newKey)
             })
             renamed.push(locale.code)
-            filesWritten.add(filePath)
+            for (const f of written) filesWritten.add(f)
           }
         }
 
@@ -1302,13 +1270,10 @@ export function createServer(): McpServer {
           throw new ToolError(`Reference locale not found: "${refCode}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass a valid locale code as referenceLocale, or omit it to use the project default.`, 'REFERENCE_LOCALE_NOT_FOUND')
         }
 
-        // Read reference locale file
-        const refFilePath = resolveLocaleFilePath(config, layer, refLocale.file)
-        if (!refFilePath) {
-          throw new ToolError(`No locale file found for reference locale "${refCode}" in layer "${layer}". Verify the layer exists and contains a file for this locale using list_locale_dirs.`, 'NO_LOCALE_FILE')
+        const refData = await readLocaleData(config, layer, refLocale)
+        if (Object.keys(refData).length === 0) {
+          throw new ToolError(`No locale data found for reference locale "${refCode}" in layer "${layer}". Verify the layer exists and contains data for this locale using list_locale_dirs.`, 'NO_LOCALE_FILE')
         }
-        const refData = await readLocaleFile(refFilePath)
-        // Only consider ref keys that have non-empty values
         const allRefKeys = getLeafKeys(refData).filter(k => {
           const v = getNestedValue(refData, k)
           return typeof v === 'string' ? v.length > 0 : v !== null && v !== undefined
@@ -1333,16 +1298,11 @@ export function createServer(): McpServer {
         const fallbackContexts: Record<string, Record<string, unknown>> = {}
 
         for (const target of targets) {
-          const targetFilePath = resolveLocaleFilePath(config, layer, target.file)
           let targetData: Record<string, unknown> = {}
 
-          if (targetFilePath) {
-            try {
-              targetData = await readLocaleFile(targetFilePath)
-            } catch {
-              // File doesn't exist yet — all keys are missing
-            }
-          }
+          try {
+            targetData = await readLocaleData(config, layer, target)
+          } catch {}
 
           // A key is missing if it doesn't exist OR its value is an empty string
           const isKeyMissing = (k: string): boolean => {
@@ -1396,11 +1356,12 @@ export function createServer(): McpServer {
               const batch = Object.fromEntries(keyEntries.slice(i, i + maxBatch))
 
               try {
-                const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, target.language || target.code)
+                const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, target.language || target.code, config.localeFileFormat)
                 const userMessage = buildTranslationUserMessage(
                   refLocale.language || refLocale.code,
                   target.language || target.code,
                   batch,
+                  config.localeFileFormat,
                 )
 
                 const samplingResult = await server.server.createMessage({
@@ -1440,9 +1401,8 @@ export function createServer(): McpServer {
               }
             }
 
-            // Single write per locale file after all batches
-            if (targetFilePath && Object.keys(allTranslations).length > 0) {
-              await mutateLocaleFile(targetFilePath, (data) => {
+            if (Object.keys(allTranslations).length > 0) {
+              await mutateLocaleData(config, layer, target, (data) => {
                 for (const [key, value] of Object.entries(allTranslations)) {
                   setNestedValue(data, key, value)
                 }
@@ -1558,18 +1518,15 @@ export function createServer(): McpServer {
           )
         }
 
-        // Collect all translation keys from locale files
-        const allTranslationKeys = new Map<string, string>() // key -> layer
+        const allTranslationKeys = new Map<string, string>()
         for (const localeDir of layersToCheck) {
-          const filePath = resolveLocaleFilePath(config, localeDir.layer, localeDef.file)
-          if (!filePath) continue
-
           let data: Record<string, unknown>
           try {
-            data = await readLocaleFile(filePath)
+            data = await readLocaleData(config, localeDir.layer, localeDef)
           } catch {
             continue
           }
+          if (Object.keys(data).length === 0) continue
 
           const leafKeys = getLeafKeys(data)
           for (const key of leafKeys) {
@@ -1865,18 +1822,15 @@ export function createServer(): McpServer {
           )
         }
 
-        // Collect translation keys per layer
         const keysByLayer = new Map<string, string[]>()
         for (const localeDir of layersToCheck) {
-          const filePath = resolveLocaleFilePath(config, localeDir.layer, localeDef.file)
-          if (!filePath) continue
-
           let data: Record<string, unknown>
           try {
-            data = await readLocaleFile(filePath)
+            data = await readLocaleData(config, localeDir.layer, localeDef)
           } catch {
             continue
           }
+          if (Object.keys(data).length === 0) continue
 
           keysByLayer.set(localeDir.layer, getLeafKeys(data))
         }
@@ -2010,7 +1964,6 @@ export function createServer(): McpServer {
           }
         }
 
-        // Actually remove orphan keys from all locale files in each layer
         const removedByLayer: Record<string, string[]> = {}
         let totalFilesWritten = 0
 
@@ -2019,16 +1972,13 @@ export function createServer(): McpServer {
           if (localeDir.aliasOf) continue
 
           for (const localeDef2 of config.locales) {
-            const filePath = resolveLocaleFilePath(config, layerName, localeDef2.file)
-            if (!filePath) continue
-
             try {
-              await mutateLocaleFile(filePath, (fileData) => {
+              const written = await mutateLocaleData(config, layerName, localeDef2, (fileData) => {
                 for (const key of orphans) {
                   removeNestedValue(fileData, key)
                 }
               })
-              totalFilesWritten++
+              totalFilesWritten += written.size
             } catch {
               continue
             }
@@ -2078,7 +2028,7 @@ export function createServer(): McpServer {
 
   server.registerResource(
     'locale-file',
-    new ResourceTemplate('i18n:///{layer}/{file}', {
+    new ResourceTemplate('i18n:///{layer}/{locale}', {
       list: async () => {
         const config = getCachedConfig()
         if (!config) {
@@ -2095,8 +2045,8 @@ export function createServer(): McpServer {
           if (localeDir.aliasOf) continue
           for (const locale of config.locales) {
             resources.push({
-              uri: `i18n:///${localeDir.layer}/${locale.file}`,
-              name: `${localeDir.layer}/${locale.file}`,
+              uri: `i18n:///${localeDir.layer}/${locale.code}`,
+              name: `${localeDir.layer}/${locale.code}`,
               description: `${locale.name ?? locale.code} translations for ${localeDir.layer} layer`,
               mimeType: 'application/json',
             })
@@ -2110,16 +2060,16 @@ export function createServer(): McpServer {
       description: 'Locale translation file for a specific layer and locale',
       mimeType: 'application/json',
     },
-    async (uri, { layer, file }) => {
+    async (uri, { layer, locale }) => {
       const config = getCachedConfig()
       if (!config) {
         throw new Error('No i18n config detected yet. Call detect_i18n_config first.')
       }
-      const filePath = resolveLocaleFilePath(config, layer as string, file as string)
-      if (!filePath) {
-        throw new Error(`Locale file not found: ${layer}/${file}`)
+      const localeDef = findLocale(config, locale as string)
+      if (!localeDef) {
+        throw new Error(`Locale not found: ${locale}`)
       }
-      const data = await readLocaleFile(filePath)
+      const data = await readLocaleData(config, layer as string, localeDef)
       return {
         contents: [
           {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { detectI18nConfig, getCachedConfig } from './config/detector.js'
-import type { I18nConfig, ProjectConfig } from './config/types.js'
+import type { I18nConfig, LocaleDefinition, ProjectConfig } from './config/types.js'
 import type { LocaleFileFormat } from './adapters/types.js'
 import { writeReportFile } from './io/json-writer.js'
 import { readLocaleData, mutateLocaleData, resolveLocaleEntries } from './io/locale-data.js'
@@ -112,7 +112,7 @@ async function applyTranslations(
   const filesWritten = new Set<string>()
   const preview: Array<{ locale: string; key: string; value: string }> = []
 
-  const byLocale = new Map<ReturnType<typeof findLocaleImpl>, Array<{ key: string; value: string }>>()
+  const byLocale = new Map<LocaleDefinition, Array<{ key: string; value: string }>>()
 
   for (const [key, localeValues] of Object.entries(translations)) {
     for (const [localeRef, value] of Object.entries(localeValues)) {
@@ -135,7 +135,6 @@ async function applyTranslations(
   }
 
   for (const [locale, entries] of byLocale) {
-    if (!locale) continue
     if (dryRun) {
       const data = await readLocaleData(config, layer, locale)
       for (const { key, value } of entries) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,11 +7,13 @@ export class ConfigError extends Error {
 
 export class FileIOError extends Error {
   public readonly filePath: string
+  public readonly code: string
 
-  constructor(message: string, filePath: string) {
+  constructor(message: string, filePath: string, code = 'FILE_IO_ERROR') {
     super(message)
     this.name = 'FileIOError'
     this.filePath = filePath
+    this.code = code
   }
 }
 

--- a/tests/io/locale-data.test.ts
+++ b/tests/io/locale-data.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, writeFile, rm, mkdir, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveLocaleEntries, readLocaleData, mutateLocaleData } from '../../src/io/locale-data.js'
+import { clearFileCache } from '../../src/io/json-reader.js'
+import { clearPhpFileCache } from '../../src/io/php-reader.js'
+import type { I18nConfig, LocaleDefinition } from '../../src/config/types.js'
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'locale-data-test-'))
+  clearFileCache()
+  clearPhpFileCache()
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+function makeNuxtConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+  return {
+    rootDir: tempDir,
+    defaultLocale: 'en',
+    fallbackLocale: { default: ['en'] },
+    locales: [
+      { code: 'en', language: 'en', file: 'en.json' },
+      { code: 'de', language: 'de', file: 'de.json' },
+    ],
+    localeDirs: [{ path: join(tempDir, 'locales'), layer: 'root', layerRootDir: tempDir }],
+    layerRootDirs: [tempDir],
+    localeFileFormat: 'json',
+    ...overrides,
+  }
+}
+
+function makeLaravelConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+  return {
+    rootDir: tempDir,
+    defaultLocale: 'en',
+    fallbackLocale: { default: ['en'] },
+    locales: [
+      { code: 'en', language: 'en' },
+      { code: 'de', language: 'de' },
+    ],
+    localeDirs: [{ path: join(tempDir, 'lang'), layer: 'root', layerRootDir: tempDir }],
+    layerRootDirs: [tempDir],
+    localeFileFormat: 'php-array',
+    ...overrides,
+  }
+}
+
+async function setupNuxtLocales() {
+  const localesDir = join(tempDir, 'locales')
+  await mkdir(localesDir, { recursive: true })
+  await writeFile(join(localesDir, 'en.json'), JSON.stringify({
+    common: { save: 'Save', cancel: 'Cancel' },
+    auth: { login: 'Login' },
+  }))
+  await writeFile(join(localesDir, 'de.json'), JSON.stringify({
+    common: { save: 'Speichern', cancel: 'Abbrechen' },
+    auth: { login: 'Anmelden' },
+  }))
+}
+
+async function setupLaravelLocales() {
+  const enDir = join(tempDir, 'lang', 'en')
+  const deDir = join(tempDir, 'lang', 'de')
+  await mkdir(enDir, { recursive: true })
+  await mkdir(deDir, { recursive: true })
+
+  await writeFile(join(enDir, 'auth.php'), `<?php\nreturn ['failed' => 'Invalid credentials', 'throttle' => 'Too many attempts'];\n`)
+  await writeFile(join(enDir, 'validation.php'), `<?php\nreturn ['required' => 'This field is required'];\n`)
+  await writeFile(join(deDir, 'auth.php'), `<?php\nreturn ['failed' => 'Ungueltige Anmeldedaten'];\n`)
+}
+
+describe('resolveLocaleEntries', () => {
+  it('returns single entry for Nuxt JSON locale', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const entries = await resolveLocaleEntries(config, 'root', locale)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].path).toBe(join(tempDir, 'locales', 'en.json'))
+    expect(entries[0].namespace).toBeNull()
+  })
+
+  it('returns one entry per .php file for Laravel locale', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual({
+      path: join(tempDir, 'lang', 'en', 'auth.php'),
+      namespace: 'auth',
+    })
+    expect(entries[1]).toEqual({
+      path: join(tempDir, 'lang', 'en', 'validation.php'),
+      namespace: 'validation',
+    })
+  })
+
+  it('returns empty array for unknown layer', async () => {
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const entries = await resolveLocaleEntries(config, 'nonexistent', locale)
+    expect(entries).toEqual([])
+  })
+
+  it('returns empty array for Nuxt locale without file field', async () => {
+    const config = makeNuxtConfig({
+      locales: [{ code: 'en', language: 'en' }],
+    })
+
+    const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+    expect(entries).toEqual([])
+  })
+
+  it('returns empty array when Laravel locale dir does not exist', async () => {
+    const config = makeLaravelConfig()
+
+    const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+    expect(entries).toEqual([])
+  })
+
+  it('follows layer aliases', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig({
+      localeDirs: [
+        { path: join(tempDir, 'locales'), layer: 'root', layerRootDir: tempDir },
+        { path: join(tempDir, 'alias-dir'), layer: 'app-shop', layerRootDir: tempDir, aliasOf: 'root' },
+      ],
+    })
+
+    const entries = await resolveLocaleEntries(config, 'app-shop', config.locales[0])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].path).toBe(join(tempDir, 'locales', 'en.json'))
+  })
+})
+
+describe('readLocaleData', () => {
+  it('reads Nuxt JSON locale as flat object', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+
+    const data = await readLocaleData(config, 'root', config.locales[0])
+
+    expect(data).toEqual({
+      common: { save: 'Save', cancel: 'Cancel' },
+      auth: { login: 'Login' },
+    })
+  })
+
+  it('reads Laravel locale as namespace-keyed object', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+
+    const data = await readLocaleData(config, 'root', config.locales[0])
+
+    expect(data).toEqual({
+      auth: { failed: 'Invalid credentials', throttle: 'Too many attempts' },
+      validation: { required: 'This field is required' },
+    })
+  })
+
+  it('reads partial Laravel locale (missing namespace files)', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+
+    const data = await readLocaleData(config, 'root', config.locales[1])
+
+    expect(data).toEqual({
+      auth: { failed: 'Ungueltige Anmeldedaten' },
+    })
+  })
+
+  it('returns empty object for non-existent locale dir', async () => {
+    const config = makeLaravelConfig()
+
+    const data = await readLocaleData(config, 'root', { code: 'fr', language: 'fr' })
+    expect(data).toEqual({})
+  })
+
+  it('returns empty object for non-existent Nuxt file', async () => {
+    await mkdir(join(tempDir, 'locales'), { recursive: true })
+    const config = makeNuxtConfig()
+
+    const data = await readLocaleData(config, 'root', { code: 'fr', language: 'fr', file: 'fr.json' })
+    expect(data).toEqual({})
+  })
+})
+
+describe('mutateLocaleData', () => {
+  it('mutates Nuxt JSON locale and writes back', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.common as Record<string, string>).save = 'Save Changes'
+      ;(data as Record<string, unknown>).newKey = 'new'
+    })
+
+    expect(written.size).toBe(1)
+    expect(written.has(join(tempDir, 'locales', 'en.json'))).toBe(true)
+
+    clearFileCache()
+    const result = await readLocaleData(config, 'root', locale)
+    expect((result.common as Record<string, string>).save).toBe('Save Changes')
+    expect(result.newKey).toBe('new')
+    expect((result.auth as Record<string, string>).login).toBe('Login')
+  })
+
+  it('mutates Laravel namespace and writes per-file', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.auth as Record<string, string>).failed = 'Bad credentials'
+      ;(data.auth as Record<string, string>).newKey = 'added'
+    })
+
+    expect(written.size).toBe(2)
+
+    clearPhpFileCache()
+    const result = await readLocaleData(config, 'root', locale)
+    expect((result.auth as Record<string, string>).failed).toBe('Bad credentials')
+    expect((result.auth as Record<string, string>).newKey).toBe('added')
+    expect((result.validation as Record<string, string>).required).toBe('This field is required')
+  })
+
+  it('creates new namespace file for Laravel', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data as Record<string, unknown>).passwords = { reset: 'Password has been reset' }
+    })
+
+    clearPhpFileCache()
+    const result = await readLocaleData(config, 'root', locale)
+    expect((result.passwords as Record<string, string>).reset).toBe('Password has been reset')
+
+    const newFile = join(tempDir, 'lang', 'en', 'passwords.php')
+    const content = await readFile(newFile, 'utf-8')
+    expect(content).toContain('reset')
+  })
+
+  it('creates locale directory for new Laravel locale', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const frLocale: LocaleDefinition = { code: 'fr', language: 'fr' }
+
+    await mutateLocaleData(config, 'root', frLocale, (data) => {
+      ;(data as Record<string, unknown>).auth = { failed: 'Identifiants invalides' }
+    })
+
+    clearPhpFileCache()
+    const updatedConfig = makeLaravelConfig({
+      locales: [...config.locales, frLocale],
+    })
+    const result = await readLocaleData(updatedConfig, 'root', frLocale)
+    expect((result.auth as Record<string, string>).failed).toBe('Identifiants invalides')
+  })
+
+  it('returns empty set when layer not found', async () => {
+    const config = makeNuxtConfig()
+    const written = await mutateLocaleData(config, 'nonexistent', config.locales[0], () => {})
+    expect(written.size).toBe(0)
+  })
+})

--- a/tests/io/locale-data.test.ts
+++ b/tests/io/locale-data.test.ts
@@ -276,4 +276,28 @@ describe('mutateLocaleData', () => {
     const written = await mutateLocaleData(config, 'nonexistent', config.locales[0], () => {})
     expect(written.size).toBe(0)
   })
+
+  it('removes orphaned PHP files when namespace is deleted', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    clearPhpFileCache()
+    const before = await readLocaleData(config, 'root', locale)
+    expect(before.auth).toBeDefined()
+    expect(before.validation).toBeDefined()
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      delete data.validation
+    })
+
+    clearPhpFileCache()
+    const after = await readLocaleData(config, 'root', locale)
+    expect(after.auth).toBeDefined()
+    expect(after.validation).toBeUndefined()
+
+    const { existsSync } = await import('node:fs')
+    expect(existsSync(join(tempDir, 'lang', 'en', 'auth.php'))).toBe(true)
+    expect(existsSync(join(tempDir, 'lang', 'en', 'validation.php'))).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

Closes #44

Wire the unified locale IO layer into `server.ts` so all 14 MCP tools work transparently on both JSON (Nuxt) and PHP array (Laravel) locale files.

## Changes

### New: `src/io/locale-data.ts` — Unified locale IO abstraction
- `resolveLocaleEntries(config, layer, locale)` → returns `{path, namespace}[]` for a locale in a layer
- `readLocaleData(config, layer, locale)` → reads + merges all files for a locale into a single object
- `mutateLocaleData(config, layer, locale, fn)` → load, mutate, split by namespace, write per-file
- Nuxt: single JSON file, flat object
- Laravel: scans `lang/{locale}/*.php`, mounts each file under its namespace key (e.g., `{ auth: {...}, validation: {...} }`)
- Creates locale directories automatically for new locales

### Modified: `src/server.ts` — All tools now use the abstraction
- **Removed** `resolveLocaleFilePath` — replaced by internal dispatch in `locale-data.ts`
- **Rewritten** `applyTranslations` — groups by locale (not file path), uses `readLocaleData`/`mutateLocaleData`
- **Updated** all 14 tools from `resolveLocaleFilePath + readLocaleFile/mutateLocaleFile` → `readLocaleData/mutateLocaleData`
- **Updated** `list_locale_dirs` — shows PHP namespaces for Laravel projects
- **Updated** resource URIs from `i18n:///{layer}/{file}` → `i18n:///{layer}/{locale}` (works for both formats)
- **Added** format-aware placeholder instructions for translation prompts (`:placeholder` for Laravel, `{placeholder}` for Nuxt)

### New: `tests/io/locale-data.test.ts` — 16 unit tests
- `resolveLocaleEntries`: JSON single entry, PHP multi-entry, unknown layer, missing file field, missing dir, alias following
- `readLocaleData`: JSON flat read, PHP namespace-keyed read, partial locale, missing locale/file
- `mutateLocaleData`: JSON roundtrip, PHP per-file write, new namespace creation, new locale dir creation

## Verification
- 364/364 tests pass (348 existing + 16 new)
- TypeScript: `tsc --noEmit` clean
- ESLint: clean
- Build: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Resource Updates**
  * Changed how locale files are referenced—now using locale identifiers instead of file paths for resource addressing

* **Improvements**
  * Translation sampling is now format-aware; prompts adapt based on locale storage format for more accurate results
  * Enhanced support for PHP array-based locale directory structures with improved namespace detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->