### PR TITLE
feat: extend code scanner to support Laravel Blade/PHP translation patterns

### DIFF
--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -2,6 +2,8 @@ import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { glob } from 'tinyglobby'
 import { log } from '../utils/logger.js'
+import type { ScanPatternSet } from './patterns.js'
+import { VUE_NUXT_PATTERNS } from './patterns.js'
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -26,46 +28,17 @@ export interface ScanResult {
   uniqueKeys: Set<string>
 }
 
-// ─── Patterns ───────────────────────────────────────────────────
-
-const SCAN_PATTERNS = ['**/*.vue', '**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.mts']
-
-const DEFAULT_IGNORE = ['node_modules', '.nuxt', '.output', 'dist', '.git', 'coverage', '.tmp']
-
-/**
- * Matches static i18n calls: $t('key'), t('key'), this.$t('key'), and double-quote variants.
- *
- * Group 1: callee ($t | t | this.$t)
- * Group 2: quote character
- * Group 3: the key string
- */
-const STATIC_KEY_PATTERN = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
-
-/**
- * Matches dynamic i18n calls with template literals: $t(`prefix.${var}`), t(`...`), this.$t(`...`)
- *
- * Group 1: callee
- * Group 2: template literal content (without backticks)
- */
-const DYNAMIC_KEY_PATTERN = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
-
-/**
- * Matches concatenation-based dynamic keys: t('prefix.' + var), $t("key." + expr)
- * Captures the static string prefix before the `+` operator.
- *
- * Group 1: callee
- * Group 2: quote character
- * Group 3: the static prefix string
- */
-const CONCAT_KEY_PATTERN = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2\s*\+/g
-
 // ─── Extraction ─────────────────────────────────────────────────
 
 /**
  * Extract all i18n key references from file content.
  * Returns static usages and dynamic (unresolvable) references.
+ *
+ * When no `patterns` argument is provided, defaults to Vue/Nuxt patterns
+ * for backward compatibility.
  */
-export function extractKeys(content: string, filePath: string): { usages: KeyUsage[]; dynamicKeys: DynamicKeyUsage[] } {
+export function extractKeys(content: string, filePath: string, patterns?: ScanPatternSet): { usages: KeyUsage[]; dynamicKeys: DynamicKeyUsage[] } {
+  const pat = patterns ?? VUE_NUXT_PATTERNS
   const usages: KeyUsage[] = []
   const dynamicKeys: DynamicKeyUsage[] = []
   const lines = content.split('\n')
@@ -74,31 +47,39 @@ export function extractKeys(content: string, filePath: string): { usages: KeyUsa
     const line = lines[i]
     const lineNumber = i + 1
 
-    // Static keys: $t('key'), t('key.path'), this.$t('key')
-    for (const match of line.matchAll(STATIC_KEY_PATTERN)) {
-      const callee = match[1]
-      const key = match[3]
-      if (!key) continue
-      // Bare `t('word')` without a dot is likely not i18n (emit, import, etc.)
-      if (callee === 't' && !key.includes('.')) continue
-      usages.push({ key, file: filePath, line: lineNumber, callee })
+    for (const regex of pat.staticKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const callee = match[1]
+        const key = match[3]
+        if (!key) continue
+        if (key.includes('{$')) continue
+        if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+        usages.push({ key, file: filePath, line: lineNumber, callee })
+      }
     }
 
-    // Dynamic keys: t(`prefix.${var}`)
-    for (const match of line.matchAll(DYNAMIC_KEY_PATTERN)) {
-      const expression = match[2]
-      if (!expression.includes('${')) continue
-      dynamicKeys.push({ expression: `\`${expression}\``, file: filePath, line: lineNumber, callee: match[1] })
+    for (const regex of pat.dynamicKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const expression = match[2]
+        if (!expression.includes('${') && !expression.includes('{$')) continue
+        const normalized = expression.includes('{$')
+          ? expression.replace(/\{\$[^}]+\}/g, '${_}')
+          : expression
+        dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
+      }
     }
 
-    // Concatenation-based dynamic keys: t('prefix.' + var)
-    // Convert prefix to template literal format so buildDynamicKeyRegexes can handle it
-    for (const match of line.matchAll(CONCAT_KEY_PATTERN)) {
-      const callee = match[1]
-      const prefix = match[3]
-      if (!prefix) continue
-      if (callee === 't' && !prefix.includes('.')) continue
-      dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: lineNumber, callee })
+    for (const regex of pat.concatKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const callee = match[1]
+        const prefix = match[3]
+        if (!prefix) continue
+        if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
+        dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: lineNumber, callee })
+      }
     }
   }
 
@@ -149,20 +130,17 @@ export function buildDynamicKeyRegexes(dynamicKeys: Pick<DynamicKeyUsage, 'expre
   const regexes: RegExp[] = []
 
   for (const dk of dynamicKeys) {
-    // Strip outer backticks: `foo.${bar}.baz` → foo.${bar}.baz
     let expr = dk.expression
     if (expr.startsWith('`') && expr.endsWith('`')) {
       expr = expr.slice(1, -1)
     }
 
-    // Skip expressions that don't contain interpolation
     if (!expr.includes('${')) continue
 
     const pattern = splitInterpolations(expr)
       .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       .join('[^.]+')
 
-    // Deduplicate identical patterns
     if (seen.has(pattern)) continue
     seen.add(pattern)
 
@@ -177,15 +155,16 @@ export function buildDynamicKeyRegexes(dynamicKeys: Pick<DynamicKeyUsage, 'expre
 /**
  * Scan source files in a directory for i18n key usage.
  *
- * Uses tinyglobby for file discovery, then extracts $t() / t() / this.$t()
- * references from all Vue, TS, and JS files.
+ * When `patterns` is omitted, defaults to Vue/Nuxt patterns for backward
+ * compatibility.
  */
-export async function scanSourceFiles(rootDir: string, excludeDirs?: string[]): Promise<ScanResult> {
-  const ignore = [...DEFAULT_IGNORE, ...(excludeDirs ?? [])]
+export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], patterns?: ScanPatternSet): Promise<ScanResult> {
+  const pat = patterns ?? VUE_NUXT_PATTERNS
+  const ignore = [...pat.ignoreDirs, ...(excludeDirs ?? [])]
 
   let relativePaths: string[]
   try {
-    relativePaths = await glob(SCAN_PATTERNS, { cwd: rootDir, ignore, dot: false, absolute: false })
+    relativePaths = await glob(pat.filePatterns, { cwd: rootDir, ignore, dot: false, absolute: false })
   } catch {
     return { usages: [], dynamicKeys: [], filesScanned: 0, uniqueKeys: new Set() }
   }
@@ -204,7 +183,7 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[]): 
       continue
     }
 
-    const { usages, dynamicKeys } = extractKeys(content, filePath)
+    const { usages, dynamicKeys } = extractKeys(content, filePath, pat)
     allUsages.push(...usages)
     allDynamicKeys.push(...dynamicKeys)
     filesScanned++

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -53,6 +53,9 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
         const callee = match[1]
         const key = match[3]
         if (!key) continue
+        // Skip PHP brace-interpolated keys like "msg.{$type}.title" — handled by dynamicKeyPatterns.
+        // Bare $var interpolation (without braces) is intentionally treated as static because
+        // it's indistinguishable from a literal dollar sign without PHP runtime context.
         if (key.includes('{$')) continue
         if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
         usages.push({ key, file: filePath, line: lineNumber, callee })

--- a/src/scanner/patterns.ts
+++ b/src/scanner/patterns.ts
@@ -1,0 +1,109 @@
+import type { LocaleFileFormat } from '../adapters/types.js'
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface ScanPatternSet {
+  label: string
+  filePatterns: string[]
+  ignoreDirs: string[]
+  /** Must capture: (1) callee, (2) quote char, (3) key */
+  staticKeyPatterns: RegExp[]
+  /** Must capture: (1) callee, (2) template content */
+  dynamicKeyPatterns: RegExp[]
+  /** Must capture: (1) callee, (2) quote char, (3) prefix */
+  concatKeyPatterns: RegExp[]
+  /**
+   * Returns true if the callee should be skipped when the key has no dot.
+   * Vue `t('word')` without a dot is likely not i18n — `emit`, `import`, etc.
+   */
+  requiresDotForCallee?: (callee: string) => boolean
+}
+
+// ─── Vue / Nuxt Patterns ────────────────────────────────────────
+
+/**
+ * Matches static i18n calls: $t('key'), t('key'), this.$t('key'), and double-quote variants.
+ * Group 1: callee ($t | t | this.$t)
+ * Group 2: quote character
+ * Group 3: the key string
+ */
+const VUE_STATIC_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
+
+/**
+ * Matches dynamic i18n calls with template literals: $t(`prefix.${var}`), t(`...`), this.$t(`...`)
+ * Group 1: callee
+ * Group 2: template literal content (without backticks)
+ */
+const VUE_DYNAMIC_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
+
+/**
+ * Matches concatenation-based dynamic keys: t('prefix.' + var), $t("key." + expr)
+ * Group 1: callee
+ * Group 2: quote character
+ * Group 3: the static prefix string
+ */
+const VUE_CONCAT_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2\s*\+/g
+
+export const VUE_NUXT_PATTERNS: ScanPatternSet = {
+  label: 'Vue / Nuxt',
+  filePatterns: ['**/*.vue', '**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.mts'],
+  ignoreDirs: ['node_modules', '.nuxt', '.output', 'dist', '.git', 'coverage', '.tmp'],
+  staticKeyPatterns: [VUE_STATIC_KEY],
+  dynamicKeyPatterns: [VUE_DYNAMIC_KEY],
+  concatKeyPatterns: [VUE_CONCAT_KEY],
+  requiresDotForCallee: (callee: string) => callee === 't',
+}
+
+// ─── Laravel / PHP Patterns ─────────────────────────────────────
+
+/**
+ * Matches Laravel static translation calls with single or double quotes:
+ *   __('key')           → Group 1: __      Group 2: '  Group 3: key
+ *   trans('key')        → Group 1: trans   Group 2: '  Group 3: key
+ *   trans_choice('k',n) → Group 1: trans_choice  Group 2: '  Group 3: k
+ *   Lang::get('key')    → Group 1: Lang::get     Group 2: '  Group 3: key
+ *   @lang('key')        → Group 1: @lang         Group 2: '  Group 3: key
+ */
+const LARAVEL_STATIC_KEY = /(?<!\w)(__|\btrans_choice|\btrans|Lang::get|@lang)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
+
+/**
+ * Matches Laravel dynamic calls with PHP variable interpolation in double-quoted strings:
+ *   __("prefix.{$var}.suffix") — PHP interpolation only works in double quotes
+ * Group 1: callee
+ * Group 2: the string content (may contain {$var} or $var)
+ */
+const LARAVEL_DYNAMIC_KEY = /(?<!\w)(__|\btrans_choice|\btrans|Lang::get|@lang)\s*\(\s*"((?:[^"\\]|\\.)*)"\s*[,)]/g
+
+/**
+ * Matches Laravel concatenation-based dynamic keys:
+ *   __('prefix.' . $var)   → PHP concat operator is `.`
+ *   trans('key.' . $expr)
+ * Group 1: callee
+ * Group 2: quote character
+ * Group 3: the static prefix string
+ */
+const LARAVEL_CONCAT_KEY = /(?<!\w)(__|\btrans_choice|\btrans|Lang::get|@lang)\s*\(\s*(['"])((?:(?!\2).)*)\2\s*\./g
+
+export const LARAVEL_PATTERNS: ScanPatternSet = {
+  label: 'Laravel',
+  filePatterns: ['**/*.blade.php', '**/*.php'],
+  ignoreDirs: ['vendor', 'storage', 'bootstrap/cache', 'node_modules', '.git', 'dist', 'coverage'],
+  staticKeyPatterns: [LARAVEL_STATIC_KEY],
+  dynamicKeyPatterns: [LARAVEL_DYNAMIC_KEY],
+  concatKeyPatterns: [LARAVEL_CONCAT_KEY],
+}
+
+// ─── Resolution ─────────────────────────────────────────────────
+
+/**
+ * Returns the appropriate scan pattern set for a given locale file format.
+ * Defaults to Vue/Nuxt patterns when format is unknown.
+ */
+export function getPatternSet(format?: LocaleFileFormat): ScanPatternSet {
+  switch (format) {
+    case 'php-array':
+      return LARAVEL_PATTERNS
+    default:
+      return VUE_NUXT_PATTERNS
+  }
+}

--- a/src/scanner/patterns.ts
+++ b/src/scanner/patterns.ts
@@ -96,8 +96,9 @@ export const LARAVEL_PATTERNS: ScanPatternSet = {
 // ─── Resolution ─────────────────────────────────────────────────
 
 /**
- * Returns the appropriate scan pattern set for a given locale file format.
- * Defaults to Vue/Nuxt patterns when format is unknown.
+ * Maps locale file format to the appropriate scan pattern set.
+ * 'php-array' → Laravel (PHP translation helpers in Blade/PHP files).
+ * 'json' / undefined → Vue/Nuxt ($t / t calls in Vue/TS/JS files).
  */
 export function getPatternSet(format?: LocaleFileFormat): ScanPatternSet {
   switch (format) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import {
   validateTranslationValue,
 } from './io/key-operations.js'
 import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from './scanner/code-scanner.js'
+import { getPatternSet } from './scanner/patterns.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
 import { resolve } from 'node:path'
@@ -1566,7 +1567,7 @@ export function createServer(): McpServer {
         const allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
 
         for (const scanDir of dirsToScan) {
-          const result = await scanSourceFiles(scanDir, excludeDirs)
+          const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
           totalFilesScanned += result.filesScanned
           for (const key of result.uniqueKeys) {
             combinedUniqueKeys.add(key)
@@ -1685,7 +1686,7 @@ export function createServer(): McpServer {
         let totalFilesScanned = 0
 
         for (const scanDir of dirsToScan) {
-          const result = await scanSourceFiles(scanDir, excludeDirs)
+          const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
           totalFilesScanned += result.filesScanned
           allUsages.push(...result.usages)
           allDynamicKeys.push(...result.dynamicKeys)
@@ -1864,7 +1865,7 @@ export function createServer(): McpServer {
         const allDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
 
         for (const scanDir of dirsToScan) {
-          const result = await scanSourceFiles(scanDir, excludeDirs)
+          const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
           totalFilesScanned += result.filesScanned
           for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
           allDynamicKeys.push(...result.dynamicKeys.map(dk => ({

--- a/tests/scanner/laravel-patterns.test.ts
+++ b/tests/scanner/laravel-patterns.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdir, writeFile, rm } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { extractKeys, scanSourceFiles } from '../../src/scanner/code-scanner.js'
+import { LARAVEL_PATTERNS, getPatternSet } from '../../src/scanner/patterns.js'
+
+const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/laravel-scanner')
+
+function extract(content: string, filePath = 'test.blade.php') {
+  return extractKeys(content, filePath, LARAVEL_PATTERNS)
+}
+
+describe('Laravel extractKeys', () => {
+  describe('static key extraction', () => {
+    it('extracts __() with single quotes', () => {
+      const { usages } = extract(`<?php echo __('messages.welcome'); ?>`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'messages.welcome', callee: '__', line: 1 })
+    })
+
+    it('extracts __() with double quotes', () => {
+      const { usages } = extract(`<?php echo __("messages.welcome"); ?>`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'messages.welcome', callee: '__' })
+    })
+
+    it('extracts trans() with single quotes', () => {
+      const { usages } = extract(`{{ trans('auth.failed') }}`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'auth.failed', callee: 'trans', line: 1 })
+    })
+
+    it('extracts trans() with double quotes', () => {
+      const { usages } = extract(`{{ trans("auth.failed") }}`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'auth.failed', callee: 'trans' })
+    })
+
+    it('extracts trans_choice()', () => {
+      const { usages } = extract(`{{ trans_choice('messages.apples', 10) }}`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'messages.apples', callee: 'trans_choice' })
+    })
+
+    it('extracts Lang::get()', () => {
+      const { usages } = extract(`<?php Lang::get('messages.welcome'); ?>`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'messages.welcome', callee: 'Lang::get' })
+    })
+
+    it('extracts @lang() Blade directive', () => {
+      const { usages } = extract(`@lang('messages.welcome')`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'messages.welcome', callee: '@lang' })
+    })
+
+    it('extracts keys without dots (no bare-callee filter for Laravel)', () => {
+      const { usages } = extract(`__('welcome')`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'welcome', callee: '__' })
+    })
+
+    it('extracts multiple keys from the same line', () => {
+      const { usages } = extract(`<p>{{ __('auth.login') }} | {{ __('auth.register') }}</p>`)
+      expect(usages).toHaveLength(2)
+      expect(usages[0].key).toBe('auth.login')
+      expect(usages[1].key).toBe('auth.register')
+    })
+
+    it('extracts keys across multiple lines with correct line numbers', () => {
+      const content = [
+        '<h1>{{ __("pages.title") }}</h1>',
+        '',
+        '<p>{{ trans("pages.body") }}</p>',
+      ].join('\n')
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(2)
+      expect(usages[0]).toMatchObject({ key: 'pages.title', line: 1 })
+      expect(usages[1]).toMatchObject({ key: 'pages.body', line: 3 })
+    })
+
+    it('extracts keys with spaces around parentheses', () => {
+      const { usages } = extract(`__(  'spaced.key'  )`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0].key).toBe('spaced.key')
+    })
+
+    it('extracts keys with nested dots', () => {
+      const { usages } = extract(`__('admin.users.permissions.edit')`)
+      expect(usages).toHaveLength(1)
+      expect(usages[0].key).toBe('admin.users.permissions.edit')
+    })
+
+    it('does not match __() preceded by a word character', () => {
+      const { usages } = extract(`foo__('not.a.key')`)
+      expect(usages).toHaveLength(0)
+    })
+
+    it('does not match trans preceded by a word character', () => {
+      const { usages } = extract(`detrans('not.a.key')`)
+      expect(usages).toHaveLength(0)
+    })
+
+    it('extracts from Blade echo and raw echo', () => {
+      const content = [
+        '{{ __("escaped.key") }}',
+        '{!! __("raw.key") !!}',
+      ].join('\n')
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(2)
+      expect(usages[0].key).toBe('escaped.key')
+      expect(usages[1].key).toBe('raw.key')
+    })
+
+    it('extracts from PHP controller code', () => {
+      const content = [
+        '<?php',
+        'class UserController extends Controller {',
+        '    public function store() {',
+        '        return redirect()->with("status", __("users.created"));',
+        '    }',
+        '}',
+      ].join('\n')
+      const { usages } = extract(content, 'UserController.php')
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'users.created', callee: '__', line: 4 })
+    })
+
+    it('extracts from validation messages array', () => {
+      const content = [
+        "'email.required' => __('validation.email_required'),",
+        "'name.max' => trans('validation.name_too_long'),",
+      ].join('\n')
+      const { usages } = extract(content, 'validation.php')
+      expect(usages).toHaveLength(2)
+      expect(usages[0].key).toBe('validation.email_required')
+      expect(usages[1].key).toBe('validation.name_too_long')
+    })
+  })
+
+  describe('dynamic key extraction', () => {
+    it('detects PHP variable interpolation in double-quoted strings', () => {
+      const { dynamicKeys } = extract(`__("messages.{$type}.title")`)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].expression).toContain('messages.')
+      expect(dynamicKeys[0].expression).toContain('.title')
+      expect(dynamicKeys[0].callee).toBe('__')
+    })
+
+    it('ignores static double-quoted strings (no interpolation)', () => {
+      const { dynamicKeys, usages } = extract(`__("messages.welcome")`)
+      expect(dynamicKeys).toHaveLength(0)
+      expect(usages).toHaveLength(1)
+    })
+
+    it('detects $var interpolation (without braces)', () => {
+      const content = `__("messages.$type.title")`
+      const { dynamicKeys } = extract(content)
+      expect(dynamicKeys).toHaveLength(0)
+    })
+  })
+
+  describe('concatenation-based dynamic keys', () => {
+    it('detects PHP dot concatenation with single quotes', () => {
+      const { dynamicKeys } = extract(`__('messages.' . $type)`)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].expression).toBe('`messages.${_}`')
+      expect(dynamicKeys[0].callee).toBe('__')
+    })
+
+    it('detects PHP dot concatenation with double quotes', () => {
+      const { dynamicKeys } = extract(`__("prefix." . $var)`)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].expression).toBe('`prefix.${_}`')
+    })
+
+    it('detects trans() concatenation', () => {
+      const { dynamicKeys } = extract(`trans('pages.' . $page)`)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].callee).toBe('trans')
+    })
+
+    it('detects @lang concatenation', () => {
+      const { dynamicKeys } = extract(`@lang('section.' . $name)`)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].callee).toBe('@lang')
+    })
+  })
+})
+
+describe('getPatternSet', () => {
+  it('returns Laravel patterns for php-array format', () => {
+    const patterns = getPatternSet('php-array')
+    expect(patterns.label).toBe('Laravel')
+    expect(patterns.filePatterns).toContain('**/*.blade.php')
+    expect(patterns.filePatterns).toContain('**/*.php')
+  })
+
+  it('returns Vue/Nuxt patterns for json format', () => {
+    const patterns = getPatternSet('json')
+    expect(patterns.label).toBe('Vue / Nuxt')
+    expect(patterns.filePatterns).toContain('**/*.vue')
+  })
+
+  it('returns Vue/Nuxt patterns for undefined format', () => {
+    const patterns = getPatternSet(undefined)
+    expect(patterns.label).toBe('Vue / Nuxt')
+  })
+})
+
+describe('Laravel scanSourceFiles', () => {
+  beforeAll(async () => {
+    await mkdir(tmpDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    await mkdir(tmpDir, { recursive: true })
+  })
+
+  it('scans .blade.php files', async () => {
+    await writeFile(join(tmpDir, 'welcome.blade.php'), [
+      '<h1>{{ __("pages.welcome.title") }}</h1>',
+      '<p>@lang("pages.welcome.body")</p>',
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.size).toBe(2)
+    expect(result.uniqueKeys.has('pages.welcome.title')).toBe(true)
+    expect(result.uniqueKeys.has('pages.welcome.body')).toBe(true)
+  })
+
+  it('scans .php files', async () => {
+    await writeFile(join(tmpDir, 'UserController.php'), [
+      '<?php',
+      'return __("users.created");',
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.has('users.created')).toBe(true)
+  })
+
+  it('scans nested directories', async () => {
+    await mkdir(join(tmpDir, 'views/partials'), { recursive: true })
+    await writeFile(join(tmpDir, 'views/partials/header.blade.php'), `{{ __('layout.header') }}`)
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.has('layout.header')).toBe(true)
+  })
+
+  it('skips vendor directory', async () => {
+    await mkdir(join(tmpDir, 'vendor/laravel'), { recursive: true })
+    await writeFile(join(tmpDir, 'vendor/laravel/helpers.php'), `__('vendor.key')`)
+    await writeFile(join(tmpDir, 'app.blade.php'), `{{ __('app.key') }}`)
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.has('vendor.key')).toBe(false)
+    expect(result.uniqueKeys.has('app.key')).toBe(true)
+  })
+
+  it('skips storage directory', async () => {
+    await mkdir(join(tmpDir, 'storage/logs'), { recursive: true })
+    await writeFile(join(tmpDir, 'storage/logs/compiled.php'), `__('cached.key')`)
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(0)
+  })
+
+  it('does not scan .vue or .ts files with Laravel patterns', async () => {
+    await writeFile(join(tmpDir, 'Component.vue'), `{{ $t('vue.key') }}`)
+    await writeFile(join(tmpDir, 'utils.ts'), `t('ts.key')`)
+    await writeFile(join(tmpDir, 'page.blade.php'), `{{ __('blade.key') }}`)
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.has('vue.key')).toBe(false)
+    expect(result.uniqueKeys.has('ts.key')).toBe(false)
+    expect(result.uniqueKeys.has('blade.key')).toBe(true)
+  })
+
+  it('respects custom excludeDirs', async () => {
+    await mkdir(join(tmpDir, 'tests'), { recursive: true })
+    await writeFile(join(tmpDir, 'tests/Feature.php'), `__('test.key')`)
+    await writeFile(join(tmpDir, 'app.php'), `__('app.key')`)
+
+    const result = await scanSourceFiles(tmpDir, ['tests'], LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(1)
+    expect(result.uniqueKeys.has('test.key')).toBe(false)
+    expect(result.uniqueKeys.has('app.key')).toBe(true)
+  })
+
+  it('handles empty directory gracefully', async () => {
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(0)
+    expect(result.uniqueKeys.size).toBe(0)
+  })
+
+  it('reports dynamic keys from scanned files', async () => {
+    await writeFile(join(tmpDir, 'dynamic.blade.php'), [
+      '{{ __("status.{$type}.label") }}',
+      '{{ __("static.key") }}',
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.usages).toHaveLength(1)
+    expect(result.usages[0].key).toBe('static.key')
+    expect(result.dynamicKeys).toHaveLength(1)
+    expect(result.dynamicKeys[0].expression).toContain('status.')
+  })
+
+  it('deduplicates keys in uniqueKeys set', async () => {
+    await writeFile(join(tmpDir, 'a.blade.php'), `{{ __('shared.key') }}`)
+    await writeFile(join(tmpDir, 'b.blade.php'), `{{ __('shared.key') }}`)
+
+    const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+    expect(result.filesScanned).toBe(2)
+    expect(result.usages).toHaveLength(2)
+    expect(result.uniqueKeys.size).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Extends the code scanner to support Laravel Blade/PHP translation patterns so `find_orphan_keys`, `scan_code_usage`, and `cleanup_unused_translations` work for Laravel projects.

## Changes
- **New `src/scanner/patterns.ts`**: `ScanPatternSet` interface with Vue/Nuxt and Laravel pattern definitions
  - Laravel patterns: `__()`, `trans()`, `trans_choice()`, `Lang::get()`, `@lang()`
  - File globs: `*.blade.php`, `*.php`
  - Ignore dirs: `vendor`, `storage`, `bootstrap/cache`
- **Refactored `src/scanner/code-scanner.ts`**: `extractKeys()` and `scanSourceFiles()` accept optional `ScanPatternSet` (defaults to Vue/Nuxt for backward compat)
  - Static keys with PHP interpolation (`{$var}`) are skipped to avoid double-counting with dynamic extraction
- **Updated `src/server.ts`**: All 3 `scanSourceFiles` call sites pass `getPatternSet(config.localeFileFormat)`
- **37 new tests** in `tests/scanner/laravel-patterns.test.ts` covering extraction, file discovery, ignore dirs, and dynamic keys

## Testing
- `pnpm typecheck` ✅
- `pnpm test` ✅ (402 tests, 72 existing scanner tests unchanged)
- `pnpm build` ✅

## Related Issues
Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel/PHP translation key scanning.
  * Introduced framework-specific scanning patterns for more accurate key detection.

* **Refactor**
  * Restructured scanner to use configurable pattern sets based on project type.

* **Tests**
  * Added comprehensive test coverage for Laravel translation key extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->