### PR TITLE
fix: skip no-op locale writes and expose framework in config

### DIFF
--- a/src/config/detector.ts
+++ b/src/config/detector.ts
@@ -32,6 +32,7 @@ export async function detectI18nConfig(projectDir: string): Promise<I18nConfig> 
   log.info(`Detected framework: ${adapter.label}`)
 
   const config = await adapter.resolve(projectDir)
+  config.framework = adapter.name
   configCache.set(canonDir, config)
   lastConfig = config
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -66,6 +66,8 @@ export interface ProjectConfig {
  * The fully resolved i18n configuration for a Nuxt project.
  */
 export interface I18nConfig {
+  /** Detected framework name (e.g., 'nuxt', 'laravel'). Set by the detector. */
+  framework?: string
   /** Absolute path to the project root */
   rootDir: string
   /** Default locale code */

--- a/src/io/locale-data.ts
+++ b/src/io/locale-data.ts
@@ -106,9 +106,15 @@ export async function mutateLocaleData(
   mutate: (data: Record<string, unknown>) => void,
 ): Promise<Set<string>> {
   const data = await readLocaleData(config, layer, locale)
+  const snapshot = JSON.stringify(data)
   mutate(data)
 
   const filesWritten = new Set<string>()
+
+  // Skip write if mutation was a no-op (e.g., key didn't exist)
+  if (JSON.stringify(data) === snapshot) {
+    return filesWritten
+  }
 
   if (config.localeFileFormat === 'php-array') {
     const localeDir = resolveLayerDir(config, layer)


### PR DESCRIPTION
## Summary

- **Skip no-op writes in `mutateLocaleData`**: Snapshots data before mutation and skips the write when content is unchanged. Prevents unnecessary file writes (and git diffs) in `remove_translations`/`rename_translation_key` when a key doesn't exist in a locale.
- **Add `framework` field to `I18nConfig`**: Optional field populated from `adapter.name` by the detector. Lets tool consumers know whether the project is `nuxt` or `laravel` without inferring from `localeFileFormat`.

All 402 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced framework detection with explicit configuration identification.

* **Performance**
  * Reduced unnecessary file writes during locale data updates by skipping no-op mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->