### PR TITLE
feat: add scaffold_locale tool and add-language prompt

### DIFF
--- a/src/adapters/laravel/index.ts
+++ b/src/adapters/laravel/index.ts
@@ -64,9 +64,11 @@ export class LaravelAdapter implements FrameworkAdapter {
       )
     }
 
-    const { defaultLocale, fallbackLocale } = await extractLocaleConfig(projectDir)
+    const { defaultLocale, fallbackLocale, configLocales } = await extractLocaleConfig(projectDir)
 
-    const locales: LocaleDefinition[] = localeSubdirs.map(code => ({
+    const allCodes = mergeLocaleCodes(localeSubdirs, configLocales)
+
+    const locales: LocaleDefinition[] = allCodes.map(code => ({
       code,
       language: code,
     }))
@@ -79,7 +81,7 @@ export class LaravelAdapter implements FrameworkAdapter {
 
     log.info(
       `Discovered ${locales.length} locale(s) in ${langDir}: `
-      + `${localeSubdirs.join(', ')}`,
+      + `${allCodes.join(', ')}`,
     )
 
     return {
@@ -142,6 +144,7 @@ async function findLocaleSubdirs(langDir: string): Promise<string[]> {
 async function extractLocaleConfig(projectDir: string): Promise<{
   defaultLocale: string
   fallbackLocale: Record<string, string[]>
+  configLocales: string[]
 }> {
   const configPath = join(projectDir, 'config', 'app.php')
 
@@ -154,17 +157,20 @@ async function extractLocaleConfig(projectDir: string): Promise<{
     return {
       defaultLocale: 'en',
       fallbackLocale: { default: ['en'] },
+      configLocales: [],
     }
   }
 
   const defaultLocale = extractPhpConfigValue(content, 'locale') ?? 'en'
   const fallbackValue = extractPhpConfigValue(content, 'fallback_locale') ?? defaultLocale
+  const configLocales = extractPhpArrayValue(content, 'locales')
 
-  log.debug(`Extracted locale config: locale=${defaultLocale}, fallback=${fallbackValue}`)
+  log.debug(`Extracted locale config: locale=${defaultLocale}, fallback=${fallbackValue}, config locales=${configLocales.length}`)
 
   return {
     defaultLocale,
     fallbackLocale: { default: [fallbackValue] },
+    configLocales,
   }
 }
 
@@ -195,4 +201,32 @@ function extractPhpConfigValue(content: string, key: string): string | null {
   }
 
   return null
+}
+
+function extractPhpArrayValue(content: string, key: string): string[] {
+  const pattern = new RegExp(
+    `['"]${key}['"]\\s*=>\\s*\\[([^\\]]*)]`,
+  )
+  const match = content.match(pattern)
+  if (!match) return []
+
+  const itemPattern = /['"]([^'"]+)['"]/g
+  const items: string[] = []
+  let itemMatch: RegExpExecArray | null
+  while ((itemMatch = itemPattern.exec(match[1])) !== null) {
+    items.push(itemMatch[1])
+  }
+  return items
+}
+
+function mergeLocaleCodes(filesystemCodes: string[], configCodes: string[]): string[] {
+  const seen = new Set(filesystemCodes)
+  const merged = [...filesystemCodes]
+  for (const code of configCodes) {
+    if (!seen.has(code)) {
+      seen.add(code)
+      merged.push(code)
+    }
+  }
+  return merged.sort()
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2332,8 +2332,9 @@ Follow these steps:
    - **Laravel**: Add the locale code to the \`available_locales\` array in \`config/app.php\`.
 3. Call \`scaffold_locale\` with the new locale code to create empty locale files in all layers.
 4. Call \`translate_missing\` for each layer to auto-translate all keys from the default locale.
-   - If auto-translation is unavailable, use \`get_translations\` to read the default locale, translate the keys yourself, then call \`add_translations\`.
-5. Report a summary: locale code added, files created, keys translated per layer.`
+   - If auto-translation is unavailable, use \`get_translations\` to read the default locale, translate the keys yourself, then call \`update_translations\`.
+5. Call \`get_missing_translations\` to verify the new locale has zero missing keys in every layer.
+6. Report a summary: locale code added, files created, keys translated per layer.`
 
       return {
         messages: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json') as { version: string }
 
-import { detectI18nConfig, getCachedConfig } from './config/detector.js'
+import { detectI18nConfig, getCachedConfig, clearConfigCache } from './config/detector.js'
 import type { I18nConfig, LocaleDefinition, ProjectConfig } from './config/types.js'
 import type { LocaleFileFormat } from './adapters/types.js'
 import { writeReportFile } from './io/json-writer.js'
@@ -333,6 +333,7 @@ export function createServer(): McpServer {
     async ({ projectDir }) => {
       try {
         const dir = projectDir ?? process.cwd()
+        clearConfigCache()
         const config = await detectI18nConfig(dir)
         return {
           content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -2057,14 +2057,16 @@ export function createServer(): McpServer {
           created: result.created.map(f => ({
             locale: f.locale,
             layer: f.layer,
-            file: toRelativePath(config.rootDir, f.file),
+            file: toRelativePath(f.file, config.rootDir),
             keys: f.keys,
+            ...(f.namespace ? { namespace: f.namespace } : {}),
           })),
           skipped: result.skipped.map(f => ({
             locale: f.locale,
             layer: f.layer,
-            file: toRelativePath(config.rootDir, f.file),
+            file: toRelativePath(f.file, config.rootDir),
             keys: f.keys,
+            ...(f.namespace ? { namespace: f.namespace } : {}),
           })),
           dryRun: dryRun ?? false,
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
 import { resolve } from 'node:path'
 import { readdir } from 'node:fs/promises'
+import { scaffoldLocale } from './tools/scaffold-locale.js'
 
 function resolveOrphanScanDirs(
   config: I18nConfig,
@@ -2029,6 +2030,58 @@ export function createServer(): McpServer {
     },
   )
 
+  // ─── Tool: scaffold_locale ──────────────────────────────────────
+
+  server.registerTool(
+    'scaffold_locale',
+    {
+      title: 'Scaffold Locale',
+      description:
+        'Create empty locale files for new languages. Copies the key structure from the default locale with all values set to empty strings. Supports both JSON (Nuxt) and PHP (Laravel) formats. Does NOT modify framework config — the agent must add the locale to the framework config before calling this tool.',
+      inputSchema: {
+        locales: z.array(z.string()).optional().describe('Locale codes to scaffold (e.g., ["sv", "ja"]). If omitted, auto-detects locales in config that are missing files.'),
+        layer: z.string().optional().describe('Scope to a single layer (e.g., "root", "app-admin"). If omitted, scaffolds across all layers.'),
+        dryRun: z.boolean().optional().describe('If true, return what would be created without writing files. Defaults to false.'),
+        projectDir: z.string().optional().describe('Absolute path to the project root. Defaults to server cwd.'),
+      },
+    },
+    async ({ locales, layer, dryRun, projectDir }) => {
+      try {
+        const dir = projectDir ?? process.cwd()
+        const config = await detectI18nConfig(dir)
+
+        const result = await scaffoldLocale(config, { locales, layer, dryRun })
+
+        const summary = {
+          created: result.created.map(f => ({
+            locale: f.locale,
+            layer: f.layer,
+            file: toRelativePath(config.rootDir, f.file),
+            keys: f.keys,
+          })),
+          skipped: result.skipped.map(f => ({
+            locale: f.locale,
+            layer: f.layer,
+            file: toRelativePath(config.rootDir, f.file),
+            keys: f.keys,
+          })),
+          dryRun: dryRun ?? false,
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(summary, null, 2),
+            },
+          ],
+        }
+      } catch (error) {
+        return toolErrorResponse('scaffolding locale', error)
+      }
+    },
+  )
+
   // ─── Resources ────────────────────────────────────────────────
 
   server.registerResource(
@@ -2212,6 +2265,72 @@ Follow these steps:
 3. For each locale with missing keys, call \`translate_missing\` to auto-fill gaps using the reference locale.
    - If auto-translation is not available, translate the keys yourself using the glossary and style guidelines above, then call \`add_translations\`.
 4. Report a summary of what was translated, organized by layer and locale.`
+
+      return {
+        messages: [
+          {
+            role: 'user' as const,
+            content: { type: 'text' as const, text: promptText },
+          },
+        ],
+      }
+    },
+  )
+
+  server.registerPrompt(
+    'add-language',
+    {
+      title: 'Add Language',
+      description: 'Add a new language to the project: update framework config, scaffold empty locale files, then translate all keys.',
+      argsSchema: {
+        language: z.string().describe('Language to add (e.g., "Swedish", "sv", "sv-SE")'),
+        projectDir: z.string().optional().describe('Absolute path to the project root. Defaults to server cwd.'),
+      },
+    },
+    async ({ language, projectDir }) => {
+      const dir = projectDir ?? process.cwd()
+      let configSection = ''
+
+      try {
+        const config = await detectI18nConfig(dir)
+        configSection += `\nDETECTED FRAMEWORK: ${config.framework ?? 'unknown'}`
+        configSection += `\nDEFAULT LOCALE: ${config.defaultLocale}`
+        configSection += `\nEXISTING LOCALES: ${config.locales.map(l => `${l.code} (${l.language})`).join(', ')}`
+        configSection += `\nLAYERS: ${config.localeDirs.filter(d => !d.aliasOf).map(d => d.layer).join(', ')}`
+
+        const pc = config.projectConfig
+        if (pc?.translationPrompt) {
+          configSection += `\nTRANSLATION STYLE: ${pc.translationPrompt}`
+        }
+        if (pc?.glossary && Object.keys(pc.glossary).length > 0) {
+          configSection += '\nGLOSSARY:'
+          for (const [term, definition] of Object.entries(pc.glossary)) {
+            configSection += `\n- ${term} → ${definition}`
+          }
+        }
+        if (pc?.localeNotes) {
+          configSection += '\nLOCALE NOTES:'
+          for (const [locale, note] of Object.entries(pc.localeNotes)) {
+            configSection += `\n- ${locale}: ${note}`
+          }
+        }
+      } catch {
+        configSection += '\nConfig detection failed — you will need to call detect_i18n_config manually.'
+      }
+
+      const promptText = `Add "${language}" as a new language to this project.
+${configSection}
+
+Follow these steps:
+
+1. Call \`detect_i18n_config\` to understand the current project setup.
+2. Add the new locale to the framework configuration:
+   - **Nuxt**: Add the locale entry to \`i18n.locales\` in \`nuxt.config.ts\` (code, language, file).
+   - **Laravel**: Add the locale code to the \`available_locales\` array in \`config/app.php\`.
+3. Call \`scaffold_locale\` with the new locale code to create empty locale files in all layers.
+4. Call \`translate_missing\` for each layer to auto-translate all keys from the default locale.
+   - If auto-translation is unavailable, use \`get_translations\` to read the default locale, translate the keys yourself, then call \`add_translations\`.
+5. Report a summary: locale code added, files created, keys translated per layer.`
 
       return {
         messages: [

--- a/src/tools/scaffold-locale.ts
+++ b/src/tools/scaffold-locale.ts
@@ -4,6 +4,7 @@ import type { I18nConfig, LocaleDefinition } from '../config/types'
 import { readLocaleData, resolveLocaleEntries } from '../io/locale-data'
 import { readLocale, writeLocale } from '../io/locale-io'
 import { getLeafKeys } from '../io/key-operations'
+import { ToolError } from '../utils/errors'
 
 export interface ScaffoldLocaleOptions {
   locales?: string[]
@@ -48,15 +49,37 @@ export async function scaffoldLocale(
     ? config.localeDirs.filter(d => d.layer === layerFilter)
     : config.localeDirs.filter(d => !d.aliasOf)
 
+  if (layerFilter && layers.length === 0) {
+    throw new ToolError(
+      `Layer not found: "${layerFilter}". Available: ${config.localeDirs.map(d => d.layer).join(', ')}`,
+      'LAYER_NOT_FOUND',
+    )
+  }
+
+  if (layerFilter && layers[0]?.aliasOf) {
+    throw new ToolError(
+      `Layer "${layerFilter}" is an alias of "${layers[0].aliasOf}". Use the target layer instead.`,
+      'LAYER_IS_ALIAS',
+    )
+  }
+
   const refLocale = config.locales.find(l => l.code === config.defaultLocale)
   if (!refLocale) {
-    throw new Error(`Default locale "${config.defaultLocale}" not found in config`)
+    throw new ToolError(
+      `Default locale "${config.defaultLocale}" not found in config`,
+      'LOCALE_NOT_FOUND',
+    )
   }
 
   const targetLocales = localeCodes
     ? localeCodes.map((code) => {
         const loc = config.locales.find(l => l.code === code)
-        if (!loc) throw new Error(`Locale "${code}" not found in config`)
+        if (!loc) {
+          throw new ToolError(
+            `Locale "${code}" not found in config. Available: ${config.locales.map(l => l.code).join(', ')}`,
+            'LOCALE_NOT_FOUND',
+          )
+        }
         return loc
       })
     : findNewLocales(config, layers)
@@ -85,7 +108,12 @@ async function scaffoldJsonLayer(
   skipped: ScaffoldedFile[],
 ): Promise<void> {
   const refData = await readLocaleData(config, dir.layer, refLocale)
-  if (Object.keys(refData).length === 0) return
+  if (Object.keys(refData).length === 0) {
+    throw new ToolError(
+      `Reference locale "${refLocale.code}" has no data in layer "${dir.layer}". Cannot scaffold without reference keys.`,
+      'NO_REFERENCE_DATA',
+    )
+  }
 
   const emptyData = buildEmptyStructure(refData)
   const keyCount = getLeafKeys(refData).length
@@ -116,7 +144,12 @@ async function scaffoldPhpLayer(
   skipped: ScaffoldedFile[],
 ): Promise<void> {
   const refEntries = await resolveLocaleEntries(config, dir.layer, refLocale)
-  if (refEntries.length === 0) return
+  if (refEntries.length === 0) {
+    throw new ToolError(
+      `Reference locale "${refLocale.code}" has no PHP files in layer "${dir.layer}". Cannot scaffold without reference keys.`,
+      'NO_REFERENCE_DATA',
+    )
+  }
 
   for (const target of targets) {
     const targetDir = join(dir.path, target.code)

--- a/src/tools/scaffold-locale.ts
+++ b/src/tools/scaffold-locale.ts
@@ -16,6 +16,7 @@ export interface ScaffoldedFile {
   layer: string
   file: string
   keys: number
+  namespace?: string
 }
 
 export interface ScaffoldLocaleResult {
@@ -119,15 +120,20 @@ async function scaffoldPhpLayer(
 
   for (const target of targets) {
     const targetDir = join(dir.path, target.code)
-    if (existsSync(targetDir)) {
-      const totalKeys = await countPhpKeys(refEntries)
-      skipped.push({ locale: target.code, layer: dir.layer, file: targetDir, keys: totalKeys })
-      continue
-    }
+    const dirExists = existsSync(targetDir)
 
     for (const refEntry of refEntries) {
       const fileName = basename(refEntry.path)
+      const namespace = fileName.replace(/\.php$/, '')
       const targetPath = join(targetDir, fileName)
+
+      if (dirExists && existsSync(targetPath)) {
+        const refData = await readLocale(refEntry.path)
+        const keyCount = getLeafKeys(refData).length
+        skipped.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount, namespace })
+        continue
+      }
+
       const refData = await readLocale(refEntry.path)
       const emptyData = buildEmptyStructure(refData)
       const keyCount = getLeafKeys(refData).length
@@ -135,18 +141,9 @@ async function scaffoldPhpLayer(
       if (!dryRun) {
         await writeLocale(targetPath, emptyData)
       }
-      created.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount })
+      created.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount, namespace })
     }
   }
-}
-
-async function countPhpKeys(entries: Array<{ path: string }>): Promise<number> {
-  let total = 0
-  for (const entry of entries) {
-    const data = await readLocale(entry.path)
-    total += getLeafKeys(data).length
-  }
-  return total
 }
 
 function findNewLocales(config: I18nConfig, layers: I18nConfig['localeDirs']): LocaleDefinition[] {

--- a/src/tools/scaffold-locale.ts
+++ b/src/tools/scaffold-locale.ts
@@ -1,0 +1,167 @@
+import { existsSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import type { I18nConfig, LocaleDefinition } from '../config/types'
+import { readLocaleData, resolveLocaleEntries } from '../io/locale-data'
+import { readLocale, writeLocale } from '../io/locale-io'
+import { getLeafKeys } from '../io/key-operations'
+
+export interface ScaffoldLocaleOptions {
+  locales?: string[]
+  layer?: string
+  dryRun?: boolean
+}
+
+export interface ScaffoldedFile {
+  locale: string
+  layer: string
+  file: string
+  keys: number
+}
+
+export interface ScaffoldLocaleResult {
+  created: ScaffoldedFile[]
+  skipped: ScaffoldedFile[]
+}
+
+export function buildEmptyStructure(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === 'string') {
+      result[key] = ''
+    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = buildEmptyStructure(value as Record<string, unknown>)
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+export async function scaffoldLocale(
+  config: I18nConfig,
+  options: ScaffoldLocaleOptions = {},
+): Promise<ScaffoldLocaleResult> {
+  const { locales: localeCodes, layer: layerFilter, dryRun } = options
+
+  const layers = layerFilter
+    ? config.localeDirs.filter(d => d.layer === layerFilter)
+    : config.localeDirs.filter(d => !d.aliasOf)
+
+  const refLocale = config.locales.find(l => l.code === config.defaultLocale)
+  if (!refLocale) {
+    throw new Error(`Default locale "${config.defaultLocale}" not found in config`)
+  }
+
+  const targetLocales = localeCodes
+    ? localeCodes.map((code) => {
+        const loc = config.locales.find(l => l.code === code)
+        if (!loc) throw new Error(`Locale "${code}" not found in config`)
+        return loc
+      })
+    : findNewLocales(config, layers)
+
+  const created: ScaffoldedFile[] = []
+  const skipped: ScaffoldedFile[] = []
+
+  for (const dir of layers) {
+    if (config.localeFileFormat === 'php-array') {
+      await scaffoldPhpLayer(config, dir, refLocale, targetLocales, dryRun, created, skipped)
+    } else {
+      await scaffoldJsonLayer(config, dir, refLocale, targetLocales, dryRun, created, skipped)
+    }
+  }
+
+  return { created, skipped }
+}
+
+async function scaffoldJsonLayer(
+  config: I18nConfig,
+  dir: I18nConfig['localeDirs'][0],
+  refLocale: LocaleDefinition,
+  targets: LocaleDefinition[],
+  dryRun: boolean | undefined,
+  created: ScaffoldedFile[],
+  skipped: ScaffoldedFile[],
+): Promise<void> {
+  const refData = await readLocaleData(config, dir.layer, refLocale)
+  if (Object.keys(refData).length === 0) return
+
+  const emptyData = buildEmptyStructure(refData)
+  const keyCount = getLeafKeys(refData).length
+
+  for (const target of targets) {
+    const entries = await resolveLocaleEntries(config, dir.layer, target)
+    const targetPath = entries.length > 0 ? entries[0].path : join(dir.path, target.file ?? `${target.code}.json`)
+
+    if (existsSync(targetPath)) {
+      skipped.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount })
+      continue
+    }
+
+    if (!dryRun) {
+      await writeLocale(targetPath, emptyData)
+    }
+    created.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount })
+  }
+}
+
+async function scaffoldPhpLayer(
+  config: I18nConfig,
+  dir: I18nConfig['localeDirs'][0],
+  refLocale: LocaleDefinition,
+  targets: LocaleDefinition[],
+  dryRun: boolean | undefined,
+  created: ScaffoldedFile[],
+  skipped: ScaffoldedFile[],
+): Promise<void> {
+  const refEntries = await resolveLocaleEntries(config, dir.layer, refLocale)
+  if (refEntries.length === 0) return
+
+  for (const target of targets) {
+    const targetDir = join(dir.path, target.code)
+    if (existsSync(targetDir)) {
+      const totalKeys = await countPhpKeys(refEntries)
+      skipped.push({ locale: target.code, layer: dir.layer, file: targetDir, keys: totalKeys })
+      continue
+    }
+
+    for (const refEntry of refEntries) {
+      const fileName = basename(refEntry.path)
+      const targetPath = join(targetDir, fileName)
+      const refData = await readLocale(refEntry.path)
+      const emptyData = buildEmptyStructure(refData)
+      const keyCount = getLeafKeys(refData).length
+
+      if (!dryRun) {
+        await writeLocale(targetPath, emptyData)
+      }
+      created.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount })
+    }
+  }
+}
+
+async function countPhpKeys(entries: Array<{ path: string }>): Promise<number> {
+  let total = 0
+  for (const entry of entries) {
+    const data = await readLocale(entry.path)
+    total += getLeafKeys(data).length
+  }
+  return total
+}
+
+function findNewLocales(config: I18nConfig, layers: I18nConfig['localeDirs']): LocaleDefinition[] {
+  if (config.localeFileFormat === 'php-array') {
+    return config.locales.filter((locale) => {
+      return layers.some((dir) => {
+        return !existsSync(join(dir.path, locale.code))
+      })
+    })
+  }
+
+  return config.locales.filter((locale) => {
+    return layers.some((dir) => {
+      const filePath = join(dir.path, locale.file ?? `${locale.code}.json`)
+      return !existsSync(filePath)
+    })
+  })
+}

--- a/tests/adapters/laravel-adapter.test.ts
+++ b/tests/adapters/laravel-adapter.test.ts
@@ -268,6 +268,30 @@ describe('LaravelAdapter.resolve', () => {
 
     expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr', 'zh'])
   })
+
+  it('includes locales from config/app.php that have no directory on disk', async () => {
+    createLaravelProject(tempDir, {
+      locales: ['en', 'de'],
+      configAppPhp: `<?php\nreturn [\n    'locale' => 'de',\n    'fallback_locale' => 'en',\n    'locales' => ['de', 'en', 'sv', 'el'],\n];\n`,
+    })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'el', 'en', 'sv'])
+  })
+
+  it('does not duplicate locales that exist on both disk and config', async () => {
+    createLaravelProject(tempDir, {
+      locales: ['en', 'de'],
+      configAppPhp: `<?php\nreturn [\n    'locale' => 'de',\n    'fallback_locale' => 'en',\n    'locales' => ['de', 'en'],\n];\n`,
+    })
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
 })
 
 describe('Adapter registry: Laravel vs Nuxt', () => {

--- a/tests/tools/scaffold-locale.test.ts
+++ b/tests/tools/scaffold-locale.test.ts
@@ -172,11 +172,11 @@ describe('scaffoldLocale', () => {
     expect(result.skipped[0].layer).toBe('root')
   })
 
-  it('throws when an explicit locale is not found in config', async () => {
+  it('throws LOCALE_NOT_FOUND when an explicit locale is not found in config', async () => {
     const config = createTestConfig(existingLocales)
 
     await expect(scaffoldLocale(config, { locales: ['sv'] }))
-      .rejects.toThrow('Locale "sv" not found in config')
+      .rejects.toMatchObject({ code: 'LOCALE_NOT_FOUND' })
   })
 
   it('returns empty created array when all requested locales already have files', async () => {
@@ -186,6 +186,26 @@ describe('scaffoldLocale', () => {
 
     expect(result.created).toEqual([])
     expect(result.skipped.length).toBe(2)
+  })
+
+  it('throws LAYER_NOT_FOUND when layer does not exist', async () => {
+    const config = createTestConfig(existingLocales)
+
+    await expect(scaffoldLocale(config, { layer: 'nonexistent' }))
+      .rejects.toMatchObject({ code: 'LAYER_NOT_FOUND' })
+  })
+
+  it('throws LAYER_IS_ALIAS when targeting an alias layer', async () => {
+    const config: I18nConfig = {
+      ...createTestConfig(existingLocales),
+      localeDirs: [
+        { path: tmpRootLocales, layer: 'root', layerRootDir: tmpDir },
+        { path: tmpRootLocales, layer: 'root-alias', layerRootDir: tmpDir, aliasOf: 'root' },
+      ],
+    }
+
+    await expect(scaffoldLocale(config, { layer: 'root-alias' }))
+      .rejects.toMatchObject({ code: 'LAYER_IS_ALIAS' })
   })
 
   it('every leaf value in the scaffolded file is an empty string', async () => {

--- a/tests/tools/scaffold-locale.test.ts
+++ b/tests/tools/scaffold-locale.test.ts
@@ -303,5 +303,35 @@ describe('scaffoldLocale (Laravel)', () => {
 
     expect(result.created.length).toBe(2)
     expect(result.created.map(f => f.file).sort()).toEqual([svAuthFile, svCommonFile].sort())
+    expect(result.created.map(f => f.namespace).sort()).toEqual(['auth', 'common'])
+  })
+
+  it('reports per-file skipped entries when locale directory already exists', async () => {
+    const config = createLaravelConfig(laravelLocales)
+
+    const result = await scaffoldLocale(config, { locales: ['de'] })
+
+    expect(result.created).toEqual([])
+    expect(result.skipped.length).toBe(2)
+    expect(result.skipped.map(f => f.namespace).sort()).toEqual(['auth', 'common'])
+    expect(result.skipped.every(f => f.locale === 'de')).toBe(true)
+    expect(result.skipped.every(f => f.keys > 0)).toBe(true)
+  })
+
+  it('skips individual files that exist and creates missing ones', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE' }
+    const config = createLaravelConfig([...laravelLocales, svLocale])
+
+    // Create sv directory with only auth.php
+    const svDir = join(tmpLangDir, 'sv')
+    await mkdir(svDir, { recursive: true })
+    await writeFile(join(svDir, 'auth.php'), `<?php\n\nreturn [\n    "failed" => "",\n];\n`)
+
+    const result = await scaffoldLocale(config, { locales: ['sv'] })
+
+    expect(result.created.length).toBe(1)
+    expect(result.created[0].namespace).toBe('common')
+    expect(result.skipped.length).toBe(1)
+    expect(result.skipped[0].namespace).toBe('auth')
   })
 })

--- a/tests/tools/scaffold-locale.test.ts
+++ b/tests/tools/scaffold-locale.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { resolve, join } from 'node:path'
+import { cp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { readLocaleFile } from '../../src/io/json-reader.js'
+import { readPhpLocaleFile } from '../../src/io/php-reader.js'
+import { getLeafKeys, getNestedValue } from '../../src/io/key-operations.js'
+import type { I18nConfig, LocaleDefinition } from '../../src/config/types.js'
+import { scaffoldLocale, buildEmptyStructure } from '../../src/tools/scaffold-locale.js'
+
+const fixtureDir = resolve(import.meta.dirname, '../fixtures/nuxt-project')
+const tmpDir = resolve(import.meta.dirname, '../../.tmp-scaffold-locale')
+const tmpRootLocales = resolve(tmpDir, 'root')
+const tmpAdminLocales = resolve(tmpDir, 'admin')
+
+const fixtureRootLocales = resolve(fixtureDir, 'i18n/locales')
+const fixtureAdminLocales = resolve(fixtureDir, 'app-admin/i18n/locales')
+
+const existingLocales: LocaleDefinition[] = [
+  { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+  { code: 'en', language: 'en-US', file: 'en-US.json' },
+  { code: 'fr', language: 'fr-FR', file: 'fr-FR.json' },
+  { code: 'es', language: 'es-ES', file: 'es-ES.json' },
+]
+
+function createTestConfig(locales: LocaleDefinition[]): I18nConfig {
+  return {
+    rootDir: tmpDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales,
+    localeDirs: [
+      {
+        path: tmpRootLocales,
+        layer: 'root',
+        layerRootDir: tmpDir,
+      },
+    ],
+    layerRootDirs: [tmpDir],
+  }
+}
+
+function createMultiLayerConfig(locales: LocaleDefinition[]): I18nConfig {
+  return {
+    rootDir: tmpDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales,
+    localeDirs: [
+      {
+        path: tmpRootLocales,
+        layer: 'root',
+        layerRootDir: tmpDir,
+      },
+      {
+        path: tmpAdminLocales,
+        layer: 'app-admin',
+        layerRootDir: resolve(tmpDir, 'admin'),
+      },
+    ],
+    layerRootDirs: [tmpDir, resolve(tmpDir, 'admin')],
+  }
+}
+
+async function copyFixtureLocales() {
+  await mkdir(tmpRootLocales, { recursive: true })
+  await mkdir(tmpAdminLocales, { recursive: true })
+  await cp(fixtureRootLocales, tmpRootLocales, { recursive: true })
+  await cp(fixtureAdminLocales, tmpAdminLocales, { recursive: true })
+}
+
+describe('scaffoldLocale', () => {
+  beforeEach(async () => {
+    await copyFixtureLocales()
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('creates a new locale file with the reference locale key structure', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createTestConfig([...existingLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['sv'] })
+
+    const svFile = join(tmpRootLocales, 'sv-SE.json')
+    expect(existsSync(svFile)).toBe(true)
+
+    const svData = await readLocaleFile(svFile)
+    expect(svData).toHaveProperty('common.actions.cancel', '')
+    expect(svData).toHaveProperty('common.actions.delete', '')
+    expect(svData).toHaveProperty('common.actions.save', '')
+    expect(svData).toHaveProperty('common.messages.loading', '')
+
+    expect(result.created.length).toBe(1)
+    expect(result.created[0].locale).toBe('sv')
+    expect(result.created[0].layer).toBe('root')
+  })
+
+  it('scaffolds across all layers when no layer is specified', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createMultiLayerConfig([...existingLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['sv'] })
+
+    expect(result.created.length).toBe(2)
+    expect(result.created.map(f => f.layer).sort()).toEqual(['app-admin', 'root'])
+
+    const svRootFile = join(tmpRootLocales, 'sv-SE.json')
+    expect(existsSync(svRootFile)).toBe(true)
+    const svRootData = await readLocaleFile(svRootFile)
+    expect(svRootData).toHaveProperty('common.actions.cancel', '')
+
+    const svAdminFile = join(tmpAdminLocales, 'sv-SE.json')
+    expect(existsSync(svAdminFile)).toBe(true)
+    const svAdminData = await readLocaleFile(svAdminFile)
+    expect(svAdminData).toHaveProperty('admin.dashboard.title', '')
+    expect(svAdminData).toHaveProperty('admin.users.list', '')
+  })
+
+  it('scopes to a single layer when layer option is specified', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createMultiLayerConfig([...existingLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['sv'], layer: 'app-admin' })
+
+    expect(result.created.length).toBe(1)
+    expect(result.created[0].layer).toBe('app-admin')
+
+    expect(existsSync(join(tmpAdminLocales, 'sv-SE.json'))).toBe(true)
+    expect(existsSync(join(tmpRootLocales, 'sv-SE.json'))).toBe(false)
+  })
+
+  it('dry run returns plan but writes no files', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createTestConfig([...existingLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['sv'], dryRun: true })
+
+    expect(result.created.length).toBe(1)
+    expect(result.created[0].locale).toBe('sv')
+    expect(result.created[0].keys).toBeGreaterThan(0)
+
+    const svFile = join(tmpRootLocales, 'sv-SE.json')
+    expect(existsSync(svFile)).toBe(false)
+  })
+
+  it('auto-detects new locales when locales option is omitted', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const jaLocale: LocaleDefinition = { code: 'ja', language: 'ja-JP', file: 'ja-JP.json' }
+    const config = createTestConfig([...existingLocales, svLocale, jaLocale])
+
+    const result = await scaffoldLocale(config)
+
+    expect(result.created.length).toBe(2)
+    expect(result.created.map(f => f.locale).sort()).toEqual(['ja', 'sv'])
+    expect(result.skipped).toEqual([])
+  })
+
+  it('skips locales that already have files and reports them', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createTestConfig([...existingLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['de', 'sv'] })
+
+    expect(result.created.length).toBe(1)
+    expect(result.created[0].locale).toBe('sv')
+
+    expect(result.skipped.length).toBe(1)
+    expect(result.skipped[0].locale).toBe('de')
+    expect(result.skipped[0].layer).toBe('root')
+  })
+
+  it('throws when an explicit locale is not found in config', async () => {
+    const config = createTestConfig(existingLocales)
+
+    await expect(scaffoldLocale(config, { locales: ['sv'] }))
+      .rejects.toThrow('Locale "sv" not found in config')
+  })
+
+  it('returns empty created array when all requested locales already have files', async () => {
+    const config = createTestConfig(existingLocales)
+
+    const result = await scaffoldLocale(config, { locales: ['de', 'en'] })
+
+    expect(result.created).toEqual([])
+    expect(result.skipped.length).toBe(2)
+  })
+
+  it('every leaf value in the scaffolded file is an empty string', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE', file: 'sv-SE.json' }
+    const config = createTestConfig([...existingLocales, svLocale])
+
+    await scaffoldLocale(config, { locales: ['sv'] })
+
+    const refData = await readLocaleFile(join(tmpRootLocales, 'de-DE.json'))
+    const svData = await readLocaleFile(join(tmpRootLocales, 'sv-SE.json'))
+
+    const refKeys = getLeafKeys(refData)
+    const svKeys = getLeafKeys(svData)
+
+    expect(svKeys).toEqual(refKeys)
+    for (const key of svKeys) {
+      expect(getNestedValue(svData, key)).toBe('')
+    }
+  })
+})
+
+describe('buildEmptyStructure', () => {
+  it('empties strings, preserves nested objects, and leaves non-string values untouched', () => {
+    const input = {
+      greeting: 'Hello',
+      nested: {
+        deep: 'World',
+        count: 42,
+        tags: ['a', 'b'],
+        flag: true,
+        empty: null,
+      },
+    }
+
+    const result = buildEmptyStructure(input)
+
+    expect(result).toEqual({
+      greeting: '',
+      nested: {
+        deep: '',
+        count: 42,
+        tags: ['a', 'b'],
+        flag: true,
+        empty: null,
+      },
+    })
+  })
+})
+
+describe('scaffoldLocale (Laravel)', () => {
+  const tmpLaravelDir = resolve(import.meta.dirname, '../../.tmp-scaffold-laravel')
+  const tmpLangDir = resolve(tmpLaravelDir, 'lang')
+
+  const laravelLocales: LocaleDefinition[] = [
+    { code: 'de', language: 'de-DE' },
+    { code: 'en', language: 'en-US' },
+  ]
+
+  function createLaravelConfig(locales: LocaleDefinition[]): I18nConfig {
+    return {
+      framework: 'laravel',
+      rootDir: tmpLaravelDir,
+      defaultLocale: 'de',
+      fallbackLocale: { default: ['en'] },
+      locales,
+      localeDirs: [
+        {
+          path: tmpLangDir,
+          layer: 'lang',
+          layerRootDir: tmpLaravelDir,
+        },
+      ],
+      layerRootDirs: [tmpLaravelDir],
+      localeFileFormat: 'php-array',
+    }
+  }
+
+  async function createLaravelFixtures() {
+    const deDir = join(tmpLangDir, 'de')
+    const enDir = join(tmpLangDir, 'en')
+    await mkdir(deDir, { recursive: true })
+    await mkdir(enDir, { recursive: true })
+
+    await writeFile(join(deDir, 'auth.php'), `<?php\n\nreturn [\n    "failed" => "Falsche Daten.",\n    "password" => "Falsches Passwort.",\n];\n`)
+    await writeFile(join(deDir, 'common.php'), `<?php\n\nreturn [\n    "greeting" => "Hallo",\n    "save" => "Speichern",\n];\n`)
+    await writeFile(join(enDir, 'auth.php'), `<?php\n\nreturn [\n    "failed" => "Wrong credentials.",\n    "password" => "Wrong password.",\n];\n`)
+    await writeFile(join(enDir, 'common.php'), `<?php\n\nreturn [\n    "greeting" => "Hello",\n    "save" => "Save",\n];\n`)
+  }
+
+  beforeEach(async () => {
+    await createLaravelFixtures()
+  })
+
+  afterEach(async () => {
+    await rm(tmpLaravelDir, { recursive: true, force: true })
+  })
+
+  it('creates one PHP file per namespace in a new locale directory', async () => {
+    const svLocale: LocaleDefinition = { code: 'sv', language: 'sv-SE' }
+    const config = createLaravelConfig([...laravelLocales, svLocale])
+
+    const result = await scaffoldLocale(config, { locales: ['sv'] })
+
+    const svAuthFile = join(tmpLangDir, 'sv', 'auth.php')
+    const svCommonFile = join(tmpLangDir, 'sv', 'common.php')
+
+    expect(existsSync(svAuthFile)).toBe(true)
+    expect(existsSync(svCommonFile)).toBe(true)
+
+    const authData = await readPhpLocaleFile(svAuthFile)
+    expect(authData).toEqual({ failed: '', password: '' })
+
+    const commonData = await readPhpLocaleFile(svCommonFile)
+    expect(commonData).toEqual({ greeting: '', save: '' })
+
+    expect(result.created.length).toBe(2)
+    expect(result.created.map(f => f.file).sort()).toEqual([svAuthFile, svCommonFile].sort())
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `scaffold_locale` tool: creates empty locale files for new languages by copying the key structure from the default locale with all values set to empty strings
- Adds `add-language` prompt: guided workflow for adding a new language end-to-end (framework config edit → scaffold files → translate missing keys)
- Supports both Nuxt (JSON) and Laravel (PHP namespace files), multi-layer scaffolding, dry-run mode, skip-existing, and auto-detect new locales

## New Tool: `scaffold_locale`

| Parameter | Description |
|-----------|-------------|
| `locales` | Locale codes to scaffold (e.g., `["sv", "ja"]`). Auto-detects if omitted. |
| `layer` | Scope to a single layer. Scaffolds all layers if omitted. |
| `dryRun` | Preview what would be created without writing files. |
| `projectDir` | Project root path. Defaults to cwd. |

## New Prompt: `add-language`

Orchestrates the full workflow: detect config → edit framework config → scaffold empty files → translate all keys.

## Tests

11 new tests covering:
- JSON scaffold (single file, multi-layer, all-keys-empty, mixed types)
- Laravel PHP scaffold (one file per namespace in locale directory)
- Dry run, skip existing, auto-detect, layer scoping
- Error cases (locale not in config, all already exist)

All 413 tests pass. Typecheck and lint clean.

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale scaffolding: generate empty locale files to add new languages based on project i18n config.
  * Add-language prompt: guided flow to add a language, update config, scaffold files, and translate missing keys.
* **Improvements**
  * More reliable i18n config detection and cache handling for accurate scaffolding.
  * Adapter detection now includes locales declared in framework config (deduplicated and sorted).
* **Tests**
  * Added comprehensive tests covering scaffolding behavior for JSON and PHP formats, dry-run, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->