### PR TITLE
fix: per-namespace dirty tracking for PHP locale writes

### DIFF
--- a/src/io/locale-data.ts
+++ b/src/io/locale-data.ts
@@ -106,21 +106,26 @@ export async function mutateLocaleData(
   mutate: (data: Record<string, unknown>) => void,
 ): Promise<Set<string>> {
   const data = await readLocaleData(config, layer, locale)
-  const snapshot = JSON.stringify(data)
-  mutate(data)
 
   const filesWritten = new Set<string>()
-
-  // Skip write if mutation was a no-op (e.g., key didn't exist)
-  if (JSON.stringify(data) === snapshot) {
-    return filesWritten
-  }
 
   if (config.localeFileFormat === 'php-array') {
     const localeDir = resolveLayerDir(config, layer)
     if (!localeDir) return filesWritten
 
     const localePath = join(localeDir, locale.code)
+
+    const preSnapshots = new Map<string, string>()
+    for (const [ns, nsData] of Object.entries(data)) {
+      preSnapshots.set(ns, JSON.stringify(nsData))
+    }
+    const mergedSnapshot = JSON.stringify(data)
+
+    mutate(data)
+
+    if (JSON.stringify(data) === mergedSnapshot) {
+      return filesWritten
+    }
 
     if (!existsSync(localePath)) {
       await mkdir(localePath, { recursive: true })
@@ -131,9 +136,11 @@ export async function mutateLocaleData(
         log.warn(`Skipping non-object namespace '${namespace}' for locale '${locale.code}'`)
         continue
       }
-      const filePath = join(localePath, `${namespace}.php`)
-      await writeLocale(filePath, nsData as Record<string, unknown>)
-      filesWritten.add(filePath)
+      if (JSON.stringify(nsData) !== preSnapshots.get(namespace)) {
+        const filePath = join(localePath, `${namespace}.php`)
+        await writeLocale(filePath, nsData as Record<string, unknown>)
+        filesWritten.add(filePath)
+      }
     }
 
     const expectedFiles = new Set(
@@ -152,6 +159,13 @@ export async function mutateLocaleData(
     catch {}
   }
   else {
+    const snapshot = JSON.stringify(data)
+    mutate(data)
+
+    if (JSON.stringify(data) === snapshot) {
+      return filesWritten
+    }
+
     const entries = await resolveLocaleEntries(config, layer, locale)
     if (entries.length === 0) return filesWritten
 

--- a/tests/io/locale-data.test.ts
+++ b/tests/io/locale-data.test.ts
@@ -217,7 +217,7 @@ describe('mutateLocaleData', () => {
     expect((result.auth as Record<string, string>).login).toBe('Login')
   })
 
-  it('mutates Laravel namespace and writes per-file', async () => {
+  it('mutates Laravel namespace and writes only changed namespaces', async () => {
     await setupLaravelLocales()
     const config = makeLaravelConfig()
     const locale = config.locales[0]
@@ -227,7 +227,9 @@ describe('mutateLocaleData', () => {
       ;(data.auth as Record<string, string>).newKey = 'added'
     })
 
-    expect(written.size).toBe(2)
+    expect(written.size).toBe(1)
+    expect(written.has(join(tempDir, 'lang', 'en', 'auth.php'))).toBe(true)
+    expect(written.has(join(tempDir, 'lang', 'en', 'validation.php'))).toBe(false)
 
     clearPhpFileCache()
     const result = await readLocaleData(config, 'root', locale)
@@ -299,5 +301,57 @@ describe('mutateLocaleData', () => {
     const { existsSync } = await import('node:fs')
     expect(existsSync(join(tempDir, 'lang', 'en', 'auth.php'))).toBe(true)
     expect(existsSync(join(tempDir, 'lang', 'en', 'validation.php'))).toBe(false)
+  })
+
+  it('returns empty set when no namespace changed', async () => {
+    await setupLaravelLocales()
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, () => {})
+    expect(written.size).toBe(0)
+  })
+
+  it('writes only 2 of 3 namespaces when 2 changed', async () => {
+    const langDir = join(tempDir, 'lang', 'en')
+    await mkdir(langDir, { recursive: true })
+    await writeFile(join(langDir, 'auth.php'), `<?php\nreturn ['failed' => 'Invalid credentials'];\n`)
+    await writeFile(join(langDir, 'validation.php'), `<?php\nreturn ['required' => 'Required'];\n`)
+    await writeFile(join(langDir, 'passwords.php'), `<?php\nreturn ['reset' => 'Reset'];\n`)
+
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.auth as Record<string, string>).failed = 'Bad creds'
+      ;(data.passwords as Record<string, string>).reset = 'Password reset'
+    })
+
+    expect(written.size).toBe(2)
+    expect(written.has(join(tempDir, 'lang', 'en', 'auth.php'))).toBe(true)
+    expect(written.has(join(tempDir, 'lang', 'en', 'passwords.php'))).toBe(true)
+    expect(written.has(join(tempDir, 'lang', 'en', 'validation.php'))).toBe(false)
+  })
+
+  it('JSON write path is unaffected by per-namespace changes', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.common as Record<string, string>).save = 'Save Changes'
+    })
+
+    expect(written.size).toBe(1)
+    expect(written.has(join(tempDir, 'locales', 'en.json'))).toBe(true)
+  })
+
+  it('JSON write path returns empty set on no-op mutation', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, () => {})
+    expect(written.size).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- Before mutation, snapshot each namespace individually via `JSON.stringify`
- After mutation, compare each namespace's snapshot and only write files that actually changed
- Return an accurate `filesWritten` count reflecting only the written namespaces
- Global no-op early-return preserved (unchanged overall → no writes, no mkdir)
- JSON write path is completely unaffected

## Tests

- Updated: existing test expectation corrected (1 file written when only `auth` changed, not 2)
- Added: only changed namespace files are written (spy-free, checks `filesWritten` set)
- Added: accurate `filesWritten` count — change 2 of 3 namespaces → count is 2
- Added: unchanged namespace file not in `filesWritten`
- Added: no-op mutation returns empty set for PHP path
- Added: JSON path returns 1 file written on real change
- Added: JSON path returns empty set on no-op

Closes #69, Closes #60, Parent PRD #64