### PR TITLE
fix: ancestor-based layer dedup for aliased Nuxt apps

### DIFF
--- a/src/adapters/nuxt/index.ts
+++ b/src/adapters/nuxt/index.ts
@@ -8,6 +8,7 @@ import { loadKit } from '../../config/nuxt-loader'
 import { loadProjectConfig } from '../../config/project-config'
 import { log } from '../../utils/logger'
 import { ConfigError } from '../../utils/errors'
+import { resolveLayerOwnership } from './layer-dedup'
 
 export class NuxtAdapter implements FrameworkAdapter {
   readonly name = 'nuxt'
@@ -113,7 +114,7 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
   const allLocaleDirs: LocaleDir[] = []
   const allLocales: LocaleDefinition[] = []
   const allLayerRootDirs: string[] = []
-  const seenLocalePaths = new Map<string, string>()
+  const seenLocalePaths = new Map<string, { layer: string, layerRootDir: string }>()
   const seenLocaleCodes = new Set<string>()
   const usedLayerNames = new Set<string>()
   let defaultLocale = 'en'
@@ -137,25 +138,42 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
 
     for (const dir of appConfig.localeDirs) {
       const realPath = await realpath(dir.path).catch(() => dir.path)
-      const existingLayer = seenLocalePaths.get(realPath)
-      if (existingLayer) {
-        if (dir.layer !== existingLayer) {
-          allLocaleDirs.push({
-            ...dir,
-            aliasOf: existingLayer,
-          })
-          log.debug(`Layer '${dir.layer}' is alias of '${existingLayer}' (same path: ${dir.path})`)
+      const existing = seenLocalePaths.get(realPath)
+      if (existing) {
+        const { owner, alias } = resolveLayerOwnership(
+          { layer: existing.layer, layerRootDir: existing.layerRootDir },
+          { layer: dir.layer, layerRootDir: dir.layerRootDir },
+          realPath,
+        )
+        if (owner !== existing.layer) {
+          const ownerIndex = allLocaleDirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
+          if (ownerIndex !== -1) {
+            const prev = allLocaleDirs[ownerIndex]
+            allLocaleDirs[ownerIndex] = { ...dir, layer: owner === dir.layer ? dir.layer : owner }
+            allLocaleDirs.push({ ...prev, aliasOf: owner === dir.layer ? dir.layer : owner })
+            seenLocalePaths.set(realPath, { layer: allLocaleDirs[ownerIndex].layer, layerRootDir: allLocaleDirs[ownerIndex].layerRootDir })
+            log.debug(`Layer '${alias}' is alias of '${owner}' (ancestor-based ownership, same path: ${dir.path})`)
+          }
+        }
+        else {
+          if (dir.layer !== existing.layer) {
+            allLocaleDirs.push({
+              ...dir,
+              layer: alias === dir.layer ? dir.layer : alias,
+              aliasOf: owner,
+            })
+            log.debug(`Layer '${alias}' is alias of '${owner}' (same path: ${dir.path})`)
+          }
         }
         continue
       }
 
-      // Disambiguate layer name if already used by a different path
       let layerName = dir.layer
       if (usedLayerNames.has(layerName)) {
         layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
       }
       usedLayerNames.add(layerName)
-      seenLocalePaths.set(realPath, layerName)
+      seenLocalePaths.set(realPath, { layer: layerName, layerRootDir: dir.layerRootDir })
       allLocaleDirs.push({ ...dir, layer: layerName })
     }
 
@@ -288,7 +306,7 @@ async function discoverLocaleDirs(
   discoveryRoot: string,
 ): Promise<LocaleDir[]> {
   const dirs: LocaleDir[] = []
-  const resolvedPaths = new Map<string, string>()
+  const resolvedPaths = new Map<string, { layer: string, layerRootDir: string }>()
   const usedLayerNames = new Set<string>()
 
   for (const layer of layers) {
@@ -307,15 +325,36 @@ async function discoverLocaleDirs(
     }
 
     const realDir = await realpath(resolvedDir).catch(() => resolvedDir)
-    const existingLayer = resolvedPaths.get(realDir)
-    if (existingLayer) {
-      dirs.push({
-        path: resolvedDir,
-        layer: layerName,
-        layerRootDir,
-        aliasOf: existingLayer,
-      })
-      log.debug(`Layer '${layerName}' is alias of '${existingLayer}'`)
+    const existing = resolvedPaths.get(realDir)
+    if (existing) {
+      const { owner, alias } = resolveLayerOwnership(
+        { layer: existing.layer, layerRootDir: existing.layerRootDir },
+        { layer: layerName, layerRootDir },
+        realDir,
+      )
+      if (owner !== existing.layer) {
+        const ownerIndex = dirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
+        if (ownerIndex !== -1) {
+          const prev = dirs[ownerIndex]
+          dirs[ownerIndex] = {
+            path: resolvedDir,
+            layer: layerName,
+            layerRootDir,
+          }
+          dirs.push({ ...prev, aliasOf: layerName })
+          resolvedPaths.set(realDir, { layer: layerName, layerRootDir })
+          log.debug(`Layer '${alias}' is alias of '${owner}' (ancestor-based ownership)`)
+        }
+      }
+      else {
+        dirs.push({
+          path: resolvedDir,
+          layer: layerName,
+          layerRootDir,
+          aliasOf: existing.layer,
+        })
+        log.debug(`Layer '${alias}' is alias of '${owner}'`)
+      }
       continue
     }
 
@@ -326,7 +365,7 @@ async function discoverLocaleDirs(
       continue
     }
 
-    resolvedPaths.set(realDir, layerName)
+    resolvedPaths.set(realDir, { layer: layerName, layerRootDir })
     dirs.push({
       path: resolvedDir,
       layer: layerName,

--- a/src/adapters/nuxt/layer-dedup.ts
+++ b/src/adapters/nuxt/layer-dedup.ts
@@ -1,0 +1,49 @@
+import { sep } from 'node:path'
+
+export interface LayerRef {
+  layer: string
+  layerRootDir: string
+}
+
+export interface OwnershipResult {
+  owner: string
+  alias: string
+}
+
+function isAncestorOf(ancestorDir: string, childPath: string): boolean {
+  const normalized = ancestorDir.endsWith(sep) ? ancestorDir : ancestorDir + sep
+  return childPath.startsWith(normalized) || childPath === ancestorDir
+}
+
+function ancestorDepth(ancestorDir: string, childPath: string): number {
+  if (!isAncestorOf(ancestorDir, childPath)) return -1
+  return ancestorDir.split(sep).filter(Boolean).length
+}
+
+export function resolveLayerOwnership(
+  existing: LayerRef,
+  incoming: LayerRef,
+  localeDirPath: string,
+): OwnershipResult {
+  const existingIsAncestor = isAncestorOf(existing.layerRootDir, localeDirPath)
+  const incomingIsAncestor = isAncestorOf(incoming.layerRootDir, localeDirPath)
+
+  if (existingIsAncestor && !incomingIsAncestor) {
+    return { owner: existing.layer, alias: incoming.layer }
+  }
+
+  if (incomingIsAncestor && !existingIsAncestor) {
+    return { owner: incoming.layer, alias: existing.layer }
+  }
+
+  if (existingIsAncestor && incomingIsAncestor) {
+    const existingDepth = ancestorDepth(existing.layerRootDir, localeDirPath)
+    const incomingDepth = ancestorDepth(incoming.layerRootDir, localeDirPath)
+    if (incomingDepth > existingDepth) {
+      return { owner: incoming.layer, alias: existing.layer }
+    }
+    return { owner: existing.layer, alias: incoming.layer }
+  }
+
+  return { owner: existing.layer, alias: incoming.layer }
+}

--- a/tests/adapters/layer-dedup.test.ts
+++ b/tests/adapters/layer-dedup.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for ancestor-based layer dedup (issue #70).
+ *
+ * When two layers claim the same locale directory path, the layer whose
+ * `layerRootDir` is an ancestor of (or equal to) the locale dir path is the
+ * true owner. The other layer gets `aliasOf` pointing to the owner.
+ *
+ * The tests exercise `resolveLayerOwnership` — the pure helper extracted
+ * from the dedup logic in `src/adapters/nuxt/index.ts`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolveLayerOwnership } from '../../src/adapters/nuxt/layer-dedup.js'
+
+// Helper: build absolute paths without platform issues
+const base = '/projects'
+const appShop = `${base}/app-shop`
+const appOutlook = `${base}/app-outlook`
+const sharedLocaleDir = `${appShop}/i18n/locales`
+
+describe('resolveLayerOwnership — ancestor is the true owner', () => {
+  it('existing layer owns when its root is an ancestor of the locale dir', () => {
+    // app-shop was discovered first and claims app-shop/i18n/locales
+    // app-outlook is discovered next with same realpath (via alias)
+    const result = resolveLayerOwnership(
+      { layer: 'app-shop', layerRootDir: appShop },
+      { layer: 'app-outlook', layerRootDir: appOutlook },
+      sharedLocaleDir,
+    )
+    expect(result.owner).toBe('app-shop')
+    expect(result.alias).toBe('app-outlook')
+  })
+
+  it('incoming layer wins when its root is an ancestor and existing is not', () => {
+    // app-outlook was (wrongly) processed first, claims app-shop/i18n/locales
+    // app-shop arrives later — it should take over as the true owner
+    const result = resolveLayerOwnership(
+      { layer: 'app-outlook', layerRootDir: appOutlook },
+      { layer: 'app-shop', layerRootDir: appShop },
+      sharedLocaleDir,
+    )
+    expect(result.owner).toBe('app-shop')
+    expect(result.alias).toBe('app-outlook')
+  })
+
+  it('discovery order does not matter: shop-first gives same result as outlook-first', () => {
+    const shopFirst = resolveLayerOwnership(
+      { layer: 'app-shop', layerRootDir: appShop },
+      { layer: 'app-outlook', layerRootDir: appOutlook },
+      sharedLocaleDir,
+    )
+    const outlookFirst = resolveLayerOwnership(
+      { layer: 'app-outlook', layerRootDir: appOutlook },
+      { layer: 'app-shop', layerRootDir: appShop },
+      sharedLocaleDir,
+    )
+    expect(shopFirst.owner).toBe(outlookFirst.owner)
+    expect(shopFirst.alias).toBe(outlookFirst.alias)
+  })
+
+  it('alias layer gets aliasOf set to the owner layer name', () => {
+    const result = resolveLayerOwnership(
+      { layer: 'app-outlook', layerRootDir: appOutlook },
+      { layer: 'app-shop', layerRootDir: appShop },
+      sharedLocaleDir,
+    )
+    // incoming (app-shop) is the true owner; existing (app-outlook) becomes alias
+    expect(result.owner).toBe('app-shop')
+    expect(result.alias).toBe('app-outlook')
+  })
+})
+
+describe('resolveLayerOwnership — nested layers: more specific wins', () => {
+  const outerDir = `${base}/monorepo`
+  const innerDir = `${outerDir}/packages/shop`
+  const nestedLocaleDir = `${innerDir}/i18n/locales`
+
+  it('inner (more specific) ancestor wins over outer ancestor', () => {
+    const result = resolveLayerOwnership(
+      { layer: 'monorepo', layerRootDir: outerDir },
+      { layer: 'shop', layerRootDir: innerDir },
+      nestedLocaleDir,
+    )
+    expect(result.owner).toBe('shop')
+    expect(result.alias).toBe('monorepo')
+  })
+
+  it('more specific wins regardless of discovery order', () => {
+    const shopFirst = resolveLayerOwnership(
+      { layer: 'shop', layerRootDir: innerDir },
+      { layer: 'monorepo', layerRootDir: outerDir },
+      nestedLocaleDir,
+    )
+    expect(shopFirst.owner).toBe('shop')
+    expect(shopFirst.alias).toBe('monorepo')
+  })
+})
+
+describe('resolveLayerOwnership — fallback when neither is an ancestor', () => {
+  it('returns existing as owner when neither root is an ancestor (first-wins fallback)', () => {
+    const dirA = `${base}/app-a`
+    const dirB = `${base}/app-b`
+    const someSharedDir = `${base}/shared/i18n/locales`
+
+    const result = resolveLayerOwnership(
+      { layer: 'app-a', layerRootDir: dirA },
+      { layer: 'app-b', layerRootDir: dirB },
+      someSharedDir,
+    )
+    // Neither is an ancestor → first-wins (existing keeps ownership)
+    expect(result.owner).toBe('app-a')
+    expect(result.alias).toBe('app-b')
+  })
+})
+
+describe('resolveLayerOwnership — when both are ancestors (same root), existing wins', () => {
+  it('exact-same layerRootDir: existing layer keeps ownership', () => {
+    const result = resolveLayerOwnership(
+      { layer: 'root', layerRootDir: appShop },
+      { layer: 'root-copy', layerRootDir: appShop },
+      sharedLocaleDir,
+    )
+    expect(result.owner).toBe('root')
+    expect(result.alias).toBe('root-copy')
+  })
+})


### PR DESCRIPTION
## Summary

- Introduces `resolveLayerOwnership` — a pure helper that compares `layerRootDir` ancestry
  to determine which of two layers claiming the same resolved locale dir path is the true owner.
- Integrates the helper into both dedup sites in `src/adapters/nuxt/index.ts`:
  the single-app intra-layer loop (`discoverLocaleDirs`) and the multi-app merge loop
  (`loadAndMergeApps`).
- Adds 8 unit tests covering: existing-wins, incoming-wins, order-independence,
  nested-ancestor specificity, and neither-ancestor fallback.

## Problem

When `app-outlook` aliases `app-shop` via a Nuxt alias (`"~": "../app-shop"`), both
layers resolve their locale dir to the same real path (`app-shop/i18n/locales`).
Under the previous first-wins logic, whichever app was discovered first would claim
ownership — if `app-outlook` was first, `app-shop` was wrongly marked as
`aliasOf: "app-outlook"` with 0 effective files.

## Fix

During dedup, check which layer's `layerRootDir` is an ancestor of the shared locale dir.
That layer is the physical owner. The other layer gets `aliasOf` pointing to the owner.
When both are ancestors (nested), the more specific (longer-path) one wins.
When neither is an ancestor, the previous first-wins fallback is preserved.

Closes #70, Closes #62, Parent PRD #64