### PR TITLE
feat: compute progressTotal for global progress bar in translate_missing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,24 @@ function findLayerOrThrow(config: I18nConfig, layer: string): LocaleDir {
 }
 
 /**
+ * Compute the total number of progress steps for translate_missing.
+ *
+ * Formula: sum(ceil(missingKeyCount / maxBatch) + 2) for each locale with > 0 missing keys.
+ * The +2 accounts for 1 "starting" + 1 "complete" notification per locale.
+ * Locales with 0 missing keys are excluded (they contribute 0 steps).
+ *
+ * @param missingKeyCounts - Array of missing key counts per locale (0 counts are ignored)
+ * @param maxBatch - Maximum keys per sampling batch
+ * @returns Total number of expected progress steps, or 0 if no locales have missing keys
+ */
+export function computeProgressTotal(missingKeyCounts: number[], maxBatch: number): number {
+  return missingKeyCounts.reduce((sum, count) => {
+    if (count <= 0) return sum
+    return sum + Math.ceil(count / maxBatch) + 2
+  }, 0)
+}
+
+/**
  * Format a caught error into an MCP tool error response.
  */
 function toolErrorResponse(context: string, error: unknown) {
@@ -1340,7 +1358,7 @@ export function createServer(): McpServer {
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
       },
     },
-    async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, projectDir }) => {
+    async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, projectDir }, extra) => {
       try {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
@@ -1380,6 +1398,42 @@ export function createServer(): McpServer {
             })
           : config.locales.filter(l => l.code !== refLocale.code)
 
+        // Pre-scan: count missing keys per target locale to compute progressTotal.
+        // readLocaleData uses mtime-based caching so the second read inside the loop is free.
+        const preScanCounts: number[] = []
+        for (const target of targets) {
+          let scanData: Record<string, unknown> = {}
+          try {
+            scanData = await readLocaleData(config, layer, target)
+          } catch {}
+          const countMissing = (k: string): boolean => {
+            const v = getNestedValue(scanData, k)
+            return v === undefined || v === '' || v === null
+          }
+          const count = keys
+            ? keys.filter(k => countMissing(k) && allRefKeys.includes(k)).length
+            : allRefKeys.filter(k => countMissing(k)).length
+          preScanCounts.push(count)
+        }
+
+        const progressTotal = computeProgressTotal(preScanCounts, maxBatch)
+        const progressToken = extra._meta?.progressToken
+        let progressCurrent = 0
+
+        const reportProgress = async (message: string) => {
+          if (!progressToken) return
+          progressCurrent++
+          await extra.sendNotification({
+            method: 'notifications/progress',
+            params: {
+              progressToken,
+              progress: progressCurrent,
+              total: progressTotal > 0 ? progressTotal : undefined,
+              message,
+            },
+          })
+        }
+
         // Check sampling support
         const clientCapabilities = server.server.getClientCapabilities()
         const samplingSupported = !!clientCapabilities?.sampling
@@ -1414,6 +1468,8 @@ export function createServer(): McpServer {
             continue
           }
 
+          await reportProgress(`Starting ${target.code}: ${missingKeys.length} missing keys`)
+
           // Build key-value pairs from reference
           const keysAndValues: Record<string, string> = {}
           for (const key of missingKeys) {
@@ -1429,6 +1485,7 @@ export function createServer(): McpServer {
               failed: [],
               samplingUsed: samplingSupported,
             }
+            await reportProgress(`Complete ${target.code} (dry run)`)
             continue
           }
 
@@ -1445,6 +1502,7 @@ export function createServer(): McpServer {
             for (let i = 0; i < keyEntries.length; i += maxBatch) {
               const batchNum = Math.floor(i / maxBatch) + 1
               const batch = Object.fromEntries(keyEntries.slice(i, i + maxBatch))
+              const totalBatches = Math.ceil(keyEntries.length / maxBatch)
               let batchTranslations: Record<string, string> | null = null
 
               for (let attempt = 0; attempt < 2; attempt++) {
@@ -1469,12 +1527,10 @@ export function createServer(): McpServer {
                     includeContext: 'none',
                   })
 
-                  // Parse the response
                   const responseText = samplingResult.content.type === 'text'
                     ? samplingResult.content.text
                     : ''
 
-                  // Try to extract JSON from the response (handle potential markdown fencing)
                   let cleanJson = responseText.trim()
                   if (cleanJson.startsWith('```')) {
                     cleanJson = cleanJson.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
@@ -1501,6 +1557,8 @@ export function createServer(): McpServer {
               } else {
                 failed.push(...Object.keys(batch))
               }
+
+              await reportProgress(`${target.code}: batch ${batchNum}/${totalBatches}`)
             }
 
             if (Object.keys(allTranslations).length > 0) {
@@ -1534,6 +1592,8 @@ export function createServer(): McpServer {
               samplingUsed: false,
             }
           }
+
+          await reportProgress(`Complete ${target.code}`)
         }
 
         const totalTranslated = Object.values(results).reduce((sum, r) => sum + r.translated.length, 0)

--- a/tests/tools/translate-and-prompts.test.ts
+++ b/tests/tools/translate-and-prompts.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../src/io/key-operations.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
 import { registerDetectorMock, playgroundDir, appAdminDir } from '../fixtures/mock-detector.js'
+import { computeProgressTotal } from '../../src/server.js'
 
 // Register the shared detector mock (vi.mock is hoisted by Vitest)
 registerDetectorMock()
@@ -853,5 +854,56 @@ describe('translate_missing: write error resilience', () => {
     expect(results['fr-FR'].writeError).toBeUndefined()
     expect(results['fr-FR'].translated).toEqual(['admin.users.list'])
     expect(results['fr-FR'].failed).toEqual([])
+  })
+})
+
+// ─── translate_missing: progressTotal computation ────────────────
+
+describe('translate_missing: progressTotal computation', () => {
+  it('correctly computes total for 2 locales with different missing key counts', () => {
+    const missingKeyCounts = [10, 60]
+    const maxBatch = 50
+    const total = computeProgressTotal(missingKeyCounts, maxBatch)
+    // locale 1: ceil(10/50) + 2 = 1 + 2 = 3
+    // locale 2: ceil(60/50) + 2 = 2 + 2 = 4
+    // total = 7
+    expect(total).toBe(7)
+  })
+
+  it('excludes locales with 0 missing keys from the total', () => {
+    const missingKeyCounts = [5, 0, 3]
+    const maxBatch = 50
+    const total = computeProgressTotal(missingKeyCounts, maxBatch)
+    // locale 1: ceil(5/50) + 2 = 1 + 2 = 3
+    // locale 2: 0 missing keys — excluded
+    // locale 3: ceil(3/50) + 2 = 1 + 2 = 3
+    // total = 6
+    expect(total).toBe(6)
+  })
+
+  it('formula matches sum(ceil(keys/batch) + 2) per locale with missing keys', () => {
+    const missingKeyCounts = [50, 100, 150]
+    const maxBatch = 50
+    const total = computeProgressTotal(missingKeyCounts, maxBatch)
+    // locale 1: ceil(50/50) + 2 = 1 + 2 = 3
+    // locale 2: ceil(100/50) + 2 = 2 + 2 = 4
+    // locale 3: ceil(150/50) + 2 = 3 + 2 = 5
+    // total = 12
+    expect(total).toBe(12)
+  })
+
+  it('single locale computes correctly', () => {
+    const missingKeyCounts = [75]
+    const maxBatch = 50
+    const total = computeProgressTotal(missingKeyCounts, maxBatch)
+    // ceil(75/50) + 2 = 2 + 2 = 4
+    expect(total).toBe(4)
+  })
+
+  it('all locales with 0 missing keys results in progressTotal of 0', () => {
+    const missingKeyCounts = [0, 0, 0]
+    const maxBatch = 50
+    const total = computeProgressTotal(missingKeyCounts, maxBatch)
+    expect(total).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- Pre-scans all target locales before the translate loop to count missing keys using mtime-cached `readLocaleData` (second read inside the loop is free)
- Computes `progressTotal = sum(ceil(missing/maxBatch) + 2)` per locale with missing keys; locales with 0 missing keys are excluded
- Sends `notifications/progress` throughout the translate loop (starting, per-batch, complete per locale) using the MCP `progressToken` from the incoming request
- Exports `computeProgressTotal` as a pure function for isolated unit testing

## Tests

5 new unit tests in `translate_missing: progressTotal computation`:
- 2 locales with different key counts → correct batch math
- Locale with 0 missing keys → excluded from total
- Formula verification: `sum(ceil(keys/batch) + 2)` per locale
- Single locale case
- All locales with 0 missing keys → total is 0

Closes #66
Parent PRD #64