### PR TITLE
feat: add modelPreferences to translate_missing sampling requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ monorepo/
 
 Discovery stops descending into a directory once it finds a `nuxt.config` — nested Nuxt layers are loaded by `@nuxt/kit` automatically.
 
+## Model Selection for Translations
+
+`translate_missing` uses [MCP sampling](https://modelcontextprotocol.io/docs/concepts/sampling) — the host (VS Code, Cursor, Claude Desktop) picks which LLM fulfills the request. The server sends `modelPreferences` hinting toward fast, cheap models since translation is high-volume and doesn't require frontier reasoning.
+
+**Built-in defaults** (used when no `samplingPreferences` in `.i18n-mcp.json`):
+
+| Priority | Value | Rationale |
+|----------|-------|-----------|
+| `hints` | `["flash", "haiku", "gpt-4o-mini"]` | Fastest models across providers (substring match) |
+| `speedPriority` | `0.9` | Users watch a progress bar — latency matters |
+| `costPriority` | `0.8` | Hundreds of batches add up |
+| `intelligencePriority` | `0.3` | Translation needs quality, not reasoning |
+
+Override via `samplingPreferences` in [`.i18n-mcp.json`](#project-config) if needed (e.g., to prefer a stronger model for nuanced locales).
+
+**Controlling the model in VS Code:**
+
+1. Command Palette → **MCP: List Servers** → select `the-i18n-mcp` → **Configure Model Access**
+2. Restrict to your preferred model (e.g., only Gemini 2.5 Flash)
+3. Your main chat/agent session continues using whatever model you chose — the restriction only applies to sampling requests from this MCP server
+
+> **Tip:** For large translation runs (1000+ keys), restricting to a fast model like Gemini 2.5 Flash significantly reduces wall-clock time. The model access restriction is per-MCP-server and independent from your agent's model.
+
 ## Project Config
 
 Optionally drop a `.i18n-mcp.json` at your project root to give the agent project-specific context. Everything is optional — the server passes them to the agent, which interprets the natural-language rules. The server walks up from `projectDir` to find the nearest config file (like ESLint or tsconfig resolution).
@@ -195,6 +218,7 @@ For IDE autocompletion, point to the schema:
 | `examples` | Few-shot translation examples demonstrating project style |
 | `orphanScan` | Per-layer config for orphan detection: `scanDirs` (overrides auto-discovered dirs) and `ignorePatterns` (glob) |
 | `reportOutput` | `true` for default `.i18n-reports/` dir, or a string for a custom path. Diagnostic tools write full output to disk and return only a summary in the MCP response |
+| `samplingPreferences` | Override model preferences for `translate_missing` sampling. See [Model Selection](#model-selection-for-translations) |
 
 ### Full example
 
@@ -242,7 +266,13 @@ For IDE autocompletion, point to the schema:
       "scanDirs": ["apps/admin"]
     }
   },
-  "reportOutput": true
+  "reportOutput": true,
+  "samplingPreferences": {
+    "hints": ["sonnet", "gpt-4o"],
+    "intelligencePriority": 0.7,
+    "speedPriority": 0.5,
+    "costPriority": 0.3
+  }
 }
 ```
 

--- a/schema.json
+++ b/schema.json
@@ -108,6 +108,38 @@
         "additionalProperties": false
       }
     },
+    "samplingPreferences": {
+      "type": "object",
+      "description": "Model preferences for translate_missing sampling requests. Overrides the built-in defaults which favor fast, cheap models (Gemini Flash, Claude Haiku, etc.). The MCP host (VS Code, Cursor, etc.) uses these hints to pick a model — all fields are advisory.",
+      "additionalProperties": false,
+      "properties": {
+        "hints": {
+          "type": "array",
+          "description": "Ordered model name hints (substring match). The host evaluates in order and takes the first match. Example: [\"flash\", \"haiku\", \"gpt-4o-mini\"].",
+          "items": {
+            "type": "string"
+          }
+        },
+        "costPriority": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "How much to prioritize cost. 0 = don't care, 1 = most important factor."
+        },
+        "speedPriority": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "How much to prioritize speed/latency. 0 = don't care, 1 = most important factor."
+        },
+        "intelligencePriority": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "How much to prioritize intelligence/capabilities. 0 = don't care, 1 = most important factor."
+        }
+      }
+    },
     "reportOutput": {
       "oneOf": [
         {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -60,6 +60,17 @@ export interface ProjectConfig {
   }>
   /** Default output directory for diagnostic tool reports. Set to true for '.i18n-reports/', or a string for a custom relative path. */
   reportOutput?: string | boolean
+  /** Model preferences for `translate_missing` sampling requests. Overrides the built-in defaults (fast/cheap model bias). */
+  samplingPreferences?: {
+    /** Ordered model name hints (substring match). First match wins. E.g., ["flash", "haiku"] */
+    hints?: string[]
+    /** 0 = don't care, 1 = most important factor */
+    costPriority?: number
+    /** 0 = don't care, 1 = most important factor */
+    speedPriority?: number
+    /** 0 = don't care, 1 = most important factor */
+    intelligencePriority?: number
+  }
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import type { ModelPreferences } from '@modelcontextprotocol/sdk/types.js'
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
@@ -26,6 +27,24 @@ import { ToolError } from './utils/errors.js'
 import { resolve } from 'node:path'
 import { readdir } from 'node:fs/promises'
 import { scaffoldLocale } from './tools/scaffold-locale.js'
+
+const DEFAULT_SAMPLING_PREFERENCES: ModelPreferences = {
+  hints: [{ name: 'flash' }, { name: 'haiku' }, { name: 'gpt-4o-mini' }],
+  costPriority: 0.8,
+  speedPriority: 0.9,
+  intelligencePriority: 0.3,
+}
+
+function resolveSamplingPreferences(projectConfig?: ProjectConfig): ModelPreferences {
+  const userPrefs = projectConfig?.samplingPreferences
+  if (!userPrefs) return DEFAULT_SAMPLING_PREFERENCES
+  return {
+    hints: userPrefs.hints?.map(name => ({ name })) ?? DEFAULT_SAMPLING_PREFERENCES.hints,
+    costPriority: userPrefs.costPriority ?? DEFAULT_SAMPLING_PREFERENCES.costPriority,
+    speedPriority: userPrefs.speedPriority ?? DEFAULT_SAMPLING_PREFERENCES.speedPriority,
+    intelligencePriority: userPrefs.intelligencePriority ?? DEFAULT_SAMPLING_PREFERENCES.intelligencePriority,
+  }
+}
 
 function resolveOrphanScanDirs(
   config: I18nConfig,
@@ -1515,6 +1534,7 @@ export function createServer(): McpServer {
                     config.localeFileFormat,
                   )
 
+                  const SAMPLING_TIMEOUT_MS = 120_000 // 2 minutes per batch
                   const samplingResult = await server.server.createMessage({
                     messages: [
                       {
@@ -1525,6 +1545,9 @@ export function createServer(): McpServer {
                     systemPrompt,
                     maxTokens: 4096,
                     includeContext: 'none',
+                    modelPreferences: resolveSamplingPreferences(config.projectConfig),
+                  }, {
+                    timeout: SAMPLING_TIMEOUT_MS,
                   })
 
                   const responseText = samplingResult.content.type === 'text'


### PR DESCRIPTION
## Summary

- Sends MCP `modelPreferences` in `translate_missing` sampling requests, hinting hosts (VS Code, Cursor, Claude Desktop) toward fast/cheap models
- Built-in defaults: `hints: ["flash", "haiku", "gpt-4o-mini"]`, `speedPriority: 0.9`, `costPriority: 0.8`, `intelligencePriority: 0.3`
- Defaults are overridable via `samplingPreferences` in `.i18n-mcp.json` for projects needing stronger models
- Adds README section explaining model selection, VS Code "Configure Model Access" workflow, and the `samplingPreferences` config option

## Changes

| File | What |
|------|------|
| `src/server.ts` | Import `ModelPreferences` type, add `DEFAULT_SAMPLING_PREFERENCES` constant, `resolveSamplingPreferences()` merge helper, wire into `createMessage` call |
| `src/config/types.ts` | Add `samplingPreferences` to `ProjectConfig` interface |
| `schema.json` | Add `samplingPreferences` object with `hints`, `costPriority`, `speedPriority`, `intelligencePriority` fields |
| `README.md` | New "Model Selection for Translations" section, add field to config table, add to full JSON example |

## How it works

1. **No config** → server sends hardcoded defaults (fast/cheap bias)
2. **With `samplingPreferences` in `.i18n-mcp.json`** → user values override defaults per-field (partial overrides work)
3. **VS Code model restriction** → user can also hard-restrict via "Configure Model Access" UI, which takes precedence over any hints

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅  
- `pnpm build` ✅
- `pnpm test` ✅ (438 tests pass)

Closes #N/A — standalone improvement from translate_missing analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added configurable model sampling preferences to optimize translation model selection through customizable priority weights for cost, speed, and intelligence factors, plus ordered model preference hints for enhanced control

## Documentation
* Updated configuration schema and README documentation with comprehensive guidance on model selection behavior, default settings, and sampling preferences customization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->