### PR TITLE
feat: log which model the MCP host picks for sampling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -28,14 +28,14 @@ import { resolve } from 'node:path'
 import { readdir } from 'node:fs/promises'
 import { scaffoldLocale } from './tools/scaffold-locale.js'
 
-const DEFAULT_SAMPLING_PREFERENCES: ModelPreferences = {
+export const DEFAULT_SAMPLING_PREFERENCES: ModelPreferences = {
   hints: [{ name: 'flash' }, { name: 'haiku' }, { name: 'gpt-4o-mini' }],
   costPriority: 0.8,
   speedPriority: 0.9,
   intelligencePriority: 0.3,
 }
 
-function resolveSamplingPreferences(projectConfig?: ProjectConfig): ModelPreferences {
+export function resolveSamplingPreferences(projectConfig?: ProjectConfig): ModelPreferences {
   const userPrefs = projectConfig?.samplingPreferences
   if (!userPrefs) return DEFAULT_SAMPLING_PREFERENCES
   return {
@@ -1554,6 +1554,10 @@ export function createServer(): McpServer {
                     ? samplingResult.content.text
                     : ''
 
+                  if (attempt === 0 && batchNum === 1) {
+                    log.info(`Sampling model: ${samplingResult.model}`)
+                  }
+
                   let cleanJson = responseText.trim()
                   if (cleanJson.startsWith('```')) {
                     cleanJson = cleanJson.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
@@ -1593,8 +1597,6 @@ export function createServer(): McpServer {
                 })
               } catch (error) {
                 log.warn(`Failed to write translations for ${target.code}: ${error instanceof Error ? error.message : String(error)}`)
-                failed.push(...translated)
-                translated.length = 0
                 results[target.code] = { translated: [], failed: [...Object.keys(keysAndValues)], samplingUsed: true, writeError: error instanceof Error ? error.message : String(error) }
                 continue
               }

--- a/tests/tools/translate-and-prompts.test.ts
+++ b/tests/tools/translate-and-prompts.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../src/io/key-operations.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
 import { registerDetectorMock, playgroundDir, appAdminDir } from '../fixtures/mock-detector.js'
-import { computeProgressTotal } from '../../src/server.js'
+import { computeProgressTotal, resolveSamplingPreferences, DEFAULT_SAMPLING_PREFERENCES } from '../../src/server.js'
 
 // Register the shared detector mock (vi.mock is hoisted by Vitest)
 registerDetectorMock()
@@ -905,5 +905,67 @@ describe('translate_missing: progressTotal computation', () => {
     const maxBatch = 50
     const total = computeProgressTotal(missingKeyCounts, maxBatch)
     expect(total).toBe(0)
+  })
+})
+
+// ─── resolveSamplingPreferences ──────────────────────────────────
+
+describe('resolveSamplingPreferences', () => {
+  it('returns built-in defaults when no project config is provided', () => {
+    const result = resolveSamplingPreferences(undefined)
+    expect(result).toEqual(DEFAULT_SAMPLING_PREFERENCES)
+  })
+
+  it('returns built-in defaults when project config has no samplingPreferences', () => {
+    const result = resolveSamplingPreferences({ context: 'some project' })
+    expect(result).toEqual(DEFAULT_SAMPLING_PREFERENCES)
+  })
+
+  it('maps string hints to ModelHint objects', () => {
+    const result = resolveSamplingPreferences({
+      samplingPreferences: { hints: ['sonnet', 'gpt-4o'] },
+    })
+    expect(result.hints).toEqual([{ name: 'sonnet' }, { name: 'gpt-4o' }])
+  })
+
+  it('overrides individual priority fields while keeping defaults for unset fields', () => {
+    const result = resolveSamplingPreferences({
+      samplingPreferences: { intelligencePriority: 0.9 },
+    })
+    expect(result.intelligencePriority).toBe(0.9)
+    expect(result.costPriority).toBe(DEFAULT_SAMPLING_PREFERENCES.costPriority)
+    expect(result.speedPriority).toBe(DEFAULT_SAMPLING_PREFERENCES.speedPriority)
+    expect(result.hints).toEqual(DEFAULT_SAMPLING_PREFERENCES.hints)
+  })
+
+  it('overrides all fields when fully specified', () => {
+    const result = resolveSamplingPreferences({
+      samplingPreferences: {
+        hints: ['claude'],
+        costPriority: 0.1,
+        speedPriority: 0.2,
+        intelligencePriority: 0.95,
+      },
+    })
+    expect(result).toEqual({
+      hints: [{ name: 'claude' }],
+      costPriority: 0.1,
+      speedPriority: 0.2,
+      intelligencePriority: 0.95,
+    })
+  })
+
+  it('falls back to default hints when hints array is undefined', () => {
+    const result = resolveSamplingPreferences({
+      samplingPreferences: { costPriority: 0.5 },
+    })
+    expect(result.hints).toEqual(DEFAULT_SAMPLING_PREFERENCES.hints)
+  })
+
+  it('handles empty hints array', () => {
+    const result = resolveSamplingPreferences({
+      samplingPreferences: { hints: [] },
+    })
+    expect(result.hints).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- Log the model name returned by `createMessage` on the first successful batch, so users can see which model their MCP host is using for translations (visible in VS Code's Output panel under the server stderr)
- Export `resolveSamplingPreferences` + `DEFAULT_SAMPLING_PREFERENCES` for testability
- Add 7 unit tests for `resolveSamplingPreferences` (was 0 — PR #77 gap)
- Remove dead code in write-error catch block (`failed.push` and `translated.length` mutations were never read)

## Example log output

```
[the-i18n-mcp] [info] Sampling model: gemini-2.5-flash
```

## Test results

451 tests pass, lint clean, typecheck clean.