### PR TITLE
fix: log sampling model on first success regardless of retry

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1438,6 +1438,7 @@ export function createServer(): McpServer {
         const progressTotal = computeProgressTotal(preScanCounts, maxBatch)
         const progressToken = extra._meta?.progressToken
         let progressCurrent = 0
+        let samplingModelLogged = false
 
         const reportProgress = async (message: string) => {
           if (!progressToken) return
@@ -1554,8 +1555,9 @@ export function createServer(): McpServer {
                     ? samplingResult.content.text
                     : ''
 
-                  if (attempt === 0 && batchNum === 1) {
+                  if (!samplingModelLogged) {
                     log.info(`Sampling model: ${samplingResult.model}`)
+                    samplingModelLogged = true
                   }
 
                   let cleanJson = responseText.trim()


### PR DESCRIPTION
## Summary

Fix model logging to trigger on the first *successful* sampling response, not just attempt 0 of batch 1. When the first attempt times out and the retry succeeds, the previous code never logged the model name.

Uses a `samplingModelLogged` flag scoped to the entire `translate_missing` call — logs once, on whichever attempt/batch succeeds first.