### PR TITLE
fix: accept 'locales' as alias for 'targetLocales'

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -749,13 +749,17 @@ export function createServer(): McpServer {
           .array(z.string())
           .optional()
           .describe('Locale codes to check for missing keys (e.g., ["de", "fr", "es"]). Defaults to all locales except the reference.'),
+        locales: z
+          .array(z.string())
+          .optional()
+          .describe('Alias for targetLocales (deprecated — use targetLocales instead).'),
         projectDir: z
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
       },
     },
-    async ({ layer, referenceLocale, targetLocales, projectDir }) => {
+    async ({ layer, referenceLocale, targetLocales, locales, projectDir }) => {
       try {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
@@ -768,8 +772,9 @@ export function createServer(): McpServer {
         }
 
         // Determine target locales
-        const targets = targetLocales
-          ? targetLocales.map((code) => {
+        const resolvedTargets = targetLocales ?? locales
+        const targets = resolvedTargets
+          ? resolvedTargets.map((code) => {
               const loc = findLocale(config, code)
               if (!loc) {
                 throw new ToolError(`Target locale not found: "${code}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass valid locale codes in targetLocales.`, 'LOCALE_NOT_FOUND')
@@ -1359,6 +1364,10 @@ export function createServer(): McpServer {
           .array(z.string())
           .optional()
           .describe('Locale codes to translate into (e.g., ["de", "fr", "sv"]). Defaults to all locales except the reference.'),
+        locales: z
+          .array(z.string())
+          .optional()
+          .describe('Alias for targetLocales (deprecated — use targetLocales instead).'),
         keys: z
           .array(z.string())
           .optional()
@@ -1377,7 +1386,7 @@ export function createServer(): McpServer {
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
       },
     },
-    async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, projectDir }, extra) => {
+    async ({ layer, referenceLocale, targetLocales, locales, keys, batchSize, dryRun, projectDir }, extra) => {
       try {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
@@ -1406,9 +1415,9 @@ export function createServer(): McpServer {
           return typeof v === 'string' ? v.length > 0 : v !== null && v !== undefined
         })
 
-        // Determine target locales
-        const targets = targetLocales
-          ? targetLocales.map((code) => {
+        const resolvedTargetLocales = targetLocales ?? locales
+        const targets = resolvedTargetLocales
+          ? resolvedTargetLocales.map((code) => {
               const loc = findLocale(config, code)
               if (!loc) {
                 throw new ToolError(`Target locale not found: "${code}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass valid locale codes in targetLocales.`, 'LOCALE_NOT_FOUND')


### PR DESCRIPTION
## Problem

Agents commonly send `locales` (the param name from `scaffold_locale`) instead of `targetLocales` when calling `translate_missing` or `get_missing_translations`. Zod silently strips the unknown property, causing the server to fall through to the default: **all locales except the reference**. On a 31-locale project, this means translating into 30 locales instead of the intended 13 — triggering cascading 2-minute timeouts.

## Fix

Accept `locales` as a deprecated alias for `targetLocales` in both `translate_missing` and `get_missing_translations`. `targetLocales` takes precedence when both are provided. The `locales` param is marked as deprecated in its `.describe()` text so agents learn the canonical name over time.

## Test results

451 tests pass, lint clean, typecheck clean.