### PR TITLE
fix: harden JSON response parsing with balanced bracket extraction and key filtering

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -322,6 +322,57 @@ function buildTranslationUserMessage(
   ].join('\n')
 }
 
+export function extractJsonFromResponse(responseText: string): Record<string, unknown> {
+  const trimmed = responseText.trim()
+
+  // Tier 1: direct parse
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>
+  } catch {}
+
+  // Tier 2: strip markdown code fences
+  if (trimmed.startsWith('```')) {
+    const stripped = trimmed.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+    try {
+      return JSON.parse(stripped) as Record<string, unknown>
+    } catch {}
+  }
+
+  // Tier 3: balanced bracket extraction — find first complete {...}
+  const start = trimmed.indexOf('{')
+  if (start !== -1) {
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < trimmed.length; i++) {
+      const ch = trimmed[i]
+      if (escape) {
+        escape = false
+        continue
+      }
+      if (ch === '\\' && inString) {
+        escape = true
+        continue
+      }
+      if (ch === '"') {
+        inString = !inString
+        continue
+      }
+      if (inString) continue
+      if (ch === '{') depth++
+      else if (ch === '}') {
+        depth--
+        if (depth === 0) {
+          const candidate = trimmed.slice(start, i + 1)
+          return JSON.parse(candidate) as Record<string, unknown>
+        }
+      }
+    }
+  }
+
+  throw new Error('No valid JSON object found in response')
+}
+
 /**
  * Build a fallback context object when sampling is not available.
  * Returns everything the agent needs to translate inline.
@@ -1560,12 +1611,14 @@ export function createServer(): McpServer {
                     samplingModelLogged = true
                   }
 
-                  let cleanJson = responseText.trim()
-                  if (cleanJson.startsWith('```')) {
-                    cleanJson = cleanJson.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+                  const parsed = extractJsonFromResponse(responseText)
+                  const batchKeys = new Set(Object.keys(batch))
+                  batchTranslations = {} as Record<string, string>
+                  for (const [key, value] of Object.entries(parsed)) {
+                    if (batchKeys.has(key) && typeof value === 'string') {
+                      batchTranslations[key] = value
+                    }
                   }
-
-                  batchTranslations = JSON.parse(cleanJson) as Record<string, string>
                   break // success — stop retrying
                 } catch (error) {
                   if (attempt === 0) {


### PR DESCRIPTION
## Summary
- Replace fragile code-fence-only JSON cleaner with a 3-tier extraction strategy:
  1. Direct `JSON.parse` for clean responses
  2. Strip markdown fences, then parse
  3. Balanced bracket scan for prose-prefixed responses (tracks `{}` depth, respects strings)
- Filter parsed results to only include keys present in the original batch — prevents hallucinated extra keys from polluting locale files
- Extract parsing into exported `extractJsonFromResponse` function for direct testability

## Testing
- `pnpm build` ✅
- `pnpm test` ✅ (451 tests pass)
- `pnpm typecheck` ✅
- `pnpm lint` ✅

## Related Issues
closes #87 (parent PRD: #84)