### PR TITLE
test: add tests for exported prompt builders, JSON parser, and maxTokens

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,14 @@ export function resolveSamplingPreferences(projectConfig?: ProjectConfig): Model
   }
 }
 
+/**
+ * Compute maxTokens for a sampling request based on batch key count.
+ * Scales linearly (40 tokens per key + 512 base) capped at 16384.
+ */
+export function computeMaxTokens(batchKeyCount: number): number {
+  return Math.min(16384, batchKeyCount * 40 + 512)
+}
+
 function resolveOrphanScanDirs(
   config: I18nConfig,
   layer: string | undefined,
@@ -1525,16 +1533,19 @@ export function createServer(): McpServer {
               const totalBatches = Math.ceil(keyEntries.length / maxBatch)
               let batchTranslations: Record<string, string> | null = null
 
-              for (let attempt = 0; attempt < 2; attempt++) {
-                try {
-                  const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, target.language || target.code, config.localeFileFormat)
-                  const userMessage = buildTranslationUserMessage(
-                    refLocale.language || refLocale.code,
-                    target.language || target.code,
-                    batch,
-                    config.localeFileFormat,
-                  )
+              const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, target.language || target.code, config.localeFileFormat)
+              const userMessage = buildTranslationUserMessage(
+                refLocale.language || refLocale.code,
+                target.language || target.code,
+                batch,
+                config.localeFileFormat,
+              )
 
+              for (let attempt = 0; attempt < 2; attempt++) {
+                if (attempt > 0) {
+                  await new Promise(r => setTimeout(r, 2000))
+                }
+                try {
                   const SAMPLING_TIMEOUT_MS = 120_000 // 2 minutes per batch
                   const samplingResult = await server.server.createMessage({
                     messages: [
@@ -1544,7 +1555,8 @@ export function createServer(): McpServer {
                       },
                     ],
                     systemPrompt,
-                    maxTokens: 4096,
+                    maxTokens: computeMaxTokens(Object.keys(batch).length),
+                    temperature: 0,
                     includeContext: 'none',
                     modelPreferences: resolveSamplingPreferences(config.projectConfig),
                   }, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -322,6 +322,57 @@ function buildTranslationUserMessage(
   ].join('\n')
 }
 
+export function extractJsonFromResponse(responseText: string): Record<string, unknown> {
+  const trimmed = responseText.trim()
+
+  // Tier 1: direct parse
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>
+  } catch {}
+
+  // Tier 2: strip markdown code fences
+  if (trimmed.startsWith('```')) {
+    const stripped = trimmed.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+    try {
+      return JSON.parse(stripped) as Record<string, unknown>
+    } catch {}
+  }
+
+  // Tier 3: balanced bracket extraction — find first complete {...}
+  const start = trimmed.indexOf('{')
+  if (start !== -1) {
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < trimmed.length; i++) {
+      const ch = trimmed[i]
+      if (escape) {
+        escape = false
+        continue
+      }
+      if (ch === '\\' && inString) {
+        escape = true
+        continue
+      }
+      if (ch === '"') {
+        inString = !inString
+        continue
+      }
+      if (inString) continue
+      if (ch === '{') depth++
+      else if (ch === '}') {
+        depth--
+        if (depth === 0) {
+          const candidate = trimmed.slice(start, i + 1)
+          return JSON.parse(candidate) as Record<string, unknown>
+        }
+      }
+    }
+  }
+
+  throw new Error('No valid JSON object found in response')
+}
+
 /**
  * Build a fallback context object when sampling is not available.
  * Returns everything the agent needs to translate inline.
@@ -1560,12 +1611,14 @@ export function createServer(): McpServer {
                     samplingModelLogged = true
                   }
 
-                  let cleanJson = responseText.trim()
-                  if (cleanJson.startsWith('```')) {
-                    cleanJson = cleanJson.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+                  const parsed = extractJsonFromResponse(responseText)
+                  const batchKeys = new Set(Object.keys(batch))
+                  batchTranslations = {} as Record<string, string>
+                  for (const [key, value] of Object.entries(parsed)) {
+                    if (batchKeys.has(key) && typeof value === 'string') {
+                      batchTranslations[key] = value
+                    }
                   }
-
-                  batchTranslations = JSON.parse(cleanJson) as Record<string, string>
                   break // success — stop retrying
                 } catch (error) {
                   if (attempt === 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -261,12 +261,14 @@ function placeholderInstruction(format?: LocaleFileFormat): string {
   return 'Preserve all {placeholder} parameters and @:linked.message references.'
 }
 
-function buildTranslationSystemPrompt(
+export function buildTranslationSystemPrompt(
   projectConfig: ProjectConfig | undefined,
   targetLocaleCode: string,
   localeFileFormat?: LocaleFileFormat,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [
+    `You are a professional translator for software UI strings. ${placeholderInstruction(localeFileFormat)} Be concise — UI space is limited.`,
+  ]
 
   if (projectConfig?.translationPrompt) {
     parts.push(projectConfig.translationPrompt)
@@ -297,9 +299,7 @@ function buildTranslationSystemPrompt(
     parts.push(`STYLE EXAMPLES:\n${exampleLines}`)
   }
 
-  if (parts.length === 0) {
-    return `You are a professional translator for software UI strings. ${placeholderInstruction(localeFileFormat)} Be concise — UI space is limited.`
-  }
+  parts.push('Return ONLY a JSON object mapping keys to translated values. No markdown, no explanation, no code fences.')
 
   return parts.join('\n\n')
 }
@@ -307,7 +307,7 @@ function buildTranslationSystemPrompt(
 /**
  * Build the user message for a translation sampling request.
  */
-function buildTranslationUserMessage(
+export function buildTranslationUserMessage(
   referenceLocaleCode: string,
   targetLocaleCode: string,
   keysAndValues: Record<string, string>,
@@ -316,9 +316,8 @@ function buildTranslationUserMessage(
   return [
     `Translate the following i18n key-value pairs from ${referenceLocaleCode} to ${targetLocaleCode}.`,
     placeholderInstruction(localeFileFormat),
-    'Return ONLY a JSON object mapping keys to translated values. No markdown, no explanation, no code fences.',
     '',
-    JSON.stringify(keysAndValues, null, 2),
+    JSON.stringify(keysAndValues),
   ].join('\n')
 }
 

--- a/tests/tools/translate-and-prompts.test.ts
+++ b/tests/tools/translate-and-prompts.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../src/io/key-operations.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
 import { registerDetectorMock, playgroundDir, appAdminDir } from '../fixtures/mock-detector.js'
-import { computeProgressTotal, resolveSamplingPreferences, DEFAULT_SAMPLING_PREFERENCES } from '../../src/server.js'
+import { computeProgressTotal, resolveSamplingPreferences, DEFAULT_SAMPLING_PREFERENCES, buildTranslationSystemPrompt, buildTranslationUserMessage, extractJsonFromResponse, computeMaxTokens } from '../../src/server.js'
 
 // Register the shared detector mock (vi.mock is hoisted by Vitest)
 registerDetectorMock()
@@ -967,5 +967,163 @@ describe('resolveSamplingPreferences', () => {
       samplingPreferences: { hints: [] },
     })
     expect(result.hints).toEqual([])
+  })
+})
+
+describe('buildTranslationSystemPrompt', () => {
+  it('includes role framing with no project config', () => {
+    const result = buildTranslationSystemPrompt(undefined, 'de')
+    expect(result).toContain('You are a professional translator')
+    expect(result).toContain('{placeholder}')
+    expect(result).toContain('Return ONLY a JSON object')
+  })
+
+  it('includes role framing even with translationPrompt set', () => {
+    const result = buildTranslationSystemPrompt({ translationPrompt: 'Be formal.' }, 'de')
+    expect(result).toContain('You are a professional translator')
+    expect(result).toContain('Be formal.')
+    expect(result).toContain('Return ONLY a JSON object')
+  })
+
+  it('includes glossary when provided', () => {
+    const result = buildTranslationSystemPrompt({
+      glossary: { Booking: 'Buchung', Resource: 'Ressource' },
+    }, 'de')
+    expect(result).toContain('GLOSSARY')
+    expect(result).toContain('Booking → Buchung')
+    expect(result).toContain('Resource → Ressource')
+  })
+
+  it('includes locale note for the target locale', () => {
+    const result = buildTranslationSystemPrompt({
+      localeNotes: { de: 'Informal German', fr: 'Formal French' },
+    }, 'de')
+    expect(result).toContain('TARGET LOCALE NOTE (de): Informal German')
+    expect(result).not.toContain('Formal French')
+  })
+
+  it('includes examples when provided', () => {
+    const result = buildTranslationSystemPrompt({
+      examples: [{ key: 'save', de: 'Speichern', note: 'imperative' }],
+    }, 'de')
+    expect(result).toContain('STYLE EXAMPLES')
+    expect(result).toContain('save')
+    expect(result).toContain('Speichern')
+    expect(result).toContain('imperative')
+  })
+
+  it('includes all fields in correct order when all are set', () => {
+    const result = buildTranslationSystemPrompt({
+      translationPrompt: 'Keep it short.',
+      glossary: { Save: 'Speichern' },
+      localeNotes: { de: 'Use du.' },
+      examples: [{ key: 'ok', de: 'OK' }],
+    }, 'de')
+    const roleIdx = result.indexOf('You are a professional translator')
+    const promptIdx = result.indexOf('Keep it short.')
+    const glossaryIdx = result.indexOf('GLOSSARY')
+    const noteIdx = result.indexOf('TARGET LOCALE NOTE')
+    const examplesIdx = result.indexOf('STYLE EXAMPLES')
+    const formatIdx = result.indexOf('Return ONLY a JSON object')
+    expect(roleIdx).toBeLessThan(promptIdx)
+    expect(promptIdx).toBeLessThan(glossaryIdx)
+    expect(glossaryIdx).toBeLessThan(noteIdx)
+    expect(noteIdx).toBeLessThan(examplesIdx)
+    expect(examplesIdx).toBeLessThan(formatIdx)
+  })
+
+  it('uses :placeholder instruction for php-array format', () => {
+    const result = buildTranslationSystemPrompt(undefined, 'de', 'php-array')
+    expect(result).toContain(':placeholder')
+    expect(result).not.toContain('{placeholder}')
+  })
+})
+
+describe('buildTranslationUserMessage', () => {
+  it('includes reference and target locale codes', () => {
+    const result = buildTranslationUserMessage('en', 'de', { hello: 'Hello' })
+    expect(result).toContain('from en to de')
+  })
+
+  it('uses compact JSON without indentation', () => {
+    const result = buildTranslationUserMessage('en', 'de', { hello: 'Hello', bye: 'Goodbye' })
+    expect(result).toContain('{"hello":"Hello","bye":"Goodbye"}')
+    expect(result).not.toContain('  "hello"')
+  })
+
+  it('does not include format instruction', () => {
+    const result = buildTranslationUserMessage('en', 'de', { hello: 'Hello' })
+    expect(result).not.toContain('Return ONLY')
+  })
+
+  it('includes placeholder instruction', () => {
+    const result = buildTranslationUserMessage('en', 'de', { hello: 'Hello' })
+    expect(result).toContain('{placeholder}')
+  })
+
+  it('uses :placeholder instruction for php-array format', () => {
+    const result = buildTranslationUserMessage('en', 'de', { hello: 'Hello' }, 'php-array')
+    expect(result).toContain(':placeholder')
+  })
+})
+
+describe('extractJsonFromResponse', () => {
+  it('parses clean JSON directly', () => {
+    const result = extractJsonFromResponse('{"key":"value"}')
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('strips markdown code fences', () => {
+    const result = extractJsonFromResponse('```json\n{"key":"value"}\n```')
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('strips bare code fences without language tag', () => {
+    const result = extractJsonFromResponse('```\n{"key":"value"}\n```')
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('extracts JSON from prose-prefixed response', () => {
+    const result = extractJsonFromResponse('Here are your translations:\n{"key":"value"}')
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('handles nested objects in values', () => {
+    const input = 'Some text {"a":"1","b":"val with } brace"} trailing'
+    const result = extractJsonFromResponse(input)
+    expect(result).toEqual({ a: '1', b: 'val with } brace' })
+  })
+
+  it('extracts first JSON object when multiple exist', () => {
+    const result = extractJsonFromResponse('{"first":"1"}\n{"second":"2"}')
+    expect(result).toEqual({ first: '1' })
+  })
+
+  it('throws when no JSON is present', () => {
+    expect(() => extractJsonFromResponse('No JSON here at all')).toThrow('No valid JSON object')
+  })
+
+  it('handles whitespace around JSON', () => {
+    const result = extractJsonFromResponse('  \n  {"key":"value"}  \n  ')
+    expect(result).toEqual({ key: 'value' })
+  })
+})
+
+describe('computeMaxTokens', () => {
+  it('returns 552 for 1 key', () => {
+    expect(computeMaxTokens(1)).toBe(552)
+  })
+
+  it('returns 2512 for 50 keys', () => {
+    expect(computeMaxTokens(50)).toBe(2512)
+  })
+
+  it('returns 8512 for 200 keys', () => {
+    expect(computeMaxTokens(200)).toBe(8512)
+  })
+
+  it('caps at 16384 for very large batches', () => {
+    expect(computeMaxTokens(500)).toBe(16384)
+    expect(computeMaxTokens(1000)).toBe(16384)
   })
 })


### PR DESCRIPTION
## Summary

- Adds 24 unit tests covering the 4 newly exported functions from PRD #84:
  - `buildTranslationSystemPrompt` (7 tests): role framing, format instruction, context/glossary/localeNotes/examples integration
  - `buildTranslationUserMessage` (5 tests): compact JSON format, source locale labeling, batch key formatting
  - `extractJsonFromResponse` (8 tests): clean JSON, markdown fences, surrounding text, nested braces, partial/invalid input
  - `computeMaxTokens` (4 tests): formula verification (keys×40+512, capped at 16384)
- All 475 tests pass (451 existing + 24 new)

## Dependencies

This branch merges `fix/harden-prompts`, `fix/sampling-reliability`, and `fix/harden-json-parsing` to access the exported functions. Merge PRs #90, #91, #92 first.

Closes #89