### PR TITLE
feat: per-layer orphan scanning, bare string matching, and $te support

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ For IDE autocompletion, point to the schema:
 | `translationPrompt` | System prompt prepended to all translation requests |
 | `localeNotes` | Per-locale instructions — terminology constraints, formality, regional conventions. **Keys must match your locale codes exactly** (case-sensitive) |
 | `examples` | Few-shot translation examples demonstrating project style |
-| `orphanScan` | Per-layer config for orphan detection: `scanDirs` (overrides auto-discovered dirs) and `ignorePatterns` (glob). Keys are layer names from `list_locale_dirs` |
+| `orphanScan` | Per-layer config for orphan detection: `ignorePatterns` (glob patterns for keys to skip). Keys are layer names from `list_locale_dirs`. Each layer automatically scans from its own root directory |
 | `reportOutput` | `true` for default `.i18n-reports/` dir, or a string for a custom path. Diagnostic tools write full output to disk and return only a summary in the MCP response |
 | `samplingPreferences` | Override model preferences for `translate_missing` sampling. See [Model Selection](#model-selection-for-translations) |
 
@@ -335,11 +335,10 @@ For IDE autocompletion, point to the schema:
   ],
   "orphanScan": {
     "shared": {
-      "scanDirs": ["apps/shop", "apps/admin", "packages/shared"],
       "ignorePatterns": ["common.datetime.**", "common.countries.*"]
     },
     "app-admin": {
-      "scanDirs": ["apps/admin"]
+      "ignorePatterns": ["admin.legacy.*"]
     }
   },
   "reportOutput": true,

--- a/schema.json
+++ b/schema.json
@@ -90,18 +90,10 @@
     },
     "orphanScan": {
       "type": "object",
-      "description": "Per-layer scan directories for orphan key detection. In monorepos, a shared layer's keys may be used across multiple apps. Map each layer name to the directories that should be scanned for its key usage. Paths are relative to the project root.",
+      "description": "Per-layer configuration for orphan key detection. Map each layer name to its settings. Scan directories are automatically determined from each layer's root directory.",
       "additionalProperties": {
         "type": "object",
-        "required": ["scanDirs"],
         "properties": {
-          "scanDirs": {
-            "type": "array",
-            "description": "Directories to scan for key usage (relative to project root).",
-            "items": {
-              "type": "string"
-            }
-          },
           "ignorePatterns": {
             "type": "array",
             "description": "Glob patterns for translation keys to exclude from orphan detection (e.g., \"common.datetime.months.*\"). Use * to match a single key segment, ** to match any depth.",

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -68,6 +68,18 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
 
   const config = parsed as Record<string, unknown>
 
+  // Reject unknown top-level keys (matches schema additionalProperties: false)
+  const knownKeys = new Set([
+    '$schema', 'framework', 'context', 'layerRules', 'glossary',
+    'translationPrompt', 'localeNotes', 'examples', 'orphanScan',
+    'reportOutput', 'samplingPreferences',
+  ])
+  for (const key of Object.keys(config)) {
+    if (!knownKeys.has(key)) {
+      throw new ConfigError(`${CONFIG_FILENAME}: unknown property "${key}". Allowed: ${[...knownKeys].filter(k => k !== '$schema').join(', ')}`)
+    }
+  }
+
   if ('framework' in config && typeof config.framework !== 'string') {
     throw new ConfigError(`${CONFIG_FILENAME}: "framework" must be a string`)
   }
@@ -160,6 +172,12 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
         throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" must be an object`)
       }
       const layerObj = layerConfig as Record<string, unknown>
+      const knownLayerKeys = new Set(['ignorePatterns'])
+      for (const k of Object.keys(layerObj)) {
+        if (!knownLayerKeys.has(k)) {
+          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" has unknown property "${k}". Allowed: ignorePatterns`)
+        }
+      }
       if ('ignorePatterns' in layerObj) {
         if (!Array.isArray(layerObj.ignorePatterns)) {
           throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns" must be an array of strings`)

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -160,14 +160,6 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
         throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" must be an object`)
       }
       const layerObj = layerConfig as Record<string, unknown>
-      if (!Array.isArray(layerObj.scanDirs)) {
-        throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.scanDirs" must be an array of strings`)
-      }
-      for (let i = 0; i < layerObj.scanDirs.length; i++) {
-        if (typeof layerObj.scanDirs[i] !== 'string') {
-          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.scanDirs[${i}]" must be a string`)
-        }
-      }
       if ('ignorePatterns' in layerObj) {
         if (!Array.isArray(layerObj.ignorePatterns)) {
           throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns" must be an array of strings`)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,8 +53,6 @@ export interface ProjectConfig {
   examples?: Array<Record<string, string>>
   /** Per-layer scan directories and ignore patterns for orphan key detection. Keys are layer names. */
   orphanScan?: Record<string, {
-    /** Directories to scan for key usage (relative to project root). */
-    scanDirs: string[]
     /** Glob patterns for translation keys to exclude from orphan detection (e.g., "common.datetime.months.*"). */
     ignorePatterns?: string[]
   }>

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -26,6 +26,12 @@ export interface ScanResult {
   dynamicKeys: DynamicKeyUsage[]
   filesScanned: number
   uniqueKeys: Set<string>
+  /**
+   * All quoted strings containing at least one dot, extracted from source files.
+   * These are NOT confirmed i18n keys — they must be intersected with actual
+   * locale keys to identify bare key references (e.g., `{ name: 'common.actions.save', i18n: true }`).
+   */
+  bareStringCandidates: Set<string>
 }
 
 // ─── Extraction ─────────────────────────────────────────────────
@@ -169,12 +175,15 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   try {
     relativePaths = await glob(pat.filePatterns, { cwd: rootDir, ignore, dot: false, absolute: false })
   } catch {
-    return { usages: [], dynamicKeys: [], filesScanned: 0, uniqueKeys: new Set() }
+    return { usages: [], dynamicKeys: [], filesScanned: 0, uniqueKeys: new Set(), bareStringCandidates: new Set() }
   }
 
   const allUsages: KeyUsage[] = []
   const allDynamicKeys: DynamicKeyUsage[] = []
+  const bareStringCandidates = new Set<string>()
   let filesScanned = 0
+
+  const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)
@@ -189,13 +198,19 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     const { usages, dynamicKeys } = extractKeys(content, filePath, pat)
     allUsages.push(...usages)
     allDynamicKeys.push(...dynamicKeys)
+
+    BARE_DOTTED_STRING.lastIndex = 0
+    for (const match of content.matchAll(BARE_DOTTED_STRING)) {
+      bareStringCandidates.add(match[2])
+    }
+
     filesScanned++
   }
 
   const uniqueKeys = new Set(allUsages.map(u => u.key))
-  log.debug(`Scanned ${filesScanned} files, found ${uniqueKeys.size} unique keys, ${allDynamicKeys.length} dynamic references`)
+  log.debug(`Scanned ${filesScanned} files, found ${uniqueKeys.size} unique keys, ${allDynamicKeys.length} dynamic references, ${bareStringCandidates.size} bare string candidates`)
 
-  return { usages: allUsages, dynamicKeys: allDynamicKeys, filesScanned, uniqueKeys }
+  return { usages: allUsages, dynamicKeys: allDynamicKeys, filesScanned, uniqueKeys, bareStringCandidates }
 }
 
 // ─── Utilities ──────────────────────────────────────────────────

--- a/src/scanner/patterns.ts
+++ b/src/scanner/patterns.ts
@@ -22,22 +22,22 @@ export interface ScanPatternSet {
 // ─── Vue / Nuxt Patterns ────────────────────────────────────────
 
 /**
- * Matches static i18n calls: $t('key'), t('key'), this.$t('key'), and double-quote variants.
- * Group 1: callee ($t | t | this.$t)
+ * Matches static i18n calls: $t('key'), t('key'), this.$t('key'), $te('key'), this.$te('key'), and double-quote variants.
+ * Group 1: callee ($t | t | this.$t | $te | this.$te)
  * Group 2: quote character
  * Group 3: the key string
  */
 const VUE_STATIC_KEY = /(?<!\w)(this\.\$te?|\$te?|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
 
 /**
- * Matches dynamic i18n calls with template literals: $t(`prefix.${var}`), t(`...`), this.$t(`...`)
+ * Matches dynamic i18n calls with template literals: $t(`prefix.${var}`), t(`...`), this.$t(`...`), $te(`...`), this.$te(`...`)
  * Group 1: callee
  * Group 2: template literal content (without backticks)
  */
 const VUE_DYNAMIC_KEY = /(?<!\w)(this\.\$te?|\$te?|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
 
 /**
- * Matches concatenation-based dynamic keys: t('prefix.' + var), $t("key." + expr)
+ * Matches concatenation-based dynamic keys: t('prefix.' + var), $t("key." + expr), $te('prefix.' + var), this.$te("key." + expr)
  * Group 1: callee
  * Group 2: quote character
  * Group 3: the static prefix string

--- a/src/scanner/patterns.ts
+++ b/src/scanner/patterns.ts
@@ -27,14 +27,14 @@ export interface ScanPatternSet {
  * Group 2: quote character
  * Group 3: the key string
  */
-const VUE_STATIC_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
+const VUE_STATIC_KEY = /(?<!\w)(this\.\$te?|\$te?|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2/g
 
 /**
  * Matches dynamic i18n calls with template literals: $t(`prefix.${var}`), t(`...`), this.$t(`...`)
  * Group 1: callee
  * Group 2: template literal content (without backticks)
  */
-const VUE_DYNAMIC_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
+const VUE_DYNAMIC_KEY = /(?<!\w)(this\.\$te?|\$te?|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
 
 /**
  * Matches concatenation-based dynamic keys: t('prefix.' + var), $t("key." + expr)
@@ -42,7 +42,7 @@ const VUE_DYNAMIC_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*`((?:[^`]|\\.)*)`/g
  * Group 2: quote character
  * Group 3: the static prefix string
  */
-const VUE_CONCAT_KEY = /(?<!\w)(this\.\$t|\$t|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2\s*\+/g
+const VUE_CONCAT_KEY = /(?<!\w)(this\.\$te?|\$te?|\bt)\s*\(\s*(['"])((?:(?!\2).)*)\2\s*\+/g
 
 export const VUE_NUXT_PATTERNS: ScanPatternSet = {
   label: 'Vue / Nuxt',

--- a/src/server.ts
+++ b/src/server.ts
@@ -1844,11 +1844,9 @@ export function createServer(): McpServer {
           const ignorePatterns = resolveOrphanIgnorePatterns(config, layerName)
           const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
 
-          const keySet = new Set(keys)
-
           for (const key of keys) {
             if (combinedUniqueKeys.has(key)) continue
-            if (combinedBareStrings.has(key) && keySet.has(key)) continue
+            if (combinedBareStrings.has(key)) continue
             if (dynamicKeyRegexes.some(re => re.test(key))) {
               totalDynamicMatchedCount++
               continue
@@ -2173,11 +2171,9 @@ export function createServer(): McpServer {
           const dynamicKeyRegexes = buildDynamicKeyRegexes(layerDynamicKeys)
           const ignorePatterns = resolveOrphanIgnorePatterns(config, layerName)
           const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
-          const keySet = new Set(keys)
-
           const orphans = keys.filter((k) => {
             if (combinedUniqueKeys.has(k)) return false
-            if (combinedBareStrings.has(k) && keySet.has(k)) return false
+            if (combinedBareStrings.has(k)) return false
             if (dynamicKeyRegexes.some(re => re.test(k))) {
               dynamicMatchedCount++
               return false

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,16 +54,6 @@ export function computeMaxTokens(batchKeyCount: number): number {
   return Math.min(16384, batchKeyCount * 40 + 512)
 }
 
-function resolveOrphanScanDirs(
-  config: I18nConfig,
-  layer: string | undefined,
-): string[] | undefined {
-  if (!layer || !config.projectConfig?.orphanScan) return undefined
-  const layerConfig = config.projectConfig.orphanScan[layer]
-  if (!layerConfig) return undefined
-  return layerConfig.scanDirs.map(d => resolve(config.rootDir, d))
-}
-
 // ─── Report output helpers ──────────────────────────────────────
 
 const DEFAULT_REPORT_DIR = '.i18n-reports'
@@ -79,11 +69,6 @@ export function validateReportPath(baseDir: string, absPath: string): void {
   }
 }
 
-/**
- * Resolve the report file path from project config.
- * Returns undefined if reportOutput is not configured,
- * or the absolute path to `<reportDir>/<toolName>.json`.
- */
 function resolveReportFilePath(
   config: I18nConfig,
   dir: string,
@@ -1770,7 +1755,6 @@ export function createServer(): McpServer {
         const dir = projectDir ?? process.cwd()
         const config = await detectI18nConfig(dir)
 
-        // Determine which locale to read keys from
         const localeCode = locale ?? config.defaultLocale
         const localeDef = findLocale(config, localeCode)
         if (!localeDef) {
@@ -1780,7 +1764,6 @@ export function createServer(): McpServer {
           )
         }
 
-        // Determine layers to check
         const layersToCheck = layer
           ? config.localeDirs.filter(d => d.layer === layer)
           : config.localeDirs.filter(d => !d.aliasOf)
@@ -1792,7 +1775,6 @@ export function createServer(): McpServer {
           throw new ToolError('No locale directories found.', 'LAYER_NOT_FOUND')
         }
 
-        // Reject alias layers — they share files with their target layer
         if (layer && layersToCheck[0]?.aliasOf) {
           throw new ToolError(
             `Layer "${layer}" is an alias of "${layersToCheck[0].aliasOf}". Use the target layer instead.`,
@@ -1800,7 +1782,7 @@ export function createServer(): McpServer {
           )
         }
 
-        const allTranslationKeys = new Map<string, string>()
+        const keysByLayer = new Map<string, { keys: string[]; localeDir: LocaleDir }>()
         for (const localeDir of layersToCheck) {
           let data: Record<string, unknown>
           try {
@@ -1809,14 +1791,11 @@ export function createServer(): McpServer {
             continue
           }
           if (Object.keys(data).length === 0) continue
-
-          const leafKeys = getLeafKeys(data)
-          for (const key of leafKeys) {
-            allTranslationKeys.set(key, localeDir.layer)
-          }
+          keysByLayer.set(localeDir.layer, { keys: getLeafKeys(data), localeDir })
         }
 
-        if (allTranslationKeys.size === 0) {
+        const totalKeys = [...keysByLayer.values()].reduce((sum, v) => sum + v.keys.length, 0)
+        if (totalKeys === 0) {
           const emptyOutput = { orphanKeys: [], summary: { totalKeys: 0, orphanCount: 0, filesScanned: 0, message: 'No translation keys found in locale files.' } }
           const reportPath = resolveReportFilePath(config, dir, 'find_orphan_keys')
           if (reportPath) {
@@ -1829,58 +1808,61 @@ export function createServer(): McpServer {
             }
           }
           return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify(emptyOutput, null, 2),
-              },
-            ],
+            content: [{ type: 'text' as const, text: JSON.stringify(emptyOutput, null, 2) }],
           }
         }
 
-        // Determine directories to scan for source code.
-        // Use all layer roots (not just those with locale dirs) so layers without
-        // i18n/locales/ still have their source files scanned for key usage.
-        const dirsToScan = scanDirs ?? resolveOrphanScanDirs(config, layer) ?? config.layerRootDirs
-
-        // Scan all source files for key usage
-        const combinedUniqueKeys = new Set<string>()
-        let totalFilesScanned = 0
-        const allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
-
-        for (const scanDir of dirsToScan) {
-          const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
-          totalFilesScanned += result.filesScanned
-          for (const key of result.uniqueKeys) {
-            combinedUniqueKeys.add(key)
-          }
-          allDynamicKeys.push(...result.dynamicKeys)
-        }
-
-        // Find orphan keys: translation keys not referenced in source code
-        const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeys)
-        const ignorePatterns = resolveOrphanIgnorePatterns(config, layer)
-        const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
-
+        // Per-layer scanning: scan from each layer's rootDir.
+        // Root layer's rootDir = project root → scans everything (root + all child apps).
+        // App layer's rootDir = app dir → scans only that app.
+        // When explicit scanDirs are provided, use them for all layers (backward compat).
         const orphanKeys: Array<{ key: string; layer: string }> = []
-        let dynamicMatchedCount = 0
-        let ignoredCount = 0
-        for (const [key, keyLayer] of allTranslationKeys) {
-          if (!combinedUniqueKeys.has(key)) {
+        let totalFilesScanned = 0
+        let totalDynamicMatchedCount = 0
+        let totalIgnoredCount = 0
+        const allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
+        const dirsScanned: string[] = []
+
+        for (const [layerName, { keys, localeDir }] of keysByLayer) {
+          const layerScanDirs = scanDirs ?? [localeDir.layerRootDir]
+          dirsScanned.push(...layerScanDirs)
+
+          const combinedUniqueKeys = new Set<string>()
+          const combinedBareStrings = new Set<string>()
+          const layerDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
+
+          for (const scanDir of layerScanDirs) {
+            const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
+            totalFilesScanned += result.filesScanned
+            for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
+            for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
+            layerDynamicKeys.push(...result.dynamicKeys)
+          }
+
+          allDynamicKeys.push(...layerDynamicKeys)
+          const dynamicKeyRegexes = buildDynamicKeyRegexes(layerDynamicKeys)
+          const ignorePatterns = resolveOrphanIgnorePatterns(config, layerName)
+          const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
+
+          const keySet = new Set(keys)
+
+          for (const key of keys) {
+            if (combinedUniqueKeys.has(key)) continue
+            if (combinedBareStrings.has(key) && keySet.has(key)) continue
             if (dynamicKeyRegexes.some(re => re.test(key))) {
-              dynamicMatchedCount++
-            } else if (ignoreRegexes.length > 0 && ignoreRegexes.some(re => re.test(key))) {
-              ignoredCount++
-            } else {
-              orphanKeys.push({ key, layer: keyLayer })
+              totalDynamicMatchedCount++
+              continue
             }
+            if (ignoreRegexes.length > 0 && ignoreRegexes.some(re => re.test(key))) {
+              totalIgnoredCount++
+              continue
+            }
+            orphanKeys.push({ key, layer: layerName })
           }
         }
 
-        // Sort orphans by layer, then key
         orphanKeys.sort((a, b) => a.layer.localeCompare(b.layer) || a.key.localeCompare(b.key))
 
-        // Group by layer for readability
         const byLayer: Record<string, string[]> = {}
         for (const { key, layer: keyLayer } of orphanKeys) {
           if (!byLayer[keyLayer]) byLayer[keyLayer] = []
@@ -1890,14 +1872,14 @@ export function createServer(): McpServer {
         const output = {
           orphanKeys: byLayer,
           summary: {
-            totalKeys: allTranslationKeys.size,
+            totalKeys,
             orphanCount: orphanKeys.length,
-            dynamicMatchedCount,
-            ignoredCount,
-            usedCount: allTranslationKeys.size - orphanKeys.length,
+            dynamicMatchedCount: totalDynamicMatchedCount,
+            ignoredCount: totalIgnoredCount,
+            usedCount: totalKeys - orphanKeys.length,
             filesScanned: totalFilesScanned,
             layersChecked: layersToCheck.map(d => d.layer),
-            dirsScanned: dirsToScan,
+            dirsScanned: [...new Set(dirsScanned)],
             locale: localeCode,
           },
           dynamicKeyWarning: allDynamicKeys.length > 0
@@ -1924,12 +1906,7 @@ export function createServer(): McpServer {
         }
 
         return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(output, null, 2),
-            },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
         }
       } catch (error) {
         return toolErrorResponse('finding orphan keys', error)
@@ -2131,7 +2108,7 @@ export function createServer(): McpServer {
           )
         }
 
-        const keysByLayer = new Map<string, string[]>()
+        const keysByLayer = new Map<string, { keys: string[]; localeDir: LocaleDir }>()
         for (const localeDir of layersToCheck) {
           let data: Record<string, unknown>
           try {
@@ -2140,11 +2117,10 @@ export function createServer(): McpServer {
             continue
           }
           if (Object.keys(data).length === 0) continue
-
-          keysByLayer.set(localeDir.layer, getLeafKeys(data))
+          keysByLayer.set(localeDir.layer, { keys: getLeafKeys(data), localeDir })
         }
 
-        const totalKeys = [...keysByLayer.values()].reduce((sum, keys) => sum + keys.length, 0)
+        const totalKeys = [...keysByLayer.values()].reduce((sum, v) => sum + v.keys.length, 0)
         if (totalKeys === 0) {
           const emptyOutput = { orphanKeys: {}, removed: {}, summary: { totalKeys: 0, orphanCount: 0, message: 'No translation keys found.' } }
           const emptyReportPath = resolveReportFilePath(config, dir, 'cleanup_unused_translations')
@@ -2165,37 +2141,43 @@ export function createServer(): McpServer {
           }
         }
 
-        // Scan source files for key usage.
-        // Use all layer roots (not just those with locale dirs) so layers without
-        // i18n/locales/ still have their source files scanned for key usage.
-        const dirsToScan = scanDirs ?? resolveOrphanScanDirs(config, layer) ?? config.layerRootDirs
-        const combinedUniqueKeys = new Set<string>()
-        let totalFilesScanned = 0
-        const allDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
-
-        for (const scanDir of dirsToScan) {
-          const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
-          totalFilesScanned += result.filesScanned
-          for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
-          allDynamicKeys.push(...result.dynamicKeys.map(dk => ({
-            expression: dk.expression,
-            file: toRelativePath(dk.file, dir),
-            line: dk.line,
-          })))
-        }
-
-        // Find orphan keys per layer
-        const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeys)
-        const ignorePatterns = resolveOrphanIgnorePatterns(config, layer)
-        const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
-
+        // Per-layer scanning: scan from each layer's rootDir.
+        // Root layer scans project root (includes all children). App layers scan only their own dir.
         const orphansByLayer: Record<string, string[]> = {}
         let orphanCount = 0
+        let totalFilesScanned = 0
         let dynamicMatchedCount = 0
         let ignoredCount = 0
-        for (const [layerName, keys] of keysByLayer) {
+        const allDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
+
+        for (const [layerName, { keys, localeDir }] of keysByLayer) {
+          const layerScanDirs = scanDirs ?? [localeDir.layerRootDir]
+
+          const combinedUniqueKeys = new Set<string>()
+          const combinedBareStrings = new Set<string>()
+          const layerDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
+
+          for (const scanDir of layerScanDirs) {
+            const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
+            totalFilesScanned += result.filesScanned
+            for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
+            for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
+            layerDynamicKeys.push(...result.dynamicKeys.map(dk => ({
+              expression: dk.expression,
+              file: toRelativePath(dk.file, dir),
+              line: dk.line,
+            })))
+          }
+
+          allDynamicKeys.push(...layerDynamicKeys)
+          const dynamicKeyRegexes = buildDynamicKeyRegexes(layerDynamicKeys)
+          const ignorePatterns = resolveOrphanIgnorePatterns(config, layerName)
+          const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
+          const keySet = new Set(keys)
+
           const orphans = keys.filter((k) => {
             if (combinedUniqueKeys.has(k)) return false
+            if (combinedBareStrings.has(k) && keySet.has(k)) return false
             if (dynamicKeyRegexes.some(re => re.test(k))) {
               dynamicMatchedCount++
               return false

--- a/tests/config/project-config.test.ts
+++ b/tests/config/project-config.test.ts
@@ -182,7 +182,6 @@ describe('loadProjectConfig', () => {
       await writeFile(configPath, JSON.stringify({
         orphanScan: {
           root: {
-            scanDirs: ['apps/shop'],
             ignorePatterns: ['common.datetime.**', 'pages.*.title']
           }
         }
@@ -213,7 +212,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({
-        orphanScan: { root: { scanDirs: ['src'] } }
+        orphanScan: { root: {} }
       }), 'utf-8')
       const config = await loadProjectConfig(tmpDir)
       expect(config!.orphanScan!.root.ignorePatterns).toBeUndefined()
@@ -240,7 +239,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({
-        orphanScan: { root: { scanDirs: ['src'], ignorePatterns: 'not-an-array' } }
+        orphanScan: { root: { ignorePatterns: 'not-an-array' } }
       }), 'utf-8')
       await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns" must be an array of strings')
     } finally {
@@ -264,7 +263,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({
-        orphanScan: { root: { scanDirs: ['src'], ignorePatterns: ['valid.*', 123] } }
+        orphanScan: { root: { ignorePatterns: ['valid.*', 123] } }
       }), 'utf-8')
       await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns[1]" must be a string')
     } finally {

--- a/tests/config/project-config.test.ts
+++ b/tests/config/project-config.test.ts
@@ -112,18 +112,18 @@ describe('loadProjectConfig', () => {
       await writeFile(configPath, JSON.stringify({
         orphanScan: {
           root: {
-            scanDirs: ['apps/shop', 'apps/admin', 'packages/shared']
+            ignorePatterns: ['common.datetime.**']
           },
           'app-admin': {
-            scanDirs: ['apps/admin']
+            ignorePatterns: ['admin.legacy.*']
           }
         }
       }), 'utf-8')
       const config = await loadProjectConfig(tmpDir)
       expect(config).not.toBeNull()
       expect(config!.orphanScan).toBeDefined()
-      expect(config!.orphanScan!.root.scanDirs).toEqual(['apps/shop', 'apps/admin', 'packages/shared'])
-      expect(config!.orphanScan!['app-admin'].scanDirs).toEqual(['apps/admin'])
+      expect(config!.orphanScan!.root.ignorePatterns).toEqual(['common.datetime.**'])
+      expect(config!.orphanScan!['app-admin'].ignorePatterns).toEqual(['admin.legacy.*'])
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -140,23 +140,25 @@ describe('loadProjectConfig', () => {
     }
   })
 
-  it('throws when orphanScan entry is missing scanDirs', async () => {
+  it('accepts orphanScan entry with only ignorePatterns', async () => {
     await mkdir(tmpDir, { recursive: true })
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
-      await writeFile(configPath, JSON.stringify({ orphanScan: { root: {} } }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('scanDirs')
+      await writeFile(configPath, JSON.stringify({ orphanScan: { root: { ignorePatterns: ['common.**'] } } }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config?.orphanScan?.root?.ignorePatterns).toEqual(['common.**'])
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
   })
 
-  it('throws when orphanScan scanDirs contains non-strings', async () => {
+  it('accepts orphanScan entry with empty object', async () => {
     await mkdir(tmpDir, { recursive: true })
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
-      await writeFile(configPath, JSON.stringify({ orphanScan: { root: { scanDirs: [123] } } }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('scanDirs')
+      await writeFile(configPath, JSON.stringify({ orphanScan: { root: {} } }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config?.orphanScan?.root).toEqual({})
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }

--- a/tests/fixtures/config.ts
+++ b/tests/fixtures/config.ts
@@ -51,9 +51,7 @@ const projectConfig = {
     },
   ],
   orphanScan: {
-    root: {
-      scanDirs: ['.', 'app-admin'],
-    },
+    root: {},
   },
 }
 


### PR DESCRIPTION
## Summary

Overhauls orphan key detection to work correctly in Nuxt monorepos with layers. Reduces false positives by **37%** (2,253 → 1,423 on a real 7,000-key project).

## Changes

- **Bare string matching**: Extract all dotted quoted strings from source files and intersect with known locale keys. Catches `{ name: 'common.actions.save', i18n: true }` patterns invisible to `t()`/`$t()` scanning (~799 keys in test project)
- **Per-layer scoping**: Each layer scans from its own `layerRootDir`. Root layer scans entire project (shared keys checked everywhere). App layers scan only their own directory (no cross-contamination from siblings)
- **Drop `scanDirs` config**: Removed from `orphanScan` — layer scoping via `layerRootDir` makes it unnecessary. Only `ignorePatterns` remains
- **`$te()` support**: `VUE_STATIC_KEY`, `VUE_DYNAMIC_KEY`, `VUE_CONCAT_KEY` now match `$te`/`this.$te`

## Real-world results (anny-ui: 7,032 keys, 7 layers)

| Layer | Keys | Orphans | FP Rate |
|-------|------|---------|---------|
| root | 1,775 | 422 | ~0% |
| app-admin | 4,586 | 789 | ~18% |
| app-shop | 478 | 190 | ~8% |
| app-designer | 180 | 20 | low |
| **Total** | **7,032** | **1,423** | — |

Remaining false positives tracked in #97 (backtick literals) and #98 (cross-layer shared dirs).

## Testing

- 475/475 tests pass
- Typecheck clean
- Build succeeds
- Verified against production monorepo with 7 layers

## Related Issues

Closes #95 (partial — addresses the core scanning gaps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated orphanScan configuration documentation to reflect automatic directory scanning

* **New Features**
  * Orphan scan directories now automatically determined from each layer's root
  * Enhanced orphan key detection with bare string candidate matching
  * Extended i18n function recognition to support `$te` in addition to `$t`

* **Refactor**
  * Simplified orphanScan configuration to remove manual directory specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->