### PR TITLE
fix: backtick static keys and cross-layer orphan scanning (#97, #98)

### DIFF
--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -71,8 +71,18 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
     for (const regex of pat.dynamicKeyPatterns) {
       regex.lastIndex = 0
       for (const match of line.matchAll(regex)) {
+        const callee = match[1]
         const expression = match[2]
-        if (!expression.includes('${') && !expression.includes('{$')) continue
+        if (!expression.includes('${') && !expression.includes('{$')) {
+          if (pat.promoteStaticDynamicMatches) {
+            const key = expression
+            if (!key) continue
+            if (key.includes('{$')) continue
+            if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+            usages.push({ key, file: filePath, line: lineNumber, callee })
+          }
+          continue
+        }
         const normalized = expression.includes('{$')
           ? expression.replace(/\{\$[^}]+\}/g, '${_}')
           : expression
@@ -247,4 +257,39 @@ export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
     }
     return new RegExp(`^${regexStr}$`)
   })
+}
+
+// ─── Layer scan planning ────────────────────────────────────────
+
+export interface LayerScanPlan {
+  dir: string
+  excludeDirs: string[]
+}
+
+interface LayerInfo {
+  layer: string
+  layerRootDir: string
+}
+
+export function buildLayerScanPlan(
+  localeDir: LayerInfo,
+  allLocaleDirs: LayerInfo[],
+  userExcludeDirs: string[] | undefined,
+): LayerScanPlan[] {
+  const baseExclude = userExcludeDirs ?? []
+  const plans: LayerScanPlan[] = [{ dir: localeDir.layerRootDir, excludeDirs: baseExclude }]
+
+  const rootLocaleDir = allLocaleDirs.find(ld =>
+    ld.layer !== localeDir.layer
+    && localeDir.layerRootDir.startsWith(ld.layerRootDir + '/'),
+  )
+  if (!rootLocaleDir) return plans
+
+  const siblingAppDirs = allLocaleDirs
+    .filter(ld => ld.layer !== rootLocaleDir.layer && ld.layer !== localeDir.layer)
+    .map(ld => relative(rootLocaleDir.layerRootDir, ld.layerRootDir))
+    .filter(rel => !rel.startsWith('..'))
+
+  plans.push({ dir: rootLocaleDir.layerRootDir, excludeDirs: [...baseExclude, ...siblingAppDirs] })
+  return plans
 }

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -77,7 +77,6 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
           if (pat.promoteStaticDynamicMatches) {
             const key = expression
             if (!key) continue
-            if (key.includes('{$')) continue
             if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
             usages.push({ key, file: filePath, line: lineNumber, callee })
           }

--- a/src/scanner/patterns.ts
+++ b/src/scanner/patterns.ts
@@ -17,6 +17,11 @@ export interface ScanPatternSet {
    * Vue `t('word')` without a dot is likely not i18n — `emit`, `import`, etc.
    */
   requiresDotForCallee?: (callee: string) => boolean
+  /**
+   * When true, dynamic-pattern matches without interpolation are promoted to static keys.
+   * Enables backtick literals like `t(\`foo.bar\`)` to be recognized as static.
+   */
+  promoteStaticDynamicMatches?: boolean
 }
 
 // ─── Vue / Nuxt Patterns ────────────────────────────────────────
@@ -52,6 +57,7 @@ export const VUE_NUXT_PATTERNS: ScanPatternSet = {
   dynamicKeyPatterns: [VUE_DYNAMIC_KEY],
   concatKeyPatterns: [VUE_CONCAT_KEY],
   requiresDotForCallee: (callee: string) => callee === 't',
+  promoteStaticDynamicMatches: true,
 }
 
 // ─── Laravel / PHP Patterns ─────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import {
   renameNestedKey,
   validateTranslationValue,
 } from './io/key-operations.js'
-import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from './scanner/code-scanner.js'
+import { scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes, buildLayerScanPlan } from './scanner/code-scanner.js'
 import { getPatternSet } from './scanner/patterns.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
@@ -1824,15 +1824,17 @@ export function createServer(): McpServer {
         const dirsScanned: string[] = []
 
         for (const [layerName, { keys, localeDir }] of keysByLayer) {
-          const layerScanDirs = scanDirs ?? [localeDir.layerRootDir]
-          dirsScanned.push(...layerScanDirs)
+          const scanPlans = scanDirs
+            ? scanDirs.map(d => ({ dir: d, excludeDirs: excludeDirs ?? [] }))
+            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs)
+          dirsScanned.push(...scanPlans.map(p => p.dir))
 
           const combinedUniqueKeys = new Set<string>()
           const combinedBareStrings = new Set<string>()
           const layerDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
 
-          for (const scanDir of layerScanDirs) {
-            const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
+          for (const plan of scanPlans) {
+            const result = await scanSourceFiles(plan.dir, plan.excludeDirs, getPatternSet(config.localeFileFormat))
             totalFilesScanned += result.filesScanned
             for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
             for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
@@ -2149,14 +2151,16 @@ export function createServer(): McpServer {
         const allDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
 
         for (const [layerName, { keys, localeDir }] of keysByLayer) {
-          const layerScanDirs = scanDirs ?? [localeDir.layerRootDir]
+          const scanPlans = scanDirs
+            ? scanDirs.map(d => ({ dir: d, excludeDirs: excludeDirs ?? [] }))
+            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs)
 
           const combinedUniqueKeys = new Set<string>()
           const combinedBareStrings = new Set<string>()
           const layerDynamicKeys: Array<{ expression: string; file: string; line: number }> = []
 
-          for (const scanDir of layerScanDirs) {
-            const result = await scanSourceFiles(scanDir, excludeDirs, getPatternSet(config.localeFileFormat))
+          for (const plan of scanPlans) {
+            const result = await scanSourceFiles(plan.dir, plan.excludeDirs, getPatternSet(config.localeFileFormat))
             totalFilesScanned += result.filesScanned
             for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
             for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
+import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes, buildLayerScanPlan } from '../../src/scanner/code-scanner.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
@@ -135,10 +135,30 @@ describe('extractKeys', () => {
     })
 
     it('does not flag template literals without interpolation as dynamic', () => {
-      // A template literal without ${} is effectively static; the static regex
-      // won't match it, but it shouldn't be flagged as dynamic either
-      const { dynamicKeys } = extract("t(`common.actions.save`)")
+      const { dynamicKeys, usages } = extract("t(`common.actions.save`)")
       expect(dynamicKeys).toHaveLength(0)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'common.actions.save', callee: 't' })
+    })
+
+    it('promotes $t() backtick literal without interpolation to static key', () => {
+      const { usages, dynamicKeys } = extract("{{ $t(`components.displayPanels.closed.label`) }}")
+      expect(dynamicKeys).toHaveLength(0)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'components.displayPanels.closed.label', callee: '$t' })
+    })
+
+    it('promotes this.$te() backtick literal without interpolation to static key', () => {
+      const { usages, dynamicKeys } = extract("this.$te(`settings.checkout.title`)")
+      expect(dynamicKeys).toHaveLength(0)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'settings.checkout.title', callee: 'this.$te' })
+    })
+
+    it('still treats backtick literals WITH interpolation as dynamic', () => {
+      const { usages, dynamicKeys } = extract("$t(`prefix.${type}.suffix`)")
+      expect(dynamicKeys).toHaveLength(1)
+      expect(usages).toHaveLength(0)
     })
 
     it('detects multiple dynamic keys on separate lines', () => {
@@ -593,5 +613,45 @@ describe('toRelativePath', () => {
 
   it('returns just the filename when file is in root', () => {
     expect(toRelativePath('/project/App.vue', '/project')).toBe('App.vue')
+  })
+})
+
+describe('buildLayerScanPlan', () => {
+  const allDirs = [
+    { layer: 'root', layerRootDir: '/project' },
+    { layer: 'app-admin', layerRootDir: '/project/app-admin' },
+    { layer: 'app-shop', layerRootDir: '/project/app-shop' },
+    { layer: 'app-designer', layerRootDir: '/project/app-designer' },
+  ]
+
+  it('returns only own dir for root layer', () => {
+    const plans = buildLayerScanPlan(allDirs[0], allDirs, undefined)
+    expect(plans).toHaveLength(1)
+    expect(plans[0].dir).toBe('/project')
+    expect(plans[0].excludeDirs).toEqual([])
+  })
+
+  it('returns own dir + root dir for app layer, excluding siblings', () => {
+    const plans = buildLayerScanPlan(allDirs[1], allDirs, undefined)
+    expect(plans).toHaveLength(2)
+    expect(plans[0].dir).toBe('/project/app-admin')
+    expect(plans[1].dir).toBe('/project')
+    expect(plans[1].excludeDirs).toContain('app-shop')
+    expect(plans[1].excludeDirs).toContain('app-designer')
+    expect(plans[1].excludeDirs).not.toContain('app-admin')
+  })
+
+  it('passes user excludeDirs to all plans', () => {
+    const plans = buildLayerScanPlan(allDirs[2], allDirs, ['storybook'])
+    expect(plans[0].excludeDirs).toContain('storybook')
+    expect(plans[1].excludeDirs).toContain('storybook')
+    expect(plans[1].excludeDirs).toContain('app-admin')
+  })
+
+  it('returns only own dir when no parent layer exists', () => {
+    const standalone = [{ layer: 'standalone', layerRootDir: '/other/app' }]
+    const plans = buildLayerScanPlan(standalone[0], standalone, undefined)
+    expect(plans).toHaveLength(1)
+    expect(plans[0].dir).toBe('/other/app')
   })
 })


### PR DESCRIPTION
## Summary
Fixes two sources of false positive orphan keys:

1. **Backtick template literals without interpolation** (#97): `t(`foo.bar`)` is now recognized as a static key. Previously only single/double-quoted strings were matched, causing ~51 false positives in app-admin.

2. **Cross-layer scan for shared root code** (#98): App-layer orphan scans now also search the root layer's source files (excluding sibling app directories). This catches keys used from shared `components/`, `composables/`, `stores/` etc. Previously ~89 false positives in app-admin and ~13 in app-shop.

## Changes
- Add `promoteStaticDynamicMatches` flag to `ScanPatternSet` — when enabled, dynamic-pattern matches without interpolation are promoted to static keys
- Extract `buildLayerScanPlan()` to `code-scanner.ts` — computes scan directories per layer, adding root dir with sibling exclusions for non-root layers
- Update `find_orphan_keys` and `cleanup_unused_translations` to use `buildLayerScanPlan`

## Testing
- `pnpm typecheck` ✅
- `pnpm test` ✅ (482 tests, +7 new)
- `pnpm build` ✅

## Related Issues
Closes #97, closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added layer-based locale directory scanning with automatic sibling directory exclusion.
  * Enhanced translation key detection for Vue/Nuxt projects with improved pattern matching.

* **Improvements**
  * Improved classification of template literal patterns in source code scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->