### PR TITLE
refactor: make cross-layer parent scanning opt-in via includeParentLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ For IDE autocompletion, point to the schema:
 | `translationPrompt` | System prompt prepended to all translation requests |
 | `localeNotes` | Per-locale instructions — terminology constraints, formality, regional conventions. **Keys must match your locale codes exactly** (case-sensitive) |
 | `examples` | Few-shot translation examples demonstrating project style |
-| `orphanScan` | Per-layer config for orphan detection: `ignorePatterns` (glob patterns for keys to skip). Keys are layer names from `list_locale_dirs`. Each layer automatically scans from its own root directory |
+| `orphanScan` | Per-layer config for orphan detection: `ignorePatterns` (glob patterns for keys to skip), `includeParentLayer` (also scan shared root code for key usage in monorepos). Keys are layer names from `list_locale_dirs`. Each layer automatically scans from its own root directory |
 | `reportOutput` | `true` for default `.i18n-reports/` dir, or a string for a custom path. Diagnostic tools write full output to disk and return only a summary in the MCP response |
 | `samplingPreferences` | Override model preferences for `translate_missing` sampling. See [Model Selection](#model-selection-for-translations) |
 
@@ -338,7 +338,8 @@ For IDE autocompletion, point to the schema:
       "ignorePatterns": ["common.datetime.**", "common.countries.*"]
     },
     "app-admin": {
-      "ignorePatterns": ["admin.legacy.*"]
+      "ignorePatterns": ["admin.legacy.*"],
+      "includeParentLayer": true
     }
   },
   "reportOutput": true,

--- a/schema.json
+++ b/schema.json
@@ -100,6 +100,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "includeParentLayer": {
+            "type": "boolean",
+            "description": "When true, also scan the parent (root) layer's source code when checking for orphans in this app layer. Useful in monorepos where shared root code (components/, composables/, etc.) references app-layer keys. Default: false.",
+            "default": false
           }
         },
         "additionalProperties": false

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -172,10 +172,10 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
         throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" must be an object`)
       }
       const layerObj = layerConfig as Record<string, unknown>
-      const knownLayerKeys = new Set(['ignorePatterns'])
+      const knownLayerKeys = new Set(['ignorePatterns', 'includeParentLayer'])
       for (const k of Object.keys(layerObj)) {
         if (!knownLayerKeys.has(k)) {
-          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" has unknown property "${k}". Allowed: ignorePatterns`)
+          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" has unknown property "${k}". Allowed: ignorePatterns, includeParentLayer`)
         }
       }
       if ('ignorePatterns' in layerObj) {
@@ -187,6 +187,9 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
             throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns[${i}]" must be a string`)
           }
         }
+      }
+      if ('includeParentLayer' in layerObj && typeof layerObj.includeParentLayer !== 'boolean') {
+        throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.includeParentLayer" must be a boolean`)
       }
     }
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -55,6 +55,8 @@ export interface ProjectConfig {
   orphanScan?: Record<string, {
     /** Glob patterns for translation keys to exclude from orphan detection (e.g., "common.datetime.months.*"). */
     ignorePatterns?: string[]
+    /** When true, also scan the parent (root) layer's source code for key usage. Useful in monorepos with shared root code. */
+    includeParentLayer?: boolean
   }>
   /** Default output directory for diagnostic tool reports. Set to true for '.i18n-reports/', or a string for a custom relative path. */
   reportOutput?: string | boolean

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -274,9 +274,12 @@ export function buildLayerScanPlan(
   localeDir: LayerInfo,
   allLocaleDirs: LayerInfo[],
   userExcludeDirs: string[] | undefined,
+  includeParentLayer = false,
 ): LayerScanPlan[] {
   const baseExclude = userExcludeDirs ?? []
   const plans: LayerScanPlan[] = [{ dir: localeDir.layerRootDir, excludeDirs: baseExclude }]
+
+  if (!includeParentLayer) return plans
 
   const rootLocaleDir = allLocaleDirs.find(ld =>
     ld.layer !== localeDir.layer

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,6 +92,13 @@ function resolveOrphanIgnorePatterns(
   return layerConfig.ignorePatterns
 }
 
+function resolveIncludeParentLayer(
+  config: I18nConfig,
+  layer: string,
+): boolean {
+  return config.projectConfig?.orphanScan?.[layer]?.includeParentLayer ?? false
+}
+
 // ─── Shared helpers ───────────────────────────────────────────────
 
 /**
@@ -1826,7 +1833,7 @@ export function createServer(): McpServer {
         for (const [layerName, { keys, localeDir }] of keysByLayer) {
           const scanPlans = scanDirs
             ? scanDirs.map(d => ({ dir: d, excludeDirs: excludeDirs ?? [] }))
-            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs)
+            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs, resolveIncludeParentLayer(config, layerName))
           dirsScanned.push(...scanPlans.map(p => p.dir))
 
           const combinedUniqueKeys = new Set<string>()
@@ -2153,7 +2160,7 @@ export function createServer(): McpServer {
         for (const [layerName, { keys, localeDir }] of keysByLayer) {
           const scanPlans = scanDirs
             ? scanDirs.map(d => ({ dir: d, excludeDirs: excludeDirs ?? [] }))
-            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs)
+            : buildLayerScanPlan(localeDir, config.localeDirs, excludeDirs, resolveIncludeParentLayer(config, layerName))
 
           const combinedUniqueKeys = new Set<string>()
           const combinedBareStrings = new Set<string>()

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -631,8 +631,15 @@ describe('buildLayerScanPlan', () => {
     expect(plans[0].excludeDirs).toEqual([])
   })
 
-  it('returns own dir + root dir for app layer, excluding siblings', () => {
+  it('returns only own dir for app layer by default (includeParentLayer=false)', () => {
     const plans = buildLayerScanPlan(allDirs[1], allDirs, undefined)
+    expect(plans).toHaveLength(1)
+    expect(plans[0].dir).toBe('/project/app-admin')
+    expect(plans[0].excludeDirs).toEqual([])
+  })
+
+  it('returns own dir + root dir when includeParentLayer=true, excluding siblings', () => {
+    const plans = buildLayerScanPlan(allDirs[1], allDirs, undefined, true)
     expect(plans).toHaveLength(2)
     expect(plans[0].dir).toBe('/project/app-admin')
     expect(plans[1].dir).toBe('/project')
@@ -641,16 +648,16 @@ describe('buildLayerScanPlan', () => {
     expect(plans[1].excludeDirs).not.toContain('app-admin')
   })
 
-  it('passes user excludeDirs to all plans', () => {
-    const plans = buildLayerScanPlan(allDirs[2], allDirs, ['storybook'])
+  it('passes user excludeDirs to all plans when includeParentLayer=true', () => {
+    const plans = buildLayerScanPlan(allDirs[2], allDirs, ['storybook'], true)
     expect(plans[0].excludeDirs).toContain('storybook')
     expect(plans[1].excludeDirs).toContain('storybook')
     expect(plans[1].excludeDirs).toContain('app-admin')
   })
 
-  it('returns only own dir when no parent layer exists', () => {
+  it('returns only own dir when no parent layer exists even with includeParentLayer=true', () => {
     const standalone = [{ layer: 'standalone', layerRootDir: '/other/app' }]
-    const plans = buildLayerScanPlan(standalone[0], standalone, undefined)
+    const plans = buildLayerScanPlan(standalone[0], standalone, undefined, true)
     expect(plans).toHaveLength(1)
     expect(plans[0].dir).toBe('/other/app')
   })


### PR DESCRIPTION
## Summary

- Makes `buildLayerScanPlan` parent-layer scanning **opt-in** instead of always-on
- Adds `orphanScan.<layer>.includeParentLayer` config option (default: `false`)
- Updates JSON schema, TypeScript types, config validation, README docs

## Why

PR #102 introduced automatic parent-layer scanning for all app layers — scanning shared root code (components/, composables/) when checking for orphans in app layers. This assumed a monorepo where root code is shared, which isn't universal and could hide real orphans in projects with independent apps.

Now users explicitly opt in per layer:

```json
{
  "orphanScan": {
    "app-admin": { "includeParentLayer": true }
  }
}
```

## Changes

- `src/scanner/code-scanner.ts`: Added `includeParentLayer` param to `buildLayerScanPlan()` (default `false`)
- `src/server.ts`: New `resolveIncludeParentLayer()` helper, passed to both `find_orphan_keys` and `cleanup_unused_translations`
- `src/config/types.ts`: Added `includeParentLayer?: boolean` to orphanScan layer config
- `src/config/project-config.ts`: Validation for the new field
- `schema.json`: Added `includeParentLayer` to orphanScan layer schema
- `tests/scanner/code-scanner.test.ts`: Updated tests — default now returns only own dir; parent scan requires explicit opt-in
- `README.md`: Documented `includeParentLayer` in config table and example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `includeParentLayer` boolean configuration option for orphan scanning per layer. When enabled, orphan key detection scans the parent (root) layer for code references in addition to the current layer, improving detection accuracy for shared code in monorepo setups. Defaults to `false` for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->