### PR TITLE
feat: auto-detect shared langDir for orphan scanning

### DIFF
--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -268,6 +268,8 @@ export interface LayerScanPlan {
 interface LayerInfo {
   layer: string
   layerRootDir: string
+  /** When set, this layer's locale files physically live in another layer's directory */
+  aliasOf?: string
 }
 
 export function buildLayerScanPlan(
@@ -279,6 +281,11 @@ export function buildLayerScanPlan(
   const baseExclude = userExcludeDirs ?? []
   const plans: LayerScanPlan[] = [{ dir: localeDir.layerRootDir, excludeDirs: baseExclude }]
 
+  const aliasLayers = allLocaleDirs.filter(ld => ld.aliasOf === localeDir.layer)
+  for (const alias of aliasLayers) {
+    plans.push({ dir: alias.layerRootDir, excludeDirs: baseExclude })
+  }
+
   if (!includeParentLayer) return plans
 
   const rootLocaleDir = allLocaleDirs.find(ld =>
@@ -288,7 +295,7 @@ export function buildLayerScanPlan(
   if (!rootLocaleDir) return plans
 
   const siblingAppDirs = allLocaleDirs
-    .filter(ld => ld.layer !== rootLocaleDir.layer && ld.layer !== localeDir.layer)
+    .filter(ld => ld.layer !== rootLocaleDir.layer && ld.layer !== localeDir.layer && !aliasLayers.some(a => a.layer === ld.layer))
     .map(ld => relative(rootLocaleDir.layerRootDir, ld.layerRootDir))
     .filter(rel => !rel.startsWith('..'))
 

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -661,4 +661,44 @@ describe('buildLayerScanPlan', () => {
     expect(plans).toHaveLength(1)
     expect(plans[0].dir).toBe('/other/app')
   })
+
+  it('includes alias layer source dir when another layer aliases the scanned layer', () => {
+    const dirsWithAlias = [
+      { layer: 'root', layerRootDir: '/project' },
+      { layer: 'app-shop', layerRootDir: '/project/app-shop' },
+      { layer: 'app-outlook', layerRootDir: '/project/app-outlook', aliasOf: 'app-shop' },
+    ]
+    const plans = buildLayerScanPlan(dirsWithAlias[1], dirsWithAlias, undefined)
+    expect(plans).toHaveLength(2)
+    expect(plans[0].dir).toBe('/project/app-shop')
+    expect(plans[1].dir).toBe('/project/app-outlook')
+  })
+
+  it('does not include alias layer dir when scanning a layer that is not the alias target', () => {
+    const dirsWithAlias = [
+      { layer: 'root', layerRootDir: '/project' },
+      { layer: 'app-shop', layerRootDir: '/project/app-shop' },
+      { layer: 'app-outlook', layerRootDir: '/project/app-outlook', aliasOf: 'app-shop' },
+    ]
+    const plans = buildLayerScanPlan(dirsWithAlias[0], dirsWithAlias, undefined)
+    expect(plans).toHaveLength(1)
+    expect(plans[0].dir).toBe('/project')
+  })
+
+  it('excludes alias layer from sibling exclusion when includeParentLayer=true', () => {
+    const dirsWithAlias = [
+      { layer: 'root', layerRootDir: '/project' },
+      { layer: 'app-shop', layerRootDir: '/project/app-shop' },
+      { layer: 'app-admin', layerRootDir: '/project/app-admin' },
+      { layer: 'app-outlook', layerRootDir: '/project/app-outlook', aliasOf: 'app-shop' },
+    ]
+    const plans = buildLayerScanPlan(dirsWithAlias[1], dirsWithAlias, undefined, true)
+    expect(plans).toHaveLength(3)
+    expect(plans[0].dir).toBe('/project/app-shop')
+    expect(plans[1].dir).toBe('/project/app-outlook')
+    expect(plans[2].dir).toBe('/project')
+    expect(plans[2].excludeDirs).toContain('app-admin')
+    expect(plans[2].excludeDirs).not.toContain('app-outlook')
+    expect(plans[2].excludeDirs).not.toContain('app-shop')
+  })
 })


### PR DESCRIPTION
## Summary

When multiple layers share the same locale directory (e.g., `app-outlook` aliases `app-shop`'s locales via `langDir`), orphan scanning now automatically includes the aliasing layer's source directory. This eliminates false orphans for keys only used in the aliasing layer.

## Changes

- Extended `buildLayerScanPlan` to detect layers with `aliasOf` pointing to the scanned layer and include their `layerRootDir` as additional scan plans
- Alias layers are excluded from sibling directory exclusion when `includeParentLayer` is enabled
- Added `aliasOf` to the internal `LayerInfo` interface

## Testing

- 4 new test cases covering alias detection, non-target layers, and sibling exclusion
- `pnpm test` ✅ (486 tests)
- `pnpm typecheck` ✅
- `pnpm build` ✅

## Impact

Fixes 20 false `outlook.*` orphans in anny-ui's app-shop layer (keys used in app-outlook which aliases app-shop's locale dir).

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for layer aliasing, allowing locale files to be referenced from alternative layer directories.

* **Tests**
  * Added test coverage for layer aliasing functionality and sibling layer filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->