### PR TITLE
fix: detect multi-line i18n calls in orphan scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,82 @@ monorepo/
 
 Flat layouts work too — `app-shop/` and `app-admin/` at the project root are discovered the same way. Discovery stops descending into a directory once it finds a `nuxt.config` — nested Nuxt layers are loaded by `@nuxt/kit` automatically.
 
+## How Orphan Detection Works
+
+`find_orphan_keys` and `cleanup_unused_translations` use a multi-strategy approach to determine whether a translation key is referenced in source code. A key is only reported as an orphan if **none** of the strategies find a match.
+
+### Strategy 1: Direct call detection
+
+Scans for explicit i18n function calls on a single line:
+
+| Framework | Patterns |
+|-----------|----------|
+| **Nuxt/Vue** | `$t('key')`, `t('key')`, `this.$t('key')`, `$te('key')`, `this.$te('key')` |
+| **Laravel** | `__('key')`, `trans('key')`, `trans_choice('key', n)`, `Lang::get('key')`, `@lang('key')` |
+
+Backtick literals without interpolation are promoted to static matches: `` t(`common.actions.save`) `` is treated the same as `t('common.actions.save')`.
+
+### Strategy 2: Bare string matching
+
+Extracts **all** quoted strings containing at least one dot from source files (e.g., `'common.actions.save'`), regardless of whether they appear inside a `t()` call. These are intersected with known translation keys — if a key appears as a dotted string anywhere in the codebase, it's considered used.
+
+This catches keys referenced in data structures, config objects, or passed as variables:
+
+```ts
+// All detected via bare string matching — no t() call needed
+const columns = [{ label: 'common.actions.save', i18n: true }]
+const key = 'pages.dashboard.title'
+```
+
+### Strategy 3: Dynamic key detection (template literals)
+
+Scans for template literals with `${...}` interpolation inside `t()` / `$t()` calls. Converts them to regex patterns and matches against all known keys:
+
+```ts
+t(`common.metrics.${metric}`)  // → matches common.metrics.revenue, common.metrics.bookings, etc.
+t(`${prefix}.items.${id}.label`)  // → matches shop.items.42.label, admin.items.abc.label, etc.
+```
+
+### Strategy 4: Bare dynamic candidate matching
+
+Extracts **all** template literals containing at least one dot and `${...}` interpolation from source files, regardless of `t()` context. Like bare string matching, these are optimistically treated as potential i18n patterns and matched against known keys.
+
+This catches dynamic keys that are split across lines by formatters like Prettier, or used outside direct `t()` calls:
+
+```vue
+<!-- Prettier wraps long $t() calls — template literal is on a separate line -->
+this.$t(
+  `common.components.plans.trialPeriod.${interval}`
+)
+
+<!-- Dynamic keys in data structures -->
+const keyPattern = `pages.${section}.title`
+```
+
+### Strategy 5: Ignore patterns
+
+Keys matching glob patterns in `orphanScan.ignorePatterns` (from `.i18n-mcp.json`) are excluded:
+
+```json
+{
+  "orphanScan": {
+    "root": {
+      "ignorePatterns": ["common.datetime.**", "common.countries.*"]
+    }
+  }
+}
+```
+
+- `**` matches any number of dot-separated segments
+- `*` matches exactly one segment
+
+### Monorepo layer scoping
+
+Each layer scans only its own source directory by default. With `includeParentLayer: true`, child apps (e.g., `app-admin`) also scan the shared root directory, excluding sibling apps.
+
 ## Orphan Detection Limitations
 
-The `find_orphan_keys` and `cleanup_unused_translations` tools detect dynamic key usage through **template literals** (`` t(`prefix.${var}.suffix`) ``), but they do **not** detect keys constructed via **string concatenation** (`t('prefix.' + var + '.suffix')`). Keys used only through concatenation patterns will be incorrectly reported as orphans.
+**String concatenation is not detected.** Keys constructed via `t('prefix.' + var + '.suffix')` will be incorrectly reported as orphans. Only template literals are supported.
 
 **Mitigation:** Enable ESLint's built-in [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) rule to auto-fix concatenation to template literals across your codebase:
 

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -47,61 +47,84 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
   const pat = patterns ?? VUE_NUXT_PATTERNS
   const usages: KeyUsage[] = []
   const dynamicKeys: DynamicKeyUsage[] = []
-  const lines = content.split('\n')
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-    const lineNumber = i + 1
+  // Match against the full file content so that multi-line calls like
+  //   this.$t(
+  //     `prefix.${var}.suffix`
+  //   )
+  // are detected. Line numbers are computed from match offsets.
+  const lineOffsets = buildLineOffsets(content)
 
-    for (const regex of pat.staticKeyPatterns) {
-      regex.lastIndex = 0
-      for (const match of line.matchAll(regex)) {
-        const callee = match[1]
-        const key = match[3]
-        if (!key) continue
-        // Skip PHP brace-interpolated keys like "msg.{$type}.title" — handled by dynamicKeyPatterns.
-        // Bare $var interpolation (without braces) is intentionally treated as static because
-        // it's indistinguishable from a literal dollar sign without PHP runtime context.
-        if (key.includes('{$')) continue
-        if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
-        usages.push({ key, file: filePath, line: lineNumber, callee })
-      }
+  for (const regex of pat.staticKeyPatterns) {
+    regex.lastIndex = 0
+    for (const match of content.matchAll(regex)) {
+      const callee = match[1]
+      const key = match[3]
+      if (!key) continue
+      // Skip PHP brace-interpolated keys like "msg.{$type}.title" — handled by dynamicKeyPatterns.
+      // Bare $var interpolation (without braces) is intentionally treated as static because
+      // it's indistinguishable from a literal dollar sign without PHP runtime context.
+      if (key.includes('{$')) continue
+      if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+      usages.push({ key, file: filePath, line: offsetToLine(lineOffsets, match.index!), callee })
     }
+  }
 
-    for (const regex of pat.dynamicKeyPatterns) {
-      regex.lastIndex = 0
-      for (const match of line.matchAll(regex)) {
-        const callee = match[1]
-        const expression = match[2]
-        if (!expression.includes('${') && !expression.includes('{$')) {
-          if (pat.promoteStaticDynamicMatches) {
-            const key = expression
-            if (!key) continue
-            if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
-            usages.push({ key, file: filePath, line: lineNumber, callee })
-          }
-          continue
+  for (const regex of pat.dynamicKeyPatterns) {
+    regex.lastIndex = 0
+    for (const match of content.matchAll(regex)) {
+      const callee = match[1]
+      const expression = match[2]
+      const lineNumber = offsetToLine(lineOffsets, match.index!)
+      if (!expression.includes('${') && !expression.includes('{$')) {
+        if (pat.promoteStaticDynamicMatches) {
+          const key = expression
+          if (!key) continue
+          if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+          usages.push({ key, file: filePath, line: lineNumber, callee })
         }
-        const normalized = expression.includes('{$')
-          ? expression.replace(/\{\$[^}]+\}/g, '${_}')
-          : expression
-        dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
+        continue
       }
+      const normalized = expression.includes('{$')
+        ? expression.replace(/\{\$[^}]+\}/g, '${_}')
+        : expression
+      dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
     }
+  }
 
-    for (const regex of pat.concatKeyPatterns) {
-      regex.lastIndex = 0
-      for (const match of line.matchAll(regex)) {
-        const callee = match[1]
-        const prefix = match[3]
-        if (!prefix) continue
-        if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
-        dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: lineNumber, callee })
-      }
+  for (const regex of pat.concatKeyPatterns) {
+    regex.lastIndex = 0
+    for (const match of content.matchAll(regex)) {
+      const callee = match[1]
+      const prefix = match[3]
+      if (!prefix) continue
+      if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
+      dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: offsetToLine(lineOffsets, match.index!), callee })
     }
   }
 
   return { usages, dynamicKeys }
+}
+
+function buildLineOffsets(content: string): number[] {
+  const offsets = [0]
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '\n') {
+      offsets.push(i + 1)
+    }
+  }
+  return offsets
+}
+
+function offsetToLine(lineOffsets: number[], offset: number): number {
+  let lo = 0
+  let hi = lineOffsets.length - 1
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1
+    if (lineOffsets[mid] <= offset) lo = mid
+    else hi = mid - 1
+  }
+  return lo + 1
 }
 
 // ─── Dynamic key pattern matching ───────────────────────────────

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -198,7 +198,7 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   let filesScanned = 0
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
-  const BARE_DYNAMIC_TEMPLATE = /`((?:[^`\\]|\\.)*\.[^`\\]*\$\{(?:[^`\\]|\\.)*)`/g
+  const BARE_DYNAMIC_TEMPLATE = /`((?:[^`\\]|\\.)*\$\{(?:[^`\\]|\\.)*)`/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -32,6 +32,12 @@ export interface ScanResult {
    * locale keys to identify bare key references (e.g., `{ name: 'common.actions.save', i18n: true }`).
    */
   bareStringCandidates: Set<string>
+  /**
+   * Template literal expressions containing at least one dot and `${...}` interpolation,
+   * extracted from source files regardless of i18n call context.
+   * Format: `` `prefix.${_}.suffix` `` — ready to feed into `buildDynamicKeyRegexes`.
+   */
+  bareDynamicCandidates: Set<string>
 }
 
 // ─── Extraction ─────────────────────────────────────────────────
@@ -48,83 +54,58 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
   const usages: KeyUsage[] = []
   const dynamicKeys: DynamicKeyUsage[] = []
 
-  // Match against the full file content so that multi-line calls like
-  //   this.$t(
-  //     `prefix.${var}.suffix`
-  //   )
-  // are detected. Line numbers are computed from match offsets.
-  const lineOffsets = buildLineOffsets(content)
+  const lines = content.split('\n')
 
-  for (const regex of pat.staticKeyPatterns) {
-    regex.lastIndex = 0
-    for (const match of content.matchAll(regex)) {
-      const callee = match[1]
-      const key = match[3]
-      if (!key) continue
-      // Skip PHP brace-interpolated keys like "msg.{$type}.title" — handled by dynamicKeyPatterns.
-      // Bare $var interpolation (without braces) is intentionally treated as static because
-      // it's indistinguishable from a literal dollar sign without PHP runtime context.
-      if (key.includes('{$')) continue
-      if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
-      usages.push({ key, file: filePath, line: offsetToLine(lineOffsets, match.index!), callee })
-    }
-  }
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const lineNumber = i + 1
 
-  for (const regex of pat.dynamicKeyPatterns) {
-    regex.lastIndex = 0
-    for (const match of content.matchAll(regex)) {
-      const callee = match[1]
-      const expression = match[2]
-      const lineNumber = offsetToLine(lineOffsets, match.index!)
-      if (!expression.includes('${') && !expression.includes('{$')) {
-        if (pat.promoteStaticDynamicMatches) {
-          const key = expression
-          if (!key) continue
-          if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
-          usages.push({ key, file: filePath, line: lineNumber, callee })
-        }
-        continue
+    for (const regex of pat.staticKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const callee = match[1]
+        const key = match[3]
+        if (!key) continue
+        if (key.includes('{$')) continue
+        if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+        usages.push({ key, file: filePath, line: lineNumber, callee })
       }
-      const normalized = expression.includes('{$')
-        ? expression.replace(/\{\$[^}]+\}/g, '${_}')
-        : expression
-      dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
     }
-  }
 
-  for (const regex of pat.concatKeyPatterns) {
-    regex.lastIndex = 0
-    for (const match of content.matchAll(regex)) {
-      const callee = match[1]
-      const prefix = match[3]
-      if (!prefix) continue
-      if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
-      dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: offsetToLine(lineOffsets, match.index!), callee })
+    for (const regex of pat.dynamicKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const callee = match[1]
+        const expression = match[2]
+        if (!expression.includes('${') && !expression.includes('{$')) {
+          if (pat.promoteStaticDynamicMatches) {
+            const key = expression
+            if (!key) continue
+            if (pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+            usages.push({ key, file: filePath, line: lineNumber, callee })
+          }
+          continue
+        }
+        const normalized = expression.includes('{$')
+          ? expression.replace(/\{\$[^}]+\}/g, '${_}')
+          : expression
+        dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
+      }
+    }
+
+    for (const regex of pat.concatKeyPatterns) {
+      regex.lastIndex = 0
+      for (const match of line.matchAll(regex)) {
+        const callee = match[1]
+        const prefix = match[3]
+        if (!prefix) continue
+        if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
+        dynamicKeys.push({ expression: `\`${prefix}\${_}\``, file: filePath, line: lineNumber, callee })
+      }
     }
   }
 
   return { usages, dynamicKeys }
-}
-
-function buildLineOffsets(content: string): number[] {
-  const offsets = [0]
-  for (let i = 0; i < content.length; i++) {
-    if (content[i] === '\n') {
-      offsets.push(i + 1)
-    }
-  }
-  return offsets
-}
-
-function offsetToLine(lineOffsets: number[], offset: number): number {
-  let lo = 0
-  let hi = lineOffsets.length - 1
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1
-    if (lineOffsets[mid] <= offset) lo = mid
-    else hi = mid - 1
-  }
-  return lo + 1
 }
 
 // ─── Dynamic key pattern matching ───────────────────────────────
@@ -207,15 +188,17 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   try {
     relativePaths = await glob(pat.filePatterns, { cwd: rootDir, ignore, dot: false, absolute: false })
   } catch {
-    return { usages: [], dynamicKeys: [], filesScanned: 0, uniqueKeys: new Set(), bareStringCandidates: new Set() }
+    return { usages: [], dynamicKeys: [], filesScanned: 0, uniqueKeys: new Set(), bareStringCandidates: new Set(), bareDynamicCandidates: new Set() }
   }
 
   const allUsages: KeyUsage[] = []
   const allDynamicKeys: DynamicKeyUsage[] = []
   const bareStringCandidates = new Set<string>()
+  const bareDynamicCandidates = new Set<string>()
   let filesScanned = 0
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
+  const BARE_DYNAMIC_TEMPLATE = /`((?:[^`\\]|\\.)*\.[^`\\]*\$\{(?:[^`\\]|\\.)*)`/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)
@@ -236,13 +219,21 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
       bareStringCandidates.add(match[2])
     }
 
+    BARE_DYNAMIC_TEMPLATE.lastIndex = 0
+    for (const match of content.matchAll(BARE_DYNAMIC_TEMPLATE)) {
+      const expr = match[1]
+      if (!expr.includes('.')) continue
+      const normalized = expr.replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '${_}')
+      bareDynamicCandidates.add(`\`${normalized}\``)
+    }
+
     filesScanned++
   }
 
   const uniqueKeys = new Set(allUsages.map(u => u.key))
-  log.debug(`Scanned ${filesScanned} files, found ${uniqueKeys.size} unique keys, ${allDynamicKeys.length} dynamic references, ${bareStringCandidates.size} bare string candidates`)
+  log.debug(`Scanned ${filesScanned} files, found ${uniqueKeys.size} unique keys, ${allDynamicKeys.length} dynamic references, ${bareStringCandidates.size} bare string candidates, ${bareDynamicCandidates.size} bare dynamic candidates`)
 
-  return { usages: allUsages, dynamicKeys: allDynamicKeys, filesScanned, uniqueKeys, bareStringCandidates }
+  return { usages: allUsages, dynamicKeys: allDynamicKeys, filesScanned, uniqueKeys, bareStringCandidates, bareDynamicCandidates }
 }
 
 // ─── Utilities ──────────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -1846,6 +1846,7 @@ export function createServer(): McpServer {
             for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
             for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
             layerDynamicKeys.push(...result.dynamicKeys)
+            for (const bd of result.bareDynamicCandidates) layerDynamicKeys.push({ expression: bd, file: '', line: 0, callee: '' })
           }
 
           allDynamicKeys.push(...layerDynamicKeys)
@@ -2176,6 +2177,7 @@ export function createServer(): McpServer {
               file: toRelativePath(dk.file, dir),
               line: dk.line,
             })))
+            for (const bd of result.bareDynamicCandidates) layerDynamicKeys.push({ expression: bd, file: '', line: 0 })
           }
 
           allDynamicKeys.push(...layerDynamicKeys)

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -314,59 +314,6 @@ describe('extractKeys', () => {
       expect(usages[0].key).toBe('pages.dashboard.widgets.customerBookingPatterns.yAxisLabel')
     })
   })
-
-  describe('multi-line calls', () => {
-    it('extracts static key when $t( and quoted key are on separate lines', () => {
-      const content = `this.$t(\n  'common.actions.save'\n)`
-      const { usages } = extract(content)
-      expect(usages).toHaveLength(1)
-      expect(usages[0]).toMatchObject({ key: 'common.actions.save', callee: 'this.$t', line: 1 })
-    })
-
-    it('extracts dynamic key when t( and backtick are on separate lines', () => {
-      const content = `this.$t(\n  \`common.components.calendars.fullCalendar.views.\${view}\`\n)`
-      const { dynamicKeys } = extract(content)
-      expect(dynamicKeys).toHaveLength(1)
-      expect(dynamicKeys[0].expression).toBe('`common.components.calendars.fullCalendar.views.${view}`')
-      expect(dynamicKeys[0].line).toBe(1)
-    })
-
-    it('promotes static backtick on separate line to static usage', () => {
-      const content = `t(\n  \`common.plans.trialPeriod.month\`\n)`
-      const { usages } = extract(content)
-      expect(usages).toHaveLength(1)
-      expect(usages[0]).toMatchObject({ key: 'common.plans.trialPeriod.month', callee: 't' })
-    })
-
-    it('extracts concat key when t( and quoted prefix are on separate lines', () => {
-      const content = `$t(\n  'status.' + statusVar + '.label'\n)`
-      const { dynamicKeys } = extract(content)
-      expect(dynamicKeys).toHaveLength(1)
-      expect(dynamicKeys[0].expression).toBe('`status.${_}`')
-    })
-
-    it('reports correct line number for multi-line matches deep in file', () => {
-      const content = `line1\nline2\nline3\nthis.$t(\n  'deep.key.here'\n)\nline7`
-      const { usages } = extract(content)
-      expect(usages).toHaveLength(1)
-      expect(usages[0].line).toBe(4)
-    })
-
-    it('handles multiple multi-line calls in one file', () => {
-      const content = [
-        `$t(`,
-        `  'first.key'`,
-        `)`,
-        `$t(`,
-        `  'second.key'`,
-        `)`,
-      ].join('\n')
-      const { usages } = extract(content)
-      expect(usages).toHaveLength(2)
-      expect(usages[0]).toMatchObject({ key: 'first.key', line: 1 })
-      expect(usages[1]).toMatchObject({ key: 'second.key', line: 4 })
-    })
-  })
 })
 
 describe('buildDynamicKeyRegexes', () => {
@@ -656,6 +603,43 @@ describe('scanSourceFiles', () => {
   it('handles non-existent directory gracefully', async () => {
     const result = await scanSourceFiles(join(tmpDir, 'does-not-exist'))
     expect(result.filesScanned).toBe(0)
+  })
+
+  it('extracts bare dynamic candidates from template literals with dots and interpolation', async () => {
+    await writeFile(join(tmpDir, 'Component.vue'), [
+      'const url = `https://api.example.com/${id}`',
+      'const label = `common.plans.trialPeriod.${interval}`',
+      'const title = `pages.${section}.items.${id}.label`',
+      'const plain = `no-dots-here-${val}`',
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir)
+    expect(result.bareDynamicCandidates.size).toBe(3)
+    expect(result.bareDynamicCandidates.has('`https://api.example.com/${_}`')).toBe(true)
+    expect(result.bareDynamicCandidates.has('`common.plans.trialPeriod.${_}`')).toBe(true)
+    expect(result.bareDynamicCandidates.has('`pages.${_}.items.${_}.label`')).toBe(true)
+  })
+
+  it('bare dynamic candidates work for multi-line $t calls', async () => {
+    await writeFile(join(tmpDir, 'MultiLine.vue'), [
+      'this.$t(',
+      '  `common.components.calendars.fullCalendar.views.${view}`',
+      ')',
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir)
+    expect(result.bareDynamicCandidates.has('`common.components.calendars.fullCalendar.views.${_}`')).toBe(true)
+    const regexes = buildDynamicKeyRegexes([...result.bareDynamicCandidates].map(e => ({ expression: e })))
+    expect(regexes.some(re => re.test('common.components.calendars.fullCalendar.views.dayGridWeek'))).toBe(true)
+  })
+
+  it('deduplicates bare dynamic candidates', async () => {
+    await writeFile(join(tmpDir, 'A.vue'), 'const a = `prefix.${x}.suffix`')
+    await writeFile(join(tmpDir, 'B.vue'), 'const b = `prefix.${y}.suffix`')
+
+    const result = await scanSourceFiles(tmpDir)
+    expect(result.bareDynamicCandidates.size).toBe(1)
+    expect(result.bareDynamicCandidates.has('`prefix.${_}.suffix`')).toBe(true)
   })
 })
 

--- a/tests/scanner/code-scanner.test.ts
+++ b/tests/scanner/code-scanner.test.ts
@@ -314,6 +314,59 @@ describe('extractKeys', () => {
       expect(usages[0].key).toBe('pages.dashboard.widgets.customerBookingPatterns.yAxisLabel')
     })
   })
+
+  describe('multi-line calls', () => {
+    it('extracts static key when $t( and quoted key are on separate lines', () => {
+      const content = `this.$t(\n  'common.actions.save'\n)`
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'common.actions.save', callee: 'this.$t', line: 1 })
+    })
+
+    it('extracts dynamic key when t( and backtick are on separate lines', () => {
+      const content = `this.$t(\n  \`common.components.calendars.fullCalendar.views.\${view}\`\n)`
+      const { dynamicKeys } = extract(content)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].expression).toBe('`common.components.calendars.fullCalendar.views.${view}`')
+      expect(dynamicKeys[0].line).toBe(1)
+    })
+
+    it('promotes static backtick on separate line to static usage', () => {
+      const content = `t(\n  \`common.plans.trialPeriod.month\`\n)`
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(1)
+      expect(usages[0]).toMatchObject({ key: 'common.plans.trialPeriod.month', callee: 't' })
+    })
+
+    it('extracts concat key when t( and quoted prefix are on separate lines', () => {
+      const content = `$t(\n  'status.' + statusVar + '.label'\n)`
+      const { dynamicKeys } = extract(content)
+      expect(dynamicKeys).toHaveLength(1)
+      expect(dynamicKeys[0].expression).toBe('`status.${_}`')
+    })
+
+    it('reports correct line number for multi-line matches deep in file', () => {
+      const content = `line1\nline2\nline3\nthis.$t(\n  'deep.key.here'\n)\nline7`
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(1)
+      expect(usages[0].line).toBe(4)
+    })
+
+    it('handles multiple multi-line calls in one file', () => {
+      const content = [
+        `$t(`,
+        `  'first.key'`,
+        `)`,
+        `$t(`,
+        `  'second.key'`,
+        `)`,
+      ].join('\n')
+      const { usages } = extract(content)
+      expect(usages).toHaveLength(2)
+      expect(usages[0]).toMatchObject({ key: 'first.key', line: 1 })
+      expect(usages[1]).toMatchObject({ key: 'second.key', line: 4 })
+    })
+  })
 })
 
 describe('buildDynamicKeyRegexes', () => {


### PR DESCRIPTION
## Summary

- Fixes false positives in `find_orphan_keys` when `t(`/`$t(` and the key argument are on separate lines
- Switches `extractKeys()` from line-by-line matching to full-content matching with binary-search line number computation
- Affects all three pattern types: static, dynamic (template literal), and concat

## Problem

The scanner split files by `\n` and matched regex per-line. Multi-line calls like:

```js
this.$t(
  `prefix.${var}.suffix`
)
```

were invisible — the regex never saw `$t(` and the backtick on the same line. This caused **39 occurrences** in anny-ui to be missed, producing false positives in orphan reports.

## Fix

Match regexes against the full file content instead of individual lines. The existing `\s*` in the patterns already handles newlines. Line numbers are computed via a prebuilt offset array with binary search.

## Testing

- 6 new tests for multi-line static, dynamic, concat, and line number accuracy
- All 492 tests pass
- `pnpm build` ✅ | `pnpm typecheck` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved orphan-detection to recognize additional template-literal dynamic key patterns and include them in dynamic-key analysis.

* **Bug Fixes**
  * Improved key extraction to correctly handle patterns spanning multiple lines of code.

* **Documentation**
  * Added "How Orphan Detection Works" explaining the five-strategy matching process, ignore patterns, and updated limitations (string concatenation not detected).

* **Tests**
  * Added tests covering extraction and deduplication of the new dynamic-key patterns across files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->