### PR TITLE
feat: GenericAdapter — support any JS/PHP project via explicit locale config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 An MCP server that gives your AI agent full control over your app's translations — without dumping entire locale files into context.
 
-Point it at a Nuxt or Laravel project and your agent can read, write, search, rename, and remove translation keys across all locales and layers. It auto-detects your framework, discovers monorepo structures, and handles the file I/O so the agent never has to parse JSON or PHP arrays manually.
+Point it at any project with JSON or PHP locale files and your agent can read, write, search, rename, and remove translation keys across all locales and layers. It auto-detects your framework (or reads explicit config), discovers monorepo structures, and handles the file I/O so the agent never has to parse JSON or PHP arrays manually.
 
 ### Why this exists
 
@@ -32,8 +32,18 @@ Managing translations with an AI agent sounds simple until you have 30 locales, 
 |-----------|--------------|----------------|---------------|
 | **Nuxt** (v3+) | JSON | `nuxt.config.ts` with `@nuxtjs/i18n` | `@nuxt/kit` (optional peer dep) |
 | **Laravel** (9+) | PHP arrays | `artisan`, `composer.json`, `lang/` directory | Built-in |
+| **Generic** (any JS/PHP project) | JSON or PHP arrays | `localeDirs` + `defaultLocale` in `.i18n-mcp.json` | Built-in |
 
-The server detects your framework automatically based on project structure. You can also force it via `"framework": "laravel"` or `"framework": "nuxt"` in `.i18n-mcp.json`.
+The server detects your framework automatically based on project structure. For projects that aren't Nuxt or Laravel (React, Vue, Next.js, Symfony, WordPress, etc.), add `localeDirs` and `defaultLocale` to your `.i18n-mcp.json` and all 15 tools work immediately:
+
+```json
+{
+  "defaultLocale": "en",
+  "localeDirs": ["src/locales"]
+}
+```
+
+You can also force a specific adapter via `"framework": "generic"`, `"framework": "laravel"`, or `"framework": "nuxt"` in `.i18n-mcp.json`.
 
 ## Quick Start
 
@@ -191,6 +201,26 @@ Every write tool requires a `layer` parameter (e.g., `"root"`, `"app-admin"`, `"
 - No additional dependencies required — works out of the box
 - Scans `.blade.php` and `.php` for `__()`, `trans()`, `trans_choice()`, `Lang::get()`, `@lang()`
 - Uses `:placeholder` syntax (not `{placeholder}`) — reflect this in your `translationPrompt` and `examples`
+
+### Generic (Any Project)
+
+- Works with any JS or PHP project: React, Vue, Next.js, Symfony, WordPress, custom setups
+- Requires `localeDirs` and `defaultLocale` in `.i18n-mcp.json`
+- Auto-discovers locales from filenames on disk (`en.json` → `"en"`, `de/` → `"de"`)
+- Auto-detects file format: flat JSON files (`en.json`), directory-per-locale JSON (`en/common.json`), or directory-per-locale PHP (`en/messages.php`)
+- Optionally restrict locales via an explicit `"locales"` array
+- Supports multiple locale directories with named layers:
+  ```json
+  {
+    "defaultLocale": "en",
+    "localeDirs": [
+      { "path": "packages/ui/locales", "layer": "ui" },
+      { "path": "packages/app/locales", "layer": "app" }
+    ]
+  }
+  ```
+- Single directory entries use `"default"` as the layer name
+- Activates implicitly when config fields are present — no `"framework": "generic"` needed (though it works as an explicit override)
 
 ## Monorepo Support (Nuxt)
 
@@ -392,7 +422,7 @@ For IDE autocompletion, point to the schema:
 
 | Field | Purpose |
 |-------|---------|
-| `framework` | Force framework detection: `"nuxt"` or `"laravel"`. Normally auto-detected from project structure |
+| `framework` | Force framework detection: `"nuxt"`, `"laravel"`, or `"generic"`. Normally auto-detected from project structure |
 | `context` | Free-form project background (business domain, user base, brand voice) |
 | `layerRules` | Rules for which layer a new key belongs to, with natural-language `when` conditions |
 | `glossary` | Term dictionary for consistent translations |
@@ -402,6 +432,9 @@ For IDE autocompletion, point to the schema:
 | `orphanScan` | Per-layer config for orphan detection: `ignorePatterns` (glob patterns for keys to skip), `includeParentLayer` (also scan shared root code for key usage in monorepos). Keys are layer names from `list_locale_dirs`. Each layer automatically scans from its own root directory |
 | `reportOutput` | `true` for default `.i18n-reports/` dir, or a string for a custom path. Diagnostic tools write full output to disk and return only a summary in the MCP response |
 | `samplingPreferences` | Override model preferences for `translate_missing` sampling. See [Model Selection](#model-selection-for-translations) |
+| `localeDirs` | Locale directories for the generic adapter. Array of path strings or `{ path, layer }` objects. Required (with `defaultLocale`) to activate the generic adapter |
+| `defaultLocale` | Default locale code. Required (with `localeDirs`) to activate the generic adapter |
+| `locales` | Explicit list of locale codes to operate on. If absent, auto-discovered from files on disk |
 
 ### Full example
 
@@ -477,7 +510,6 @@ See [`playground/nuxt/.i18n-mcp.json`](playground/nuxt/.i18n-mcp.json) for a wor
 - [ ] Flat JSON support — `flatJson: true` in vue-i18n config
 - [ ] Pluralization support — vue-i18n plural forms and Laravel `trans_choice`
 - [ ] Confidence scoring for orphan keys — flag low-confidence orphans that share a prefix with dynamic patterns ([#109](https://github.com/fabkho/the-i18n-mcp/issues/109))
-- [ ] Plain vue-i18n support (without Nuxt)
 
 ## Development
 

--- a/schema.json
+++ b/schema.json
@@ -12,7 +12,7 @@
     },
     "framework": {
       "type": "string",
-      "enum": ["nuxt", "laravel"],
+      "enum": ["nuxt", "laravel", "generic"],
       "description": "Force framework detection instead of auto-detecting from project structure."
     },
     "context": {
@@ -155,6 +155,44 @@
         }
       ],
       "description": "Enable file output for diagnostic tools (get_missing_translations, find_empty_translations, find_orphan_keys, scan_code_usage, cleanup_unused_translations). When set, each tool writes its full JSON report to <reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true for the default '.i18n-reports/' directory, or a string for a custom path."
+    },
+    "localeDirs": {
+      "type": "array",
+      "description": "Locale directories for the generic adapter. Each entry is a path string (layer defaults to 'default') or an object with 'path' and 'layer' properties.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Relative path to a locale directory. Layer name defaults to 'default'."
+          },
+          {
+            "type": "object",
+            "required": ["path", "layer"],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Relative path to a locale directory."
+              },
+              "layer": {
+                "type": "string",
+                "description": "Layer name for this locale directory."
+              }
+            }
+          }
+        ]
+      }
+    },
+    "defaultLocale": {
+      "type": "string",
+      "description": "Default locale code. Required for generic adapter activation."
+    },
+    "locales": {
+      "type": "array",
+      "description": "Explicit list of locale codes to operate on. If absent, locales are auto-discovered from files on disk.",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/src/adapters/generic/index.ts
+++ b/src/adapters/generic/index.ts
@@ -1,0 +1,158 @@
+import { readdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import type { FrameworkAdapter, LocaleFileFormat } from '../types'
+import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import { loadProjectConfig } from '../../config/project-config'
+import { log } from '../../utils/logger'
+import { ConfigError } from '../../utils/errors'
+
+export class GenericAdapter implements FrameworkAdapter {
+  readonly name = 'generic'
+  readonly label = 'Generic'
+  readonly localeFileFormat: LocaleFileFormat = 'json'
+
+  private cachedConfig: { projectDir: string; config: import('../../config/types').ProjectConfig | null } | null = null
+
+  private async getProjectConfig(projectDir: string) {
+    if (this.cachedConfig?.projectDir === projectDir) {
+      return this.cachedConfig.config
+    }
+    const config = await loadProjectConfig(projectDir)
+    this.cachedConfig = { projectDir, config }
+    return config
+  }
+
+  async detect(projectDir: string): Promise<number> {
+    const config = await this.getProjectConfig(projectDir)
+    if (!config) return 0
+    if (config.localeDirs && config.localeDirs.length > 0 && config.defaultLocale) {
+      return 10
+    }
+    return 0
+  }
+
+  async resolve(projectDir: string): Promise<I18nConfig> {
+    const projectConfig = await this.getProjectConfig(projectDir)
+    if (!projectConfig?.localeDirs || projectConfig.localeDirs.length === 0 || !projectConfig.defaultLocale) {
+      throw new ConfigError(
+        'GenericAdapter requires both "localeDirs" and "defaultLocale" in .i18n-mcp.json',
+      )
+    }
+
+    const localeDirs: LocaleDir[] = projectConfig.localeDirs.map((entry) => {
+      if (typeof entry === 'string') {
+        return {
+          path: resolve(projectDir, entry),
+          layer: 'default',
+          layerRootDir: projectDir,
+        }
+      }
+      return {
+        path: resolve(projectDir, entry.path),
+        layer: entry.layer,
+        layerRootDir: projectDir,
+      }
+    })
+
+    for (const dir of localeDirs) {
+      if (!existsSync(dir.path)) {
+        throw new ConfigError(`Locale directory does not exist: ${dir.path}`)
+      }
+    }
+
+    const detectedFormat = await detectFileFormat(localeDirs[0].path)
+    const discoveredLocales = projectConfig.locales ?? await discoverLocales(localeDirs, detectedFormat)
+
+    if (discoveredLocales.length === 0) {
+      throw new ConfigError(
+        `No locale files found in ${localeDirs.map(d => d.path).join(', ')}`,
+      )
+    }
+
+    const locales: LocaleDefinition[] = discoveredLocales.map(code => ({
+      code,
+      language: code,
+      ...(detectedFormat === 'json' ? { file: `${code}.json` } : {}),
+    }))
+
+    log.info(
+      `Generic adapter: ${locales.length} locale(s), format=${detectedFormat}, `
+      + `dirs=${localeDirs.map(d => d.layer).join(', ')}`,
+    )
+
+    return {
+      rootDir: projectDir,
+      defaultLocale: projectConfig.defaultLocale,
+      fallbackLocale: { default: [projectConfig.defaultLocale] },
+      locales,
+      localeDirs,
+      layerRootDirs: [projectDir],
+      projectConfig,
+      localeFileFormat: detectedFormat,
+    }
+  }
+}
+
+async function detectFileFormat(localeDir: string): Promise<LocaleFileFormat> {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await readdir(localeDir, { withFileTypes: true })
+  }
+  catch {
+    return 'json'
+  }
+
+  // Flat files: en.json, de.json
+  if (entries.some(e => e.isFile() && e.name.endsWith('.json'))) {
+    return 'json'
+  }
+
+  // Directory-per-locale: en/, de/ — check contents
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const subFiles = await readdir(join(localeDir, entry.name)).catch(() => [] as string[])
+    if (subFiles.some(f => f.endsWith('.php'))) return 'php-array'
+    if (subFiles.some(f => f.endsWith('.json'))) return 'json'
+  }
+
+  return 'json'
+}
+
+const NON_LOCALE_NAMES = new Set([
+  'index', 'readme', 'config', 'vendor', 'node_modules', '.git', '.DS_Store',
+])
+
+async function discoverLocales(localeDirs: LocaleDir[], format: LocaleFileFormat): Promise<string[]> {
+  const codes = new Set<string>()
+
+  for (const dir of localeDirs) {
+    let entries: import('node:fs').Dirent[]
+    try {
+      entries = await readdir(dir.path, { withFileTypes: true })
+    }
+    catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue
+
+      if (entry.isFile() && entry.name.endsWith('.json') && format === 'json') {
+        const code = entry.name.replace(/\.json$/, '')
+        if (!NON_LOCALE_NAMES.has(code.toLowerCase())) {
+          codes.add(code)
+        }
+      }
+      else if (entry.isDirectory() && !NON_LOCALE_NAMES.has(entry.name.toLowerCase())) {
+        const subFiles = await readdir(join(dir.path, entry.name)).catch(() => [] as string[])
+        const ext = format === 'php-array' ? '.php' : '.json'
+        if (subFiles.some(f => f.endsWith(ext))) {
+          codes.add(entry.name)
+        }
+      }
+    }
+  }
+
+  return [...codes].sort()
+}

--- a/src/config/detector.ts
+++ b/src/config/detector.ts
@@ -2,6 +2,7 @@ import type { I18nConfig } from './types'
 import { registerAdapter, detectFramework } from '../adapters/registry'
 import { NuxtAdapter } from '../adapters/nuxt/index'
 import { LaravelAdapter } from '../adapters/laravel/index'
+import { GenericAdapter } from '../adapters/generic/index'
 import { loadProjectConfig } from './project-config'
 import { log } from '../utils/logger'
 import { canonicalPath } from './discovery'
@@ -10,6 +11,7 @@ export { discoverNuxtApps } from './discovery'
 
 registerAdapter(new NuxtAdapter())
 registerAdapter(new LaravelAdapter())
+registerAdapter(new GenericAdapter())
 
 const configCache = new Map<string, I18nConfig>()
 

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -72,7 +72,7 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
   const knownKeys = new Set([
     '$schema', 'framework', 'context', 'layerRules', 'glossary',
     'translationPrompt', 'localeNotes', 'examples', 'orphanScan',
-    'reportOutput', 'samplingPreferences',
+    'reportOutput', 'samplingPreferences', 'localeDirs', 'defaultLocale', 'locales',
   ])
   for (const key of Object.keys(config)) {
     if (!knownKeys.has(key)) {
@@ -194,6 +194,48 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     }
   }
 
+  // Validate localeDirs
+  if ('localeDirs' in config) {
+    if (!Array.isArray(config.localeDirs)) {
+      throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs" must be an array`)
+    }
+    for (let i = 0; i < config.localeDirs.length; i++) {
+      const entry = config.localeDirs[i]
+      if (typeof entry === 'string') {
+        if (entry.trim() === '') {
+          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}]" must be a non-empty string`)
+        }
+      } else if (typeof entry === 'object' && entry !== null && !Array.isArray(entry)) {
+        const obj = entry as Record<string, unknown>
+        if (typeof obj.path !== 'string' || obj.path.trim() === '') {
+          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}].path" must be a non-empty string`)
+        }
+        if (typeof obj.layer !== 'string' || obj.layer.trim() === '') {
+          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}].layer" must be a non-empty string`)
+        }
+      } else {
+        throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}]" must be a string or { path, layer } object`)
+      }
+    }
+  }
+
+  // Validate defaultLocale
+  if ('defaultLocale' in config && typeof config.defaultLocale !== 'string') {
+    throw new ConfigError(`${CONFIG_FILENAME}: "defaultLocale" must be a string`)
+  }
+
+  // Validate locales
+  if ('locales' in config) {
+    if (!Array.isArray(config.locales)) {
+      throw new ConfigError(`${CONFIG_FILENAME}: "locales" must be an array of strings`)
+    }
+    for (let i = 0; i < config.locales.length; i++) {
+      if (typeof config.locales[i] !== 'string') {
+        throw new ConfigError(`${CONFIG_FILENAME}: "locales[${i}]" must be a string`)
+      }
+    }
+  }
+
   if ('reportOutput' in config) {
     if (config.reportOutput !== true) {
       if (typeof config.reportOutput !== 'string' || config.reportOutput.trim() === '') {
@@ -214,5 +256,8 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     examples: config.examples as Array<Record<string, string>> | undefined,
     orphanScan: config.orphanScan as ProjectConfig['orphanScan'],
     reportOutput: config.reportOutput as string | boolean | undefined,
+    localeDirs: config.localeDirs as ProjectConfig['localeDirs'],
+    defaultLocale: config.defaultLocale as string | undefined,
+    locales: config.locales as string[] | undefined,
   }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -60,6 +60,12 @@ export interface ProjectConfig {
   }>
   /** Default output directory for diagnostic tool reports. Set to true for '.i18n-reports/', or a string for a custom relative path. */
   reportOutput?: string | boolean
+  /** Locale directories for the generic adapter. Each entry is a path string (layer="default") or { path, layer } object. */
+  localeDirs?: Array<string | { path: string; layer: string }>
+  /** Default locale code (required for generic adapter activation). */
+  defaultLocale?: string
+  /** Explicit list of locale codes. If absent, auto-discovered from files on disk. */
+  locales?: string[]
   /** Model preferences for `translate_missing` sampling requests. Overrides the built-in defaults (fast/cheap model bias). */
   samplingPreferences?: {
     /** Ordered model name hints (substring match). First match wins. E.g., ["flash", "haiku"] */

--- a/tests/adapters/generic-adapter.test.ts
+++ b/tests/adapters/generic-adapter.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { GenericAdapter } from '../../src/adapters/generic/index'
+import { registerAdapter, resetRegistry, detectFramework } from '../../src/adapters/registry'
+import { NuxtAdapter } from '../../src/adapters/nuxt/index'
+import { LaravelAdapter } from '../../src/adapters/laravel/index'
+
+function createGenericProject(root: string, opts: {
+  localeDirs?: Array<string | { path: string; layer: string }>
+  defaultLocale?: string
+  locales?: string[]
+  framework?: string
+  structure?: 'flat-json' | 'dir-json' | 'dir-php'
+  localeNames?: string[]
+} = {}) {
+  const {
+    localeDirs = ['locales'],
+    defaultLocale = 'en',
+    locales,
+    framework,
+    structure = 'flat-json',
+    localeNames = ['en', 'de'],
+  } = opts
+
+  const config: Record<string, unknown> = { localeDirs, defaultLocale }
+  if (locales) config.locales = locales
+  if (framework) config.framework = framework
+
+  writeFileSync(join(root, '.i18n-mcp.json'), JSON.stringify(config, null, 2))
+
+  for (const entry of localeDirs) {
+    const dirPath = typeof entry === 'string' ? entry : entry.path
+    const absDir = join(root, dirPath)
+    mkdirSync(absDir, { recursive: true })
+
+    for (const locale of localeNames) {
+      if (structure === 'flat-json') {
+        writeFileSync(join(absDir, `${locale}.json`), JSON.stringify({ hello: 'world' }))
+      } else if (structure === 'dir-json') {
+        mkdirSync(join(absDir, locale), { recursive: true })
+        writeFileSync(join(absDir, locale, 'common.json'), JSON.stringify({ hello: 'world' }))
+      } else if (structure === 'dir-php') {
+        mkdirSync(join(absDir, locale), { recursive: true })
+        writeFileSync(join(absDir, locale, 'messages.php'), '<?php return [];')
+      }
+    }
+  }
+}
+
+describe('GenericAdapter.detect', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `generic-adapter-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('has correct static properties', () => {
+    const adapter = new GenericAdapter()
+    expect(adapter.name).toBe('generic')
+    expect(adapter.label).toBe('Generic')
+    expect(adapter.localeFileFormat).toBe('json')
+  })
+
+  it('returns 10 when both localeDirs and defaultLocale are present', async () => {
+    createGenericProject(tempDir)
+    const adapter = new GenericAdapter()
+    expect(await adapter.detect(tempDir)).toBe(10)
+  })
+
+  it('returns 0 when localeDirs is missing', async () => {
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({ defaultLocale: 'en' }))
+    const adapter = new GenericAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when defaultLocale is missing', async () => {
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({ localeDirs: ['locales'] }))
+    const adapter = new GenericAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when no config file exists', async () => {
+    const adapter = new GenericAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when localeDirs is empty', async () => {
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({ localeDirs: [], defaultLocale: 'en' }))
+    const adapter = new GenericAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+})
+
+describe('GenericAdapter.resolve', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `generic-resolve-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves flat JSON project with auto-discovered locales', async () => {
+    createGenericProject(tempDir, { localeNames: ['en', 'de', 'fr'] })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.rootDir).toBe(tempDir)
+    expect(config.defaultLocale).toBe('en')
+    expect(config.fallbackLocale).toEqual({ default: ['en'] })
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr'])
+    expect(config.locales[0].file).toBe('de.json')
+    expect(config.localeDirs).toHaveLength(1)
+    expect(config.localeDirs[0].layer).toBe('default')
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'locales'))
+    expect(config.localeDirs[0].layerRootDir).toBe(tempDir)
+    expect(config.layerRootDirs).toEqual([tempDir])
+    expect(config.localeFileFormat).toBe('json')
+  })
+
+  it('resolves directory-per-locale JSON project', async () => {
+    createGenericProject(tempDir, { structure: 'dir-json', localeNames: ['en', 'de'] })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+    expect(config.localeFileFormat).toBe('json')
+  })
+
+  it('resolves directory-per-locale PHP project', async () => {
+    createGenericProject(tempDir, { structure: 'dir-php', localeNames: ['en', 'de'] })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+    expect(config.localeFileFormat).toBe('php-array')
+    expect(config.locales[0].file).toBeUndefined()
+  })
+
+  it('uses explicit locales from config instead of auto-discovery', async () => {
+    createGenericProject(tempDir, {
+      localeNames: ['en', 'de', 'fr', 'es'],
+      locales: ['en', 'de'],
+    })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'de'])
+  })
+
+  it('supports multiple localeDirs with explicit layer names', async () => {
+    createGenericProject(tempDir, {
+      localeDirs: [
+        { path: 'packages/ui/locales', layer: 'ui' },
+        { path: 'packages/app/locales', layer: 'app' },
+      ],
+      localeNames: ['en', 'de'],
+    })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs).toHaveLength(2)
+    expect(config.localeDirs[0].layer).toBe('ui')
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'packages/ui/locales'))
+    expect(config.localeDirs[1].layer).toBe('app')
+  })
+
+  it('single string localeDirs entry gets layer "default"', async () => {
+    createGenericProject(tempDir, { localeDirs: ['src/locales'] })
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs[0].layer).toBe('default')
+  })
+
+  it('throws when locale directory does not exist', async () => {
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({
+      localeDirs: ['nonexistent'],
+      defaultLocale: 'en',
+    }))
+
+    const adapter = new GenericAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('Locale directory does not exist')
+  })
+
+  it('throws when localeDirs is empty (e.g. via framework hint)', async () => {
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({
+      localeDirs: [],
+      defaultLocale: 'en',
+    }))
+
+    const adapter = new GenericAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('GenericAdapter requires both')
+  })
+
+  it('throws when no locale files are found', async () => {
+    const localeDir = join(tempDir, 'locales')
+    mkdirSync(localeDir, { recursive: true })
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({
+      localeDirs: ['locales'],
+      defaultLocale: 'en',
+    }))
+
+    const adapter = new GenericAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale files found')
+  })
+
+  it('ignores non-locale files like index.json and README.md', async () => {
+    createGenericProject(tempDir, { localeNames: ['en'] })
+    writeFileSync(join(tempDir, 'locales', 'index.json'), '{}')
+    writeFileSync(join(tempDir, 'locales', 'README.md'), '# Readme')
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en'])
+  })
+
+  it('ignores dotfiles', async () => {
+    createGenericProject(tempDir, { localeNames: ['en'] })
+    writeFileSync(join(tempDir, 'locales', '.DS_Store'), '')
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en'])
+  })
+
+  it('includes projectConfig in resolved config', async () => {
+    createGenericProject(tempDir)
+
+    const adapter = new GenericAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.projectConfig).toBeDefined()
+    expect(config.projectConfig!.defaultLocale).toBe('en')
+    expect(config.projectConfig!.localeDirs).toEqual(['locales'])
+  })
+})
+
+describe('Adapter registry: Generic vs others', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `registry-generic-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    resetRegistry()
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+    resetRegistry()
+  })
+
+  it('selects GenericAdapter when localeDirs + defaultLocale present and no framework signals', async () => {
+    createGenericProject(tempDir)
+
+    registerAdapter(new NuxtAdapter())
+    registerAdapter(new LaravelAdapter())
+    registerAdapter(new GenericAdapter())
+
+    const adapter = await detectFramework(tempDir)
+    expect(adapter.name).toBe('generic')
+  })
+
+  it('selects GenericAdapter over LaravelAdapter when explicit localeDirs config is present', async () => {
+    createGenericProject(tempDir)
+    writeFileSync(join(tempDir, 'artisan'), '#!/usr/bin/env php')
+    writeFileSync(join(tempDir, 'composer.json'), JSON.stringify({
+      require: { 'laravel/framework': '^11.0' },
+    }))
+    const langDir = join(tempDir, 'lang', 'en')
+    mkdirSync(langDir, { recursive: true })
+    writeFileSync(join(langDir, 'auth.php'), '<?php return [];')
+
+    registerAdapter(new NuxtAdapter())
+    registerAdapter(new LaravelAdapter())
+    registerAdapter(new GenericAdapter())
+
+    const adapter = await detectFramework(tempDir)
+    expect(adapter.name).toBe('generic')
+  })
+
+  it('respects framework hint "generic"', async () => {
+    registerAdapter(new NuxtAdapter())
+    registerAdapter(new LaravelAdapter())
+    registerAdapter(new GenericAdapter())
+
+    const adapter = await detectFramework('/any/dir', 'generic')
+    expect(adapter.name).toBe('generic')
+  })
+})


### PR DESCRIPTION
## Summary

Implements #104 — adds a `GenericAdapter` so any JS or PHP project can use all 15 MCP tools by adding `localeDirs` and `defaultLocale` to `.i18n-mcp.json`.

- **New `GenericAdapter`** (`src/adapters/generic/index.ts`): Activates implicitly when both fields are present (confidence 10). Auto-discovers locales from filenames, auto-detects file format (flat JSON, directory-per-locale JSON, directory-per-locale PHP), supports multiple locale directories with named layers.
- **ProjectConfig schema extended**: Added `localeDirs`, `defaultLocale`, `locales` fields to `types.ts`, `project-config.ts`, and `schema.json` (including `"generic"` in the framework enum).
- **Registered in detector**: `GenericAdapter` added alongside Nuxt and Laravel adapters — no changes to registry logic.
- **18 tests** covering detect confidence, resolve for all 3 directory structures, layer naming, explicit locales, error cases, and registry integration.
- **README updated**: Supported Frameworks table, new Generic section, Project Config table, updated intro text.

### Config example

```json
{
  "defaultLocale": "en",
  "localeDirs": ["src/locales"]
}
```

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Generic adapter enabling the translation server to work with any project containing JSON or PHP locale files
  * Added new configuration options: `localeDirs`, `defaultLocale`, and `locales` in `.i18n-mcp.json`
  * Server now auto-detects generic projects from project structure or explicit framework configuration

* **Documentation**
  * Updated README with Generic adapter setup and configuration requirements

* **Tests**
  * Added comprehensive test coverage for Generic adapter behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->