### PR TITLE
feat: add find_misplaced_keys tool for detecting keys in wrong layer

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -149,7 +149,7 @@
           "description": "Set to true to write reports to the default '.i18n-reports/' directory."
         }
       ],
-      "description": "Enable file output for diagnostic tools (get_missing_translations, find_empty_translations, find_orphan_keys, scan_code_usage, cleanup_unused_translations). When set, each tool writes its full JSON report to <reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true for the default '.i18n-reports/' directory, or a string for a custom path."
+      "description": "Enable file output for diagnostic tools (get_missing_translations, find_empty_translations, find_orphan_keys, find_misplaced_keys, scan_code_usage, cleanup_unused_translations). When set, each tool writes its full JSON report to <reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true for the default '.i18n-reports/' directory, or a string for a custom path."
     },
     "localeDirs": {
       "type": "array",

--- a/src/scanner/code-scanner.ts
+++ b/src/scanner/code-scanner.ts
@@ -449,6 +449,145 @@ export interface OrphanScanResult {
   unresolvedKeyWarnings: UnresolvedKeyWarning[]
 }
 
+// ─── Misplaced Key Detection ────────────────────────────────────
+
+export interface MisplacedKeyEntry {
+  key: string
+  currentLayer: string
+  suggestedLayer: string
+  usedIn: string[]
+}
+
+export interface MisplacedKeysResult {
+  misplacedKeys: MisplacedKeyEntry[]
+  summary: {
+    total: number
+    moveToRoot: number
+    moveToChild: number
+    byCurrentLayer: Record<string, number>
+  }
+}
+
+export interface MisplacedKeysScanOptions {
+  keysByLayer: Map<string, { keys: string[]; localeDir: { layer: string } }>
+  apps: AppInfo[]
+  excludeDirs?: string[]
+  resolveIgnorePatterns: (layerName: string) => string[] | undefined
+  patterns?: ScanPatternSet
+}
+
+/**
+ * Detect translation keys that live in the wrong layer.
+ * - Child → Root: key in child layer but used from root or multiple apps
+ * - Root → Child: key in root layer but only used from a single child app
+ */
+export async function findMisplacedKeysForConfig(options: MisplacedKeysScanOptions): Promise<MisplacedKeysResult> {
+  const { keysByLayer, apps, excludeDirs, resolveIgnorePatterns, patterns } = options
+
+  if (apps.length <= 1) {
+    return { misplacedKeys: [], summary: { total: 0, moveToRoot: 0, moveToChild: 0, byCurrentLayer: {} } }
+  }
+
+  // Scan all app directories
+  const scanCache = await scanAllApps(apps, excludeDirs, patterns)
+
+  // Build per-app key usage: for each app, which keys does its source code reference?
+  const appKeyUsage = new Map<string, Set<string>>()
+  for (const app of apps) {
+    const result = scanCache.get(app.rootDir)
+    if (!result) continue
+    appKeyUsage.set(app.name, result.uniqueKeys)
+  }
+
+  // Also track bare string matches per app (keys referenced as dotted strings outside t() calls)
+  const appBareStrings = new Map<string, Set<string>>()
+  for (const app of apps) {
+    const result = scanCache.get(app.rootDir)
+    if (!result) continue
+    appBareStrings.set(app.name, result.bareStringCandidates)
+  }
+
+  // Find the root layer name (the layer that other apps depend on)
+  const rootApp = apps.find(a => {
+    // Root is the app that appears as a dependency of other apps
+    return apps.some(other => other.layers.includes(a.name))
+  })
+  const rootLayerName = rootApp?.name ?? apps[0].name
+
+  const misplacedKeys: MisplacedKeyEntry[] = []
+
+  for (const [layerName, { keys }] of keysByLayer) {
+    const ignorePatterns = resolveIgnorePatterns(layerName)
+    const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
+
+    for (const key of keys) {
+      // Skip ignored keys
+      if (ignoreRegexes.length > 0 && ignoreRegexes.some(re => re.test(key))) continue
+
+      // Determine which apps use this key
+      const usedByApps: string[] = []
+      for (const app of apps) {
+        const directKeys = appKeyUsage.get(app.name)
+        const bareStrings = appBareStrings.get(app.name)
+        if (directKeys?.has(key) || bareStrings?.has(key)) {
+          usedByApps.push(app.name)
+        }
+      }
+
+      // If no app uses the key, skip (it's an orphan, not misplaced)
+      if (usedByApps.length === 0) continue
+
+      const isInRoot = layerName === rootLayerName
+      const isUsedByMultipleApps = usedByApps.length > 1
+      const isUsedByRoot = usedByApps.includes(rootLayerName)
+
+      if (isInRoot) {
+        // Root → Child: key in root but used by only one child app (not root itself)
+        if (!isUsedByMultipleApps && !isUsedByRoot) {
+          misplacedKeys.push({
+            key,
+            currentLayer: layerName,
+            suggestedLayer: usedByApps[0],
+            usedIn: usedByApps,
+          })
+        }
+      } else {
+        // Child → Root: key in child layer but used from root or other apps
+        const isUsedOutsideOwnLayer = usedByApps.some(a => a !== layerName)
+        if (isUsedOutsideOwnLayer) {
+          misplacedKeys.push({
+            key,
+            currentLayer: layerName,
+            suggestedLayer: rootLayerName,
+            usedIn: usedByApps,
+          })
+        }
+      }
+    }
+  }
+
+  misplacedKeys.sort((a, b) => a.currentLayer.localeCompare(b.currentLayer) || a.key.localeCompare(b.key))
+
+  const moveToRoot = misplacedKeys.filter(m => m.suggestedLayer === rootLayerName).length
+  const moveToChild = misplacedKeys.length - moveToRoot
+  const byCurrentLayer: Record<string, number> = {}
+  for (const m of misplacedKeys) {
+    byCurrentLayer[m.currentLayer] = (byCurrentLayer[m.currentLayer] ?? 0) + 1
+  }
+
+  return {
+    misplacedKeys,
+    summary: {
+      total: misplacedKeys.length,
+      moveToRoot,
+      moveToChild,
+      byCurrentLayer,
+    },
+  }
+}
+
+// ─── Orphan Key Detection ───────────────────────────────────────
+
 export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promise<OrphanScanResult> {
   const { keysByLayer, apps, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import {
   renameNestedKey,
   validateTranslationValue,
 } from './io/key-operations.js'
-import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from './scanner/code-scanner.js'
+import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig, findMisplacedKeysForConfig } from './scanner/code-scanner.js'
 import { getPatternSet } from './scanner/patterns.js'
 import { log } from './utils/logger.js'
 import { ToolError } from './utils/errors.js'
@@ -1885,6 +1885,105 @@ export function createServer(): McpServer {
         }
       } catch (error) {
         return toolErrorResponse('finding orphan keys', error)
+      }
+    },
+  )
+
+  // ─── find_misplaced_keys ────────────────────────────────────────
+
+  server.registerTool(
+    'find_misplaced_keys',
+    {
+      title: 'Find Misplaced Translation Keys',
+      description:
+        'Detect translation keys living in the wrong layer. Flags keys in child layers used by root/other apps (should move to root), and keys in root used by only one child app (should move to that child). Requires a multi-layer project (e.g., Nuxt monorepo).',
+      inputSchema: {
+        locale: z
+          .string()
+          .optional()
+          .describe('Locale code to read translation keys from (e.g., "en", "en-US"). Defaults to the project default locale.'),
+        excludeDirs: z
+          .array(z.string())
+          .optional()
+          .describe('Directory names to skip when scanning source files. Example: ["storybook", "__tests__", "node_modules"].'),
+        ignorePatterns: z
+          .array(z.string())
+          .optional()
+          .describe('Glob patterns for keys to skip. Use * for single segment, ** for multiple. Example: ["common.datetime.**"].'),
+        projectDir: z
+          .string()
+          .optional()
+          .describe('Absolute path to the project root. Defaults to server cwd.'),
+      },
+    },
+    async ({ locale, excludeDirs, ignorePatterns, projectDir }) => {
+      try {
+        const dir = projectDir ?? process.cwd()
+        const config = await detectI18nConfig(dir)
+
+        if (config.apps.length <= 1) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ misplacedKeys: [], summary: { total: 0, message: 'Misplaced key detection requires a multi-layer project (e.g., Nuxt monorepo). This project has a single app.' } }, null, 2) }],
+          }
+        }
+
+        const localeCode = locale ?? config.defaultLocale
+        const localeDef = findLocale(config, localeCode)
+        if (!localeDef) {
+          throw new ToolError(
+            `Locale not found: "${localeCode}". Available: ${config.locales.map(l => l.code).join(', ')}`,
+            'LOCALE_NOT_FOUND',
+          )
+        }
+
+        const layersToCheck = config.localeDirs.filter(d => !d.aliasOf)
+        const keysByLayer = new Map<string, { keys: string[]; localeDir: { layer: string } }>()
+        for (const localeDir of layersToCheck) {
+          let data: Record<string, unknown>
+          try {
+            data = await readLocaleData(config, localeDir.layer, localeDef)
+          } catch {
+            continue
+          }
+          if (Object.keys(data).length === 0) continue
+          keysByLayer.set(localeDir.layer, { keys: getLeafKeys(data), localeDir })
+        }
+
+        const resolveIgnore = (layerName: string): string[] | undefined => {
+          const base = resolveOrphanIgnorePatterns(config, layerName)
+          if (!ignorePatterns && !base) return undefined
+          return [...(base ?? []), ...(ignorePatterns ?? [])]
+        }
+
+        const result = await findMisplacedKeysForConfig({
+          keysByLayer,
+          apps: config.apps,
+          excludeDirs: excludeDirs || undefined,
+          resolveIgnorePatterns: resolveIgnore,
+          patterns: getPatternSet(config.localeFileFormat),
+        })
+
+        const output = {
+          misplacedKeys: result.misplacedKeys,
+          summary: result.summary,
+        }
+
+        const reportPath = resolveReportFilePath(config, dir, 'find_misplaced_keys')
+        if (reportPath) {
+          await writeReportFile(reportPath, output, {
+            tool: 'find_misplaced_keys',
+            args: { locale, excludeDirs, ignorePatterns },
+          })
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ reportFile: reportPath, summary: output.summary }, null, 2) }],
+          }
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
+        }
+      } catch (error) {
+        return toolErrorResponse('finding misplaced keys', error)
       }
     },
   )

--- a/tests/scanner/misplaced-keys.test.ts
+++ b/tests/scanner/misplaced-keys.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdir, writeFile, rm } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { findMisplacedKeysForConfig } from '../../src/scanner/code-scanner.js'
+import type { AppInfo } from '../../src/config/types.js'
+
+const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/misplaced')
+
+async function createFile(relativePath: string, content: string) {
+  const fullPath = join(tmpDir, relativePath)
+  await mkdir(dirname(fullPath), { recursive: true })
+  await writeFile(fullPath, content)
+}
+
+describe('findMisplacedKeysForConfig', () => {
+  beforeAll(async () => {
+    await mkdir(tmpDir, { recursive: true })
+
+    // root layer source files
+    await createFile('root/components/SharedComponent.vue', `
+      <template>{{ $t('shared.title') }}</template>
+      <script setup>
+      const label = t('shared.actions.save')
+      const onlyRoot = t('root.only.here')
+      </script>
+    `)
+
+    // app-admin source files
+    await createFile('app-admin/pages/Dashboard.vue', `
+      <template>{{ $t('admin.dashboard.title') }}</template>
+      <script setup>
+      const x = t('admin.settings.label')
+      const shared = t('shared.title')
+      </script>
+    `)
+
+    // app-shop source files
+    await createFile('app-shop/pages/Products.vue', `
+      <template>{{ $t('shop.products.title') }}</template>
+      <script setup>
+      const y = t('shared.title')
+      const childOnly = t('child.in.root')
+      </script>
+    `)
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  const apps: AppInfo[] = [
+    { name: 'root', rootDir: join(tmpDir, 'root'), layers: [] },
+    { name: 'app-admin', rootDir: join(tmpDir, 'app-admin'), layers: ['root'] },
+    { name: 'app-shop', rootDir: join(tmpDir, 'app-shop'), layers: ['root'] },
+  ]
+
+  it('returns empty for single-app projects', async () => {
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer: new Map([['root', { keys: ['some.key'], localeDir: { layer: 'root' } }]]),
+      apps: [{ name: 'root', rootDir: join(tmpDir, 'root'), layers: [] }],
+      resolveIgnorePatterns: () => undefined,
+    })
+    expect(result.misplacedKeys).toEqual([])
+    expect(result.summary.total).toBe(0)
+  })
+
+  it('detects child key used from root (child → root)', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['shared.title', 'admin.dashboard.title'], localeDir: { layer: 'app-admin' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    const misplaced = result.misplacedKeys.find(m => m.key === 'shared.title')
+    expect(misplaced).toBeDefined()
+    expect(misplaced!.currentLayer).toBe('app-admin')
+    expect(misplaced!.suggestedLayer).toBe('root')
+    expect(misplaced!.usedIn).toContain('root')
+  })
+
+  it('does not flag child key used only by its own layer', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['admin.dashboard.title', 'admin.settings.label'], localeDir: { layer: 'app-admin' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    const flagged = result.misplacedKeys.filter(m => m.key.startsWith('admin.'))
+    expect(flagged).toEqual([])
+  })
+
+  it('detects root key used only by one child (root → child)', async () => {
+    const keysByLayer = new Map([
+      ['root', { keys: ['child.in.root', 'shared.title', 'root.only.here'], localeDir: { layer: 'root' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    const misplaced = result.misplacedKeys.find(m => m.key === 'child.in.root')
+    expect(misplaced).toBeDefined()
+    expect(misplaced!.currentLayer).toBe('root')
+    expect(misplaced!.suggestedLayer).toBe('app-shop')
+    expect(misplaced!.usedIn).toEqual(['app-shop'])
+  })
+
+  it('does not flag root key used by root itself', async () => {
+    const keysByLayer = new Map([
+      ['root', { keys: ['root.only.here'], localeDir: { layer: 'root' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    expect(result.misplacedKeys).toEqual([])
+  })
+
+  it('does not flag root key used by multiple children', async () => {
+    const keysByLayer = new Map([
+      ['root', { keys: ['shared.title'], localeDir: { layer: 'root' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    const flagged = result.misplacedKeys.find(m => m.key === 'shared.title')
+    expect(flagged).toBeUndefined()
+  })
+
+  it('flags child key used by another child (not just root)', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['shared.title'], localeDir: { layer: 'app-admin' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    const misplaced = result.misplacedKeys.find(m => m.key === 'shared.title')
+    expect(misplaced).toBeDefined()
+    expect(misplaced!.suggestedLayer).toBe('root')
+    expect(misplaced!.usedIn).toContain('app-shop')
+  })
+
+  it('respects ignorePatterns', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['shared.title', 'shared.actions.save'], localeDir: { layer: 'app-admin' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => ['shared.**'],
+    })
+
+    expect(result.misplacedKeys).toEqual([])
+  })
+
+  it('skips orphan keys (used by zero apps)', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['nonexistent.key.nowhere'], localeDir: { layer: 'app-admin' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    expect(result.misplacedKeys).toEqual([])
+  })
+
+  it('summary counts are correct', async () => {
+    const keysByLayer = new Map([
+      ['app-admin', { keys: ['shared.title'], localeDir: { layer: 'app-admin' } }],
+      ['root', { keys: ['child.in.root'], localeDir: { layer: 'root' } }],
+    ])
+
+    const result = await findMisplacedKeysForConfig({
+      keysByLayer,
+      apps,
+      resolveIgnorePatterns: () => undefined,
+    })
+
+    expect(result.summary.moveToRoot).toBe(1)
+    expect(result.summary.moveToChild).toBe(1)
+    expect(result.summary.total).toBe(2)
+    expect(result.summary.byCurrentLayer['app-admin']).toBe(1)
+    expect(result.summary.byCurrentLayer['root']).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new `find_misplaced_keys` MCP tool that audits translation key placement across layers in multi-layer Nuxt monorepos. Detects:
- **Child → Root**: keys in child layers used by root or other apps (should move to root)
- **Root → Child**: keys in root used by only one child app (should move to that child)

## Changes

- `src/scanner/code-scanner.ts`: Added `findMisplacedKeysForConfig()` with `MisplacedKeyEntry`, `MisplacedKeysResult`, `MisplacedKeysScanOptions` interfaces
- `src/server.ts`: Registered `find_misplaced_keys` tool with locale, excludeDirs, ignorePatterns, projectDir params
- `schema.json`: Updated reportOutput description to include the new tool
- `tests/scanner/misplaced-keys.test.ts`: 9 tests covering all placement scenarios

## Testing

- `pnpm typecheck` ✅
- `pnpm test` ✅ (521 tests pass)
- `pnpm build` ✅

## Related Issues

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic tool to detect i18n keys that may be misplaced across app layers, helping identify and suggest corrections for configuration issues in multi-app i18n setups. Includes support for locale selection and filtering options.

* **Tests**
  * Added comprehensive test coverage for the misplaced key detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->