### PR TITLE
fix: simplify orphan scan — root-first scan, fix false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,21 @@ Drop a `.i18n-mcp.json` at your project root for project-specific context:
 
 The scanner finds translation key references in source code:
 
-**Nuxt/Vue patterns:** `$t('key')`, `t('key')`, `$tc('key')`, `i18n.t('key')`, `v-t="'key'"`, template literals with `$t`
+**Nuxt/Vue patterns:** `$t('key')`, `t('key')`, `$tc('key')`, `i18n.t('key')`, template literals with `$t`
 
 **Laravel/PHP patterns:** `__('key')`, `trans('key')`, `@lang('key')`, `Lang::get('key')`, `trans_choice('key')`
 
-**Dynamic key handling:**
-- Template literals like `` $t(`status.${val}`) `` → the scanner extracts `status.` as a prefix and matches all keys under `status.*`
-- Keys matching dynamic prefixes are excluded from orphan results (reported as "uncertain" separately)
-- String concatenation (`'prefix.' + var`) is **not** detected — use template literals for coverage
+**Bare string candidates:** Any quoted dot-notation string in source (`'some.key'`, `"some.key"`) is treated as a potential key reference — regardless of whether it's inside a `t()` call. This catches patterns like `{ label: 'common.actions.save', i18n: true }` and non-standard i18n call styles.
 
-**Monorepo scope:**
-- Each layer's keys are scanned only against source files that consume that layer
-- Layer consumption is determined by the framework's layer/dependency graph
+**Dynamic key handling:**
+- Template literals: `` $t(`status.${val}`) `` → matches all keys under `status.*`
+- String concatenation: `t('prefix.' + var)` → matches all keys under `prefix.*` (single-line and multiline forms both detected)
+- Keys matched by dynamic patterns are reported as "uncertain" separately and excluded from cleanup
+
+**Scan scope:**
+- The scanner always starts from the project root and recurses into all subdirectories
+- All layers share the same combined scan results — no per-layer dependency graph needed
+- Standard ignore dirs (`node_modules`, `.nuxt`, `.output`, `dist`) are excluded automatically
 
 ## Development
 

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -1376,8 +1376,7 @@ export async function findOrphanKeysOp(opts: {
 
   const orphanResult = await findOrphanKeysForConfig({
     keysByLayer,
-    apps: config.apps,
-    scanDirs: scanDirs || undefined,
+    scanDirs: scanDirs || [dir],
     excludeDirs: excludeDirs || undefined,
     resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),
@@ -1597,8 +1596,7 @@ export async function cleanupUnusedTranslations(opts: {
 
   const orphanResult = await findOrphanKeysForConfig({
     keysByLayer,
-    apps: config.apps,
-    scanDirs: scanDirs || undefined,
+    scanDirs: scanDirs || [dir],
     excludeDirs: excludeDirs || undefined,
     resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -1,11 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { glob } from 'tinyglobby'
-import { DepGraph } from 'dependency-graph'
 import { log } from '../utils/logger.js'
 import type { ScanPatternSet } from './patterns.js'
 import { VUE_NUXT_PATTERNS } from './patterns.js'
-import type { AppInfo } from '../config/types.js'
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -238,9 +236,15 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   let filesScanned = 0
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
-  const BARE_DYNAMIC_TEMPLATE = /`((?:[^`\\]|\\.)*\$\{(?:[^`\\]|\\.)*)`/g
+  const BARE_DYNAMIC_TEMPLATE = /`([^`\\\n]{0,200}\$\{[^`\\\n]{0,200})`/g
   /** Matches PHP double-quoted strings containing $var or {$var} interpolation with at least one dot */
   const BARE_PHP_DYNAMIC = /"((?:[^"\\]|\\.)*(?:\{\$|\$[a-zA-Z_])(?:[^"\\]|\\.)*)"/g
+  /**
+   * Matches string concat prefixes ending with a dot: 'some.key.' + var
+   * Catches multiline t() calls where the prefix is on a separate line from t(.
+   * Group 1: the prefix without trailing dot.
+   */
+  const BARE_CONCAT_PREFIX = /['"](((?:[\w-]+\.)+[\w-]+)\.)['"]\s*\+/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)
@@ -277,6 +281,12 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
         .replace(/\{\$[^}]+\}/g, '${_}')
         .replace(/\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*/g, '${_}')
       bareDynamicCandidates.add(`\`${normalized}\``)
+    }
+
+    // Concat prefix: 'some.key.' + var  (catches multiline t() calls)
+    BARE_CONCAT_PREFIX.lastIndex = 0
+    for (const match of content.matchAll(BARE_CONCAT_PREFIX)) {
+      bareDynamicCandidates.add(`\`${match[2]}.\${_}\``)
     }
 
     filesScanned++
@@ -324,100 +334,10 @@ export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
   })
 }
 
-// ─── Layer scan planning ────────────────────────────────────────
-
-export interface LayerScanPlan {
-  dir: string
-  excludeDirs: string[]
-}
-
-export async function scanAllApps(
-  apps: AppInfo[],
-  excludeDirs: string[] | undefined,
-  patterns?: ScanPatternSet,
-): Promise<Map<string, ScanResult>> {
-  const cache = new Map<string, ScanResult>()
-  const seen = new Set<string>()
-
-  for (const app of apps) {
-    if (seen.has(app.rootDir)) continue
-    seen.add(app.rootDir)
-    const result = await scanSourceFiles(app.rootDir, excludeDirs ?? [], patterns)
-    cache.set(app.rootDir, result)
-  }
-
-  return cache
-}
-
-export function buildLayerScanPlan(
-  layerName: string,
-  apps: AppInfo[],
-  userExcludeDirs: string[] | undefined,
-): LayerScanPlan[] {
-  const baseExclude = userExcludeDirs ?? []
-  const graph = new DepGraph<string>()
-  const APP_PREFIX = 'app::'
-
-  for (const app of apps) {
-    graph.addNode(APP_PREFIX + app.name, app.rootDir)
-    for (const layer of app.layers) {
-      if (!graph.hasNode(layer)) graph.addNode(layer, '')
-      graph.addDependency(APP_PREFIX + app.name, layer)
-    }
-  }
-
-  let consumerAppNames: string[]
-  try {
-    consumerAppNames = graph.dependantsOf(layerName)
-      .filter(n => n.startsWith(APP_PREFIX))
-      .map(n => n.slice(APP_PREFIX.length))
-  } catch {
-    consumerAppNames = apps.map(a => a.name)
-  }
-
-  if (consumerAppNames.length === 0) {
-    consumerAppNames = [layerName]
-  }
-
-  const scannedDirs = new Set<string>()
-  const plans: LayerScanPlan[] = []
-
-  const layerRootDirs = new Map<string, string>()
-  for (const app of apps) {
-    layerRootDirs.set(app.name, app.rootDir)
-  }
-
-  for (const appName of consumerAppNames) {
-    const app = apps.find(a => a.name === appName)
-    if (!app) continue
-    if (!scannedDirs.has(app.rootDir)) {
-      scannedDirs.add(app.rootDir)
-      plans.push({ dir: app.rootDir, excludeDirs: baseExclude })
-    }
-    for (const depLayer of app.layers) {
-      const depApp = apps.find(a => a.name === depLayer)
-      if (!depApp) continue
-      if (scannedDirs.has(depApp.rootDir)) continue
-      scannedDirs.add(depApp.rootDir)
-      plans.push({ dir: depApp.rootDir, excludeDirs: baseExclude })
-    }
-  }
-
-  if (plans.length === 0) {
-    for (const app of apps) {
-      if (scannedDirs.has(app.rootDir)) continue
-      scannedDirs.add(app.rootDir)
-      plans.push({ dir: app.rootDir, excludeDirs: baseExclude })
-    }
-  }
-
-  return plans
-}
-
 export interface OrphanScanOptions {
   keysByLayer: Map<string, { keys: string[]; localeDir: { layer: string } }>
-  apps: AppInfo[]
-  scanDirs?: string[]
+  /** Root directories to scan for source file usage. Scanned recursively. */
+  scanDirs: string[]
   excludeDirs?: string[]
   resolveIgnorePatterns: (layerName: string) => string[] | undefined
   patterns?: ScanPatternSet
@@ -450,67 +370,40 @@ export interface OrphanScanResult {
 }
 
 export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promise<OrphanScanResult> {
-  const { keysByLayer, apps, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
+  const { keysByLayer, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
 
-  let scanCache: Map<string, ScanResult>
-  if (scanDirs) {
-    scanCache = new Map()
-    for (const dir of scanDirs) {
-      scanCache.set(dir, await scanSourceFiles(dir, excludeDirs ?? [], patterns))
+  // Single recursive scan from each provided root dir.
+  // All layers share the combined results — no per-layer scan planning needed.
+  const combinedUniqueKeys = new Set<string>()
+  const combinedBareStrings = new Set<string>()
+  const allDynamicKeysRaw: Array<{ expression: string; file: string; line: number; callee: string }> = []
+  let totalFilesScanned = 0
+
+  for (const dir of scanDirs) {
+    const result = await scanSourceFiles(dir, excludeDirs ?? [], patterns)
+    totalFilesScanned += result.filesScanned
+    for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
+    for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
+    allDynamicKeysRaw.push(...result.dynamicKeys)
+    for (const bd of result.bareDynamicCandidates) {
+      allDynamicKeysRaw.push({ expression: bd, file: '', line: 0, callee: '' })
     }
-  } else {
-    scanCache = await scanAllApps(apps, excludeDirs, patterns)
   }
+
+  const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeysRaw)
+  const unresolvedWarnings = buildUnresolvedWarnings(allDynamicKeysRaw)
+  const uncertainRegexes = buildIgnorePatternRegexes(unresolvedWarnings.map(w => w.suggestedIgnorePattern))
 
   const orphansByLayer: Record<string, string[]> = {}
   let orphanCount = 0
   const uncertainByLayer: Record<string, string[]> = {}
   let uncertainCount = 0
-  let totalFilesScanned = 0
   let dynamicMatchedCount = 0
   let ignoredCount = 0
-  const allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
-  const dirsScanned: string[] = []
-
-  for (const result of scanCache.values()) {
-    totalFilesScanned += result.filesScanned
-  }
-
-  const unresolvedWarnings: UnresolvedKeyWarning[] = []
 
   for (const [layerName, { keys }] of keysByLayer) {
-    let relevantResults: ScanResult[]
-    if (scanDirs) {
-      relevantResults = [...scanCache.values()]
-    } else {
-      const plans = buildLayerScanPlan(layerName, apps, excludeDirs)
-      dirsScanned.push(...plans.map(p => p.dir))
-      relevantResults = plans
-        .map(p => scanCache.get(p.dir))
-        .filter((r): r is ScanResult => r !== undefined)
-    }
-
-    const combinedUniqueKeys = new Set<string>()
-    const combinedBareStrings = new Set<string>()
-    const layerDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
-
-    for (const result of relevantResults) {
-      for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
-      for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
-      layerDynamicKeys.push(...result.dynamicKeys)
-      for (const bd of result.bareDynamicCandidates) {
-        layerDynamicKeys.push({ expression: bd, file: '', line: 0, callee: '' })
-      }
-    }
-
-    allDynamicKeys.push(...layerDynamicKeys)
-    const dynamicKeyRegexes = buildDynamicKeyRegexes(layerDynamicKeys)
     const ignorePatterns = resolveIgnorePatterns(layerName)
     const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
-
-    const layerWarnings = buildUnresolvedWarnings(layerDynamicKeys)
-    unresolvedWarnings.push(...layerWarnings)
-    const uncertainRegexes = buildIgnorePatternRegexes(layerWarnings.map(w => w.suggestedIgnorePattern))
 
     const orphans = keys.filter((k) => {
       if (combinedUniqueKeys.has(k)) return false
@@ -554,8 +447,8 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
     totalFilesScanned,
     dynamicMatchedCount,
     ignoredCount,
-    allDynamicKeys,
-    dirsScanned: [...new Set(dirsScanned)],
+    allDynamicKeys: allDynamicKeysRaw,
+    dirsScanned: scanDirs,
     unresolvedKeyWarnings: unresolvedWarnings,
   }
 }

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes, buildLayerScanPlan } from '../../src/scanner/code-scanner.js'
-import type { AppInfo } from '../../src/config/types.js'
+import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
@@ -654,74 +653,4 @@ describe('toRelativePath', () => {
   })
 })
 
-describe('buildLayerScanPlan', () => {
-  it('single app — scans app root for any layer', () => {
-    const apps: AppInfo[] = [
-      { name: 'root', rootDir: '/project', layers: ['root', 'ui', 'shared'] }
-    ]
-    const plans = buildLayerScanPlan('ui', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/project')
-    expect(plans[0].excludeDirs).toEqual([])
-  })
 
-  it('monorepo siblings — shared layer scans all consumer apps', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, undefined)
-    expect(plans).toHaveLength(2)
-    const dirs = plans.map(p => p.dir).sort()
-    expect(dirs).toEqual(['/mono/app-1', '/mono/app-2'])
-  })
-
-  it('monorepo siblings — app-specific layer scans only that app', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-1', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/mono/app-1')
-  })
-
-  it('passes user excludeDirs to all plans', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, ['storybook'])
-    for (const plan of plans) {
-      expect(plan.excludeDirs).toContain('storybook')
-    }
-  })
-
-  it('deduplicates scan dirs when apps share rootDir', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/project', layers: ['root', 'ui'] },
-      { name: 'app-2', rootDir: '/project', layers: ['root', 'shared'] },
-    ]
-    const plans = buildLayerScanPlan('root', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/project')
-  })
-
-  it('monorepo nested — shared layer scans all consumer apps', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/shared/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/shared/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, undefined)
-    expect(plans).toHaveLength(2)
-  })
-
-  it('falls back to all apps when layer not in graph', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1'] },
-    ]
-    const plans = buildLayerScanPlan('unknown-layer', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/mono/app-1')
-  })
-})


### PR DESCRIPTION
## What changed

### Orphan detection: scan from project root

Previously, `findOrphanKeysForConfig` built a per-layer scan plan using a dependency graph of Nuxt apps. Two problems:

1. Root Nuxt app (`.`) failed to load on relative paths → root `components/` never scanned → ~600 false positives
2. Unnecessary complexity: brittle dependency-graph logic

**New approach:** always scan recursively from `projectDir`. All layers share one combined scan result. No dependency graph needed.

Result on anny-ui: **1713 → 1103 orphans** (610 false positives removed), files scanned 1486 → 2526.

### Fixed: multiline concat prefix not detected

```ts
return t(
  'some.key.prefix.' + dynamicVar,
  { ... }
)
```

`t(` and prefix on different lines → `VUE_CONCAT_KEY` (line-by-line) missed it. Added `BARE_CONCAT_PREFIX` regex over full file content. Fixed 11 false positives in `shelly.activeWindow.*`, `microsoft365/teams/zoom.settings.*`.

### Fixed: BARE_DYNAMIC_TEMPLATE regex too greedy

Old regex matched backtick-to-backtick across unlimited lines — captured entire Vue SFC file contents as one expression. Capped to 200 chars per segment and banned newlines.

### Removed: `buildLayerScanPlan` + `scanAllApps` (~80 lines, 7 tests)

Dead code now that orphan scan always uses a single root scan dir.

### README: updated orphan detection docs

- Removed incorrect claim that `'prefix.' + var` concat is undetected
- Updated scan scope description (root-first, no dependency graph)
- Added bare string candidate matching explanation

## Stats (anny-ui)

| | Before | After |
|---|---|---|
| Files scanned | 1,486 | 2,526 |
| Certain orphans | 1,713 | 1,103 |
| False positives eliminated | — | 610 |
| Uncertain (dynamic) | 36 | 31 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced "How Orphan Detection Works" documentation with expanded scanner capability descriptions, improved clarity on Nuxt/Vue pattern detection and bare string translation key reference handling.

* **Refactor**
  * Streamlined orphan key detection from per-layer scanning to a single combined scan across all project layers with automatic standard ignore directory exclusion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fabkho/the-i18n-kit/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->