### PR TITLE
feat: add outputFile param to large-output tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,21 @@ Drop a `.i18n-mcp.json` at your project root for project-specific context:
 
 The scanner finds translation key references in source code:
 
-**Nuxt/Vue patterns:** `$t('key')`, `t('key')`, `$tc('key')`, `i18n.t('key')`, `v-t="'key'"`, template literals with `$t`
+**Nuxt/Vue patterns:** `$t('key')`, `t('key')`, `$tc('key')`, `i18n.t('key')`, template literals with `$t`
 
 **Laravel/PHP patterns:** `__('key')`, `trans('key')`, `@lang('key')`, `Lang::get('key')`, `trans_choice('key')`
 
-**Dynamic key handling:**
-- Template literals like `` $t(`status.${val}`) `` → the scanner extracts `status.` as a prefix and matches all keys under `status.*`
-- Keys matching dynamic prefixes are excluded from orphan results (reported as "uncertain" separately)
-- String concatenation (`'prefix.' + var`) is **not** detected — use template literals for coverage
+**Bare string candidates:** Any quoted dot-notation string in source (`'some.key'`, `"some.key"`) is treated as a potential key reference — regardless of whether it's inside a `t()` call. This catches patterns like `{ label: 'common.actions.save', i18n: true }` and non-standard i18n call styles.
 
-**Monorepo scope:**
-- Each layer's keys are scanned only against source files that consume that layer
-- Layer consumption is determined by the framework's layer/dependency graph
+**Dynamic key handling:**
+- Template literals: `` $t(`status.${val}`) `` → matches all keys under `status.*`
+- String concatenation: `t('prefix.' + var)` → matches all keys under `prefix.*` (single-line and multiline forms both detected)
+- Keys matched by dynamic patterns are reported as "uncertain" separately and excluded from cleanup
+
+**Scan scope:**
+- The scanner always starts from the project root and recurses into all subdirectories
+- All layers share the same combined scan results — no per-layer dependency graph needed
+- Standard ignore dirs (`node_modules`, `.nuxt`, `.output`, `dist`) are excluded automatically
 
 ## Development
 

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -15,6 +15,21 @@ export const sharedArgs = {
 
 /** Output result — JSON for piped/--json, pretty-printed for TTY */
 export function outputResult(data: unknown, args: { json?: boolean }): void {
+  // When result has reportFile key, format it nicely
+  if (
+    data !== null &&
+    typeof data === 'object' &&
+    'reportFile' in (data as Record<string, unknown>)
+  ) {
+    const { reportFile, ...rest } = data as Record<string, unknown>
+    const summaryJson = JSON.stringify(rest, null, 2)
+    if (args.json || !process.stdout.isTTY) {
+      process.stdout.write(`Wrote report to: ${reportFile}\n${summaryJson}\n`)
+    } else {
+      consola.log(`Wrote report to: ${reportFile}\n${summaryJson}`)
+    }
+    return
+  }
   const json = JSON.stringify(data, null, 2)
   if (args.json || !process.stdout.isTTY) {
     process.stdout.write(json + '\n')

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -22,6 +22,10 @@ export default defineCommand({
       description: 'Preview without removing (default: true)',
       default: true,
     },
+    outputFile: {
+      type: 'string',
+      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
+    },
   },
   async run({ args }) {
     const result = await cleanupUnusedTranslations({
@@ -29,6 +33,7 @@ export default defineCommand({
       locale: args.locale,
       dryRun: args.dryRun,
       projectDir: args.projectDir,
+      outputFile: args.outputFile,
     })
     outputResult(result, args)
   },

--- a/packages/cli/src/commands/empty.ts
+++ b/packages/cli/src/commands/empty.ts
@@ -17,12 +17,17 @@ export default defineCommand({
       type: 'string',
       description: 'Filter to a specific locale',
     },
+    outputFile: {
+      type: 'string',
+      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
+    },
   },
   async run({ args }) {
     const result = await findEmptyTranslations({
       layer: args.layer,
       locale: args.locale,
       projectDir: args.projectDir,
+      outputFile: args.outputFile,
     })
     outputResult(result, args)
   },

--- a/packages/cli/src/commands/missing.ts
+++ b/packages/cli/src/commands/missing.ts
@@ -21,6 +21,10 @@ export default defineCommand({
       type: 'string',
       description: 'Comma-separated target locales (default: all except ref)',
     },
+    outputFile: {
+      type: 'string',
+      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
+    },
   },
   async run({ args }) {
     const result = await getMissingTranslations({
@@ -28,6 +32,7 @@ export default defineCommand({
       referenceLocale: args.ref,
       targetLocales: splitList(args.targets),
       projectDir: args.projectDir,
+      outputFile: args.outputFile,
     })
     outputResult(result, args)
   },

--- a/packages/cli/src/commands/orphans.ts
+++ b/packages/cli/src/commands/orphans.ts
@@ -17,12 +17,17 @@ export default defineCommand({
       type: 'string',
       description: 'Locale to check (default: project default)',
     },
+    outputFile: {
+      type: 'string',
+      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
+    },
   },
   async run({ args }) {
     const result = await findOrphanKeysOp({
       layer: args.layer,
       locale: args.locale,
       projectDir: args.projectDir,
+      outputFile: args.outputFile,
     })
     outputResult(result, args)
   },

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -13,11 +13,16 @@ export default defineCommand({
       type: 'string',
       description: 'Comma-separated keys to report on (default: all)',
     },
+    outputFile: {
+      type: 'string',
+      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
+    },
   },
   async run({ args }) {
     const result = await scanCodeUsageOp({
       keys: splitList(args.keys),
       projectDir: args.projectDir,
+      outputFile: args.outputFile,
     })
     outputResult(result, args)
   },

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -1376,8 +1376,7 @@ export async function findOrphanKeysOp(opts: {
 
   const orphanResult = await findOrphanKeysForConfig({
     keysByLayer,
-    apps: config.apps,
-    scanDirs: scanDirs || undefined,
+    scanDirs: scanDirs || [dir],
     excludeDirs: excludeDirs || undefined,
     resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),
@@ -1597,8 +1596,7 @@ export async function cleanupUnusedTranslations(opts: {
 
   const orphanResult = await findOrphanKeysForConfig({
     keysByLayer,
-    apps: config.apps,
-    scanDirs: scanDirs || undefined,
+    scanDirs: scanDirs || [dir],
     excludeDirs: excludeDirs || undefined,
     resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -601,6 +601,7 @@ export async function getMissingTranslations(opts: {
   targetLocales?: string[]
   locales?: string[]
   projectDir?: string
+  outputFile?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { layer } = opts
   const dir = opts.projectDir ?? process.cwd()
@@ -687,7 +688,7 @@ export async function getMissingTranslations(opts: {
     },
   }
 
-  const reportPath = resolveReportFilePath(config, dir, 'get_missing_translations')
+  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'get_missing_translations')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'get_missing_translations',
@@ -706,6 +707,7 @@ export async function findEmptyTranslations(opts: {
   layer?: string
   locale?: string
   projectDir?: string
+  outputFile?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { layer, locale } = opts
   const dir = opts.projectDir ?? process.cwd()
@@ -770,7 +772,7 @@ export async function findEmptyTranslations(opts: {
     },
   }
 
-  const reportPath = resolveReportFilePath(config, dir, 'find_empty_translations')
+  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_empty_translations')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'find_empty_translations',
@@ -1316,6 +1318,7 @@ export async function findOrphanKeysOp(opts: {
   scanDirs?: string[]
   excludeDirs?: string[]
   projectDir?: string
+  outputFile?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
@@ -1363,7 +1366,7 @@ export async function findOrphanKeysOp(opts: {
   const totalKeys = [...keysByLayer.values()].reduce((sum, v) => sum + v.keys.length, 0)
   if (totalKeys === 0) {
     const emptyOutput = { orphanKeys: {} as Record<string, string[]>, summary: { totalKeys: 0, orphanCount: 0, filesScanned: 0, message: 'No translation keys found in locale files.' } }
-    const reportPath = resolveReportFilePath(config, dir, 'find_orphan_keys')
+    const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
     if (reportPath) {
       await writeReportFile(reportPath, emptyOutput, {
         tool: 'find_orphan_keys',
@@ -1430,7 +1433,7 @@ export async function findOrphanKeysOp(opts: {
       : undefined,
   }
 
-  const reportPath = resolveReportFilePath(config, dir, 'find_orphan_keys')
+  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'find_orphan_keys',
@@ -1450,6 +1453,7 @@ export async function scanCodeUsageOp(opts: {
   scanDirs?: string[]
   excludeDirs?: string[]
   projectDir?: string
+  outputFile?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { keys, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
@@ -1513,7 +1517,7 @@ export async function scanCodeUsageOp(opts: {
     }))
   }
 
-  const reportPath = resolveReportFilePath(config, dir, 'scan_code_usage')
+  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'scan_code_usage')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'scan_code_usage',
@@ -1535,6 +1539,7 @@ export async function cleanupUnusedTranslations(opts: {
   excludeDirs?: string[]
   dryRun?: boolean
   projectDir?: string
+  outputFile?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
@@ -1583,7 +1588,7 @@ export async function cleanupUnusedTranslations(opts: {
   const totalKeys = [...keysByLayer.values()].reduce((sum, v) => sum + v.keys.length, 0)
   if (totalKeys === 0) {
     const emptyOutput = { orphanKeys: {}, removed: {}, summary: { totalKeys: 0, orphanCount: 0, message: 'No translation keys found.' } }
-    const emptyReportPath = resolveReportFilePath(config, dir, 'cleanup_unused_translations')
+    const emptyReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'cleanup_unused_translations')
     if (emptyReportPath) {
       await writeReportFile(emptyReportPath, emptyOutput, {
         tool: 'cleanup_unused_translations',
@@ -1623,7 +1628,7 @@ export async function cleanupUnusedTranslations(opts: {
       uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
       summary: { totalKeys, orphanCount: 0, uncertainCount: orphanResult.uncertainCount, dynamicMatchedCount, ignoredCount, filesScanned: totalFilesScanned, message: messageParts.join(' ') },
     }
-    const zeroReportPath = resolveReportFilePath(config, dir, 'cleanup_unused_translations')
+    const zeroReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'cleanup_unused_translations')
     if (zeroReportPath) {
       await writeReportFile(zeroReportPath, zeroOutput, {
         tool: 'cleanup_unused_translations',
@@ -1664,7 +1669,7 @@ export async function cleanupUnusedTranslations(opts: {
         suggestedIgnorePattern: w.suggestedIgnorePattern,
       }))
     }
-    const dryRunReportPath = resolveReportFilePath(config, dir, 'cleanup_unused_translations')
+    const dryRunReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'cleanup_unused_translations')
     if (dryRunReportPath) {
       await writeReportFile(dryRunReportPath, output, {
         tool: 'cleanup_unused_translations',
@@ -1715,7 +1720,7 @@ export async function cleanupUnusedTranslations(opts: {
     },
   }
 
-  const removalReportPath = resolveReportFilePath(config, dir, 'cleanup_unused_translations')
+  const removalReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'cleanup_unused_translations')
   if (removalReportPath) {
     await writeReportFile(removalReportPath, removalOutput, {
       tool: 'cleanup_unused_translations',

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -1,11 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { glob } from 'tinyglobby'
-import { DepGraph } from 'dependency-graph'
 import { log } from '../utils/logger.js'
 import type { ScanPatternSet } from './patterns.js'
 import { VUE_NUXT_PATTERNS } from './patterns.js'
-import type { AppInfo } from '../config/types.js'
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -238,9 +236,15 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   let filesScanned = 0
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
-  const BARE_DYNAMIC_TEMPLATE = /`((?:[^`\\]|\\.)*\$\{(?:[^`\\]|\\.)*)`/g
+  const BARE_DYNAMIC_TEMPLATE = /`([^`\\\n]{0,200}\$\{[^`\\\n]{0,200})`/g
   /** Matches PHP double-quoted strings containing $var or {$var} interpolation with at least one dot */
   const BARE_PHP_DYNAMIC = /"((?:[^"\\]|\\.)*(?:\{\$|\$[a-zA-Z_])(?:[^"\\]|\\.)*)"/g
+  /**
+   * Matches string concat prefixes ending with a dot: 'some.key.' + var
+   * Catches multiline t() calls where the prefix is on a separate line from t(.
+   * Group 1: the prefix without trailing dot.
+   */
+  const BARE_CONCAT_PREFIX = /['"](((?:[\w-]+\.)+[\w-]+)\.)['"]\s*\+/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)
@@ -277,6 +281,12 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
         .replace(/\{\$[^}]+\}/g, '${_}')
         .replace(/\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*/g, '${_}')
       bareDynamicCandidates.add(`\`${normalized}\``)
+    }
+
+    // Concat prefix: 'some.key.' + var  (catches multiline t() calls)
+    BARE_CONCAT_PREFIX.lastIndex = 0
+    for (const match of content.matchAll(BARE_CONCAT_PREFIX)) {
+      bareDynamicCandidates.add(`\`${match[2]}.\${_}\``)
     }
 
     filesScanned++
@@ -324,100 +334,10 @@ export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
   })
 }
 
-// ─── Layer scan planning ────────────────────────────────────────
-
-export interface LayerScanPlan {
-  dir: string
-  excludeDirs: string[]
-}
-
-export async function scanAllApps(
-  apps: AppInfo[],
-  excludeDirs: string[] | undefined,
-  patterns?: ScanPatternSet,
-): Promise<Map<string, ScanResult>> {
-  const cache = new Map<string, ScanResult>()
-  const seen = new Set<string>()
-
-  for (const app of apps) {
-    if (seen.has(app.rootDir)) continue
-    seen.add(app.rootDir)
-    const result = await scanSourceFiles(app.rootDir, excludeDirs ?? [], patterns)
-    cache.set(app.rootDir, result)
-  }
-
-  return cache
-}
-
-export function buildLayerScanPlan(
-  layerName: string,
-  apps: AppInfo[],
-  userExcludeDirs: string[] | undefined,
-): LayerScanPlan[] {
-  const baseExclude = userExcludeDirs ?? []
-  const graph = new DepGraph<string>()
-  const APP_PREFIX = 'app::'
-
-  for (const app of apps) {
-    graph.addNode(APP_PREFIX + app.name, app.rootDir)
-    for (const layer of app.layers) {
-      if (!graph.hasNode(layer)) graph.addNode(layer, '')
-      graph.addDependency(APP_PREFIX + app.name, layer)
-    }
-  }
-
-  let consumerAppNames: string[]
-  try {
-    consumerAppNames = graph.dependantsOf(layerName)
-      .filter(n => n.startsWith(APP_PREFIX))
-      .map(n => n.slice(APP_PREFIX.length))
-  } catch {
-    consumerAppNames = apps.map(a => a.name)
-  }
-
-  if (consumerAppNames.length === 0) {
-    consumerAppNames = [layerName]
-  }
-
-  const scannedDirs = new Set<string>()
-  const plans: LayerScanPlan[] = []
-
-  const layerRootDirs = new Map<string, string>()
-  for (const app of apps) {
-    layerRootDirs.set(app.name, app.rootDir)
-  }
-
-  for (const appName of consumerAppNames) {
-    const app = apps.find(a => a.name === appName)
-    if (!app) continue
-    if (!scannedDirs.has(app.rootDir)) {
-      scannedDirs.add(app.rootDir)
-      plans.push({ dir: app.rootDir, excludeDirs: baseExclude })
-    }
-    for (const depLayer of app.layers) {
-      const depApp = apps.find(a => a.name === depLayer)
-      if (!depApp) continue
-      if (scannedDirs.has(depApp.rootDir)) continue
-      scannedDirs.add(depApp.rootDir)
-      plans.push({ dir: depApp.rootDir, excludeDirs: baseExclude })
-    }
-  }
-
-  if (plans.length === 0) {
-    for (const app of apps) {
-      if (scannedDirs.has(app.rootDir)) continue
-      scannedDirs.add(app.rootDir)
-      plans.push({ dir: app.rootDir, excludeDirs: baseExclude })
-    }
-  }
-
-  return plans
-}
-
 export interface OrphanScanOptions {
   keysByLayer: Map<string, { keys: string[]; localeDir: { layer: string } }>
-  apps: AppInfo[]
-  scanDirs?: string[]
+  /** Root directories to scan for source file usage. Scanned recursively. */
+  scanDirs: string[]
   excludeDirs?: string[]
   resolveIgnorePatterns: (layerName: string) => string[] | undefined
   patterns?: ScanPatternSet
@@ -450,67 +370,40 @@ export interface OrphanScanResult {
 }
 
 export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promise<OrphanScanResult> {
-  const { keysByLayer, apps, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
+  const { keysByLayer, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
 
-  let scanCache: Map<string, ScanResult>
-  if (scanDirs) {
-    scanCache = new Map()
-    for (const dir of scanDirs) {
-      scanCache.set(dir, await scanSourceFiles(dir, excludeDirs ?? [], patterns))
+  // Single recursive scan from each provided root dir.
+  // All layers share the combined results — no per-layer scan planning needed.
+  const combinedUniqueKeys = new Set<string>()
+  const combinedBareStrings = new Set<string>()
+  const allDynamicKeysRaw: Array<{ expression: string; file: string; line: number; callee: string }> = []
+  let totalFilesScanned = 0
+
+  for (const dir of scanDirs) {
+    const result = await scanSourceFiles(dir, excludeDirs ?? [], patterns)
+    totalFilesScanned += result.filesScanned
+    for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
+    for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
+    allDynamicKeysRaw.push(...result.dynamicKeys)
+    for (const bd of result.bareDynamicCandidates) {
+      allDynamicKeysRaw.push({ expression: bd, file: '', line: 0, callee: '' })
     }
-  } else {
-    scanCache = await scanAllApps(apps, excludeDirs, patterns)
   }
+
+  const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeysRaw)
+  const unresolvedWarnings = buildUnresolvedWarnings(allDynamicKeysRaw)
+  const uncertainRegexes = buildIgnorePatternRegexes(unresolvedWarnings.map(w => w.suggestedIgnorePattern))
 
   const orphansByLayer: Record<string, string[]> = {}
   let orphanCount = 0
   const uncertainByLayer: Record<string, string[]> = {}
   let uncertainCount = 0
-  let totalFilesScanned = 0
   let dynamicMatchedCount = 0
   let ignoredCount = 0
-  const allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
-  const dirsScanned: string[] = []
-
-  for (const result of scanCache.values()) {
-    totalFilesScanned += result.filesScanned
-  }
-
-  const unresolvedWarnings: UnresolvedKeyWarning[] = []
 
   for (const [layerName, { keys }] of keysByLayer) {
-    let relevantResults: ScanResult[]
-    if (scanDirs) {
-      relevantResults = [...scanCache.values()]
-    } else {
-      const plans = buildLayerScanPlan(layerName, apps, excludeDirs)
-      dirsScanned.push(...plans.map(p => p.dir))
-      relevantResults = plans
-        .map(p => scanCache.get(p.dir))
-        .filter((r): r is ScanResult => r !== undefined)
-    }
-
-    const combinedUniqueKeys = new Set<string>()
-    const combinedBareStrings = new Set<string>()
-    const layerDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }> = []
-
-    for (const result of relevantResults) {
-      for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
-      for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
-      layerDynamicKeys.push(...result.dynamicKeys)
-      for (const bd of result.bareDynamicCandidates) {
-        layerDynamicKeys.push({ expression: bd, file: '', line: 0, callee: '' })
-      }
-    }
-
-    allDynamicKeys.push(...layerDynamicKeys)
-    const dynamicKeyRegexes = buildDynamicKeyRegexes(layerDynamicKeys)
     const ignorePatterns = resolveIgnorePatterns(layerName)
     const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
-
-    const layerWarnings = buildUnresolvedWarnings(layerDynamicKeys)
-    unresolvedWarnings.push(...layerWarnings)
-    const uncertainRegexes = buildIgnorePatternRegexes(layerWarnings.map(w => w.suggestedIgnorePattern))
 
     const orphans = keys.filter((k) => {
       if (combinedUniqueKeys.has(k)) return false
@@ -554,8 +447,8 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
     totalFilesScanned,
     dynamicMatchedCount,
     ignoredCount,
-    allDynamicKeys,
-    dirsScanned: [...new Set(dirsScanned)],
+    allDynamicKeys: allDynamicKeysRaw,
+    dirsScanned: scanDirs,
     unresolvedKeyWarnings: unresolvedWarnings,
   }
 }

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes, buildLayerScanPlan } from '../../src/scanner/code-scanner.js'
-import type { AppInfo } from '../../src/config/types.js'
+import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
@@ -654,74 +653,4 @@ describe('toRelativePath', () => {
   })
 })
 
-describe('buildLayerScanPlan', () => {
-  it('single app — scans app root for any layer', () => {
-    const apps: AppInfo[] = [
-      { name: 'root', rootDir: '/project', layers: ['root', 'ui', 'shared'] }
-    ]
-    const plans = buildLayerScanPlan('ui', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/project')
-    expect(plans[0].excludeDirs).toEqual([])
-  })
 
-  it('monorepo siblings — shared layer scans all consumer apps', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, undefined)
-    expect(plans).toHaveLength(2)
-    const dirs = plans.map(p => p.dir).sort()
-    expect(dirs).toEqual(['/mono/app-1', '/mono/app-2'])
-  })
-
-  it('monorepo siblings — app-specific layer scans only that app', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-1', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/mono/app-1')
-  })
-
-  it('passes user excludeDirs to all plans', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/mono/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, ['storybook'])
-    for (const plan of plans) {
-      expect(plan.excludeDirs).toContain('storybook')
-    }
-  })
-
-  it('deduplicates scan dirs when apps share rootDir', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/project', layers: ['root', 'ui'] },
-      { name: 'app-2', rootDir: '/project', layers: ['root', 'shared'] },
-    ]
-    const plans = buildLayerScanPlan('root', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/project')
-  })
-
-  it('monorepo nested — shared layer scans all consumer apps', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/shared/app-1', layers: ['app-1', 'app-shared'] },
-      { name: 'app-2', rootDir: '/shared/app-2', layers: ['app-2', 'app-shared'] },
-    ]
-    const plans = buildLayerScanPlan('app-shared', apps, undefined)
-    expect(plans).toHaveLength(2)
-  })
-
-  it('falls back to all apps when layer not in graph', () => {
-    const apps: AppInfo[] = [
-      { name: 'app-1', rootDir: '/mono/app-1', layers: ['app-1'] },
-    ]
-    const plans = buildLayerScanPlan('unknown-layer', apps, undefined)
-    expect(plans).toHaveLength(1)
-    expect(plans[0].dir).toBe('/mono/app-1')
-  })
-})

--- a/packages/cli/tests/tools/output-file-param.test.ts
+++ b/packages/cli/tests/tools/output-file-param.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the `outputFile` parameter on large-output operations.
+ *
+ * Verifies:
+ * - When `outputFile` is provided, op writes JSON to disk and returns `{ reportFile, summary }`.
+ * - Paths outside the project directory (e.g., /tmp) are accepted when `outputFile` is explicit.
+ * - When `outputFile` is absent and no config-level `reportOutput`, full payload is returned inline.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { registerDetectorMock, playgroundDir, appAdminDir } from '../fixtures/mock-detector.js'
+
+// Register the shared detector mock (vi.mock is hoisted by Vitest)
+registerDetectorMock()
+
+const { clearConfigCache } = await import('../../src/config/detector.js')
+
+import {
+  getMissingTranslations,
+  findEmptyTranslations,
+  findOrphanKeysOp,
+  scanCodeUsageOp,
+  cleanupUnusedTranslations,
+} from '../../src/core/operations.js'
+
+let tmpDir: string
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'i18n-kit-test-'))
+})
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+afterEach(() => {
+  clearConfigCache()
+})
+
+// ─── getMissingTranslations ──────────────────────────────────────────────────
+
+describe('getMissingTranslations — outputFile', () => {
+  it('writes full JSON to disk and returns { reportFile, summary }', async () => {
+    const outPath = join(tmpDir, 'missing.json')
+    const result = await getMissingTranslations({
+      projectDir: appAdminDir,
+      outputFile: outPath,
+    })
+
+    expect(result).toHaveProperty('reportFile', outPath)
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('missing')
+
+    const raw = await readFile(outPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed).toHaveProperty('tool', 'get_missing_translations')
+    expect(parsed).toHaveProperty('missing')
+  })
+
+  it('accepts /tmp paths (outside project dir) when outputFile is explicit', async () => {
+    const outPath = join(tmpDir, 'missing-tmp.json')
+    await expect(
+      getMissingTranslations({ projectDir: appAdminDir, outputFile: outPath }),
+    ).resolves.toHaveProperty('reportFile', outPath)
+  })
+
+  it('returns full inline payload when outputFile is absent', async () => {
+    const result = await getMissingTranslations({ projectDir: appAdminDir })
+    expect(result).toHaveProperty('missing')
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('reportFile')
+  })
+})
+
+// ─── findEmptyTranslations ───────────────────────────────────────────────────
+
+describe('findEmptyTranslations — outputFile', () => {
+  it('writes full JSON to disk and returns { reportFile, summary }', async () => {
+    const outPath = join(tmpDir, 'empty.json')
+    const result = await findEmptyTranslations({
+      projectDir: appAdminDir,
+      outputFile: outPath,
+    })
+
+    expect(result).toHaveProperty('reportFile', outPath)
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('emptyKeys')
+
+    const raw = await readFile(outPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed).toHaveProperty('tool', 'find_empty_translations')
+    expect(parsed).toHaveProperty('emptyKeys')
+  })
+
+  it('accepts /tmp paths (outside project dir) when outputFile is explicit', async () => {
+    const outPath = join(tmpDir, 'empty-tmp.json')
+    await expect(
+      findEmptyTranslations({ projectDir: appAdminDir, outputFile: outPath }),
+    ).resolves.toHaveProperty('reportFile', outPath)
+  })
+
+  it('returns full inline payload when outputFile is absent', async () => {
+    const result = await findEmptyTranslations({ projectDir: appAdminDir })
+    expect(result).toHaveProperty('emptyKeys')
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('reportFile')
+  })
+})
+
+// ─── findOrphanKeysOp ────────────────────────────────────────────────────────
+
+describe('findOrphanKeysOp — outputFile', () => {
+  it('writes full JSON to disk and returns { reportFile, summary }', async () => {
+    const outPath = join(tmpDir, 'orphans.json')
+    const result = await findOrphanKeysOp({
+      projectDir: playgroundDir,
+      outputFile: outPath,
+    })
+
+    expect(result).toHaveProperty('reportFile', outPath)
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('orphanKeys')
+
+    const raw = await readFile(outPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed).toHaveProperty('tool', 'find_orphan_keys')
+    expect(parsed).toHaveProperty('orphanKeys')
+  })
+
+  it('accepts /tmp paths (outside project dir) when outputFile is explicit', async () => {
+    const outPath = join(tmpDir, 'orphans-tmp.json')
+    await expect(
+      findOrphanKeysOp({ projectDir: playgroundDir, outputFile: outPath }),
+    ).resolves.toHaveProperty('reportFile', outPath)
+  })
+
+  it('returns full inline payload when outputFile is absent', async () => {
+    const result = await findOrphanKeysOp({ projectDir: playgroundDir })
+    expect(result).toHaveProperty('orphanKeys')
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('reportFile')
+  })
+})
+
+// ─── scanCodeUsageOp ─────────────────────────────────────────────────────────
+
+describe('scanCodeUsageOp — outputFile', () => {
+  it('writes full JSON to disk and returns { reportFile, summary }', async () => {
+    const outPath = join(tmpDir, 'scan.json')
+    const result = await scanCodeUsageOp({
+      projectDir: playgroundDir,
+      outputFile: outPath,
+    })
+
+    expect(result).toHaveProperty('reportFile', outPath)
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('usages')
+
+    const raw = await readFile(outPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed).toHaveProperty('tool', 'scan_code_usage')
+    expect(parsed).toHaveProperty('usages')
+  })
+
+  it('accepts /tmp paths (outside project dir) when outputFile is explicit', async () => {
+    const outPath = join(tmpDir, 'scan-tmp.json')
+    await expect(
+      scanCodeUsageOp({ projectDir: playgroundDir, outputFile: outPath }),
+    ).resolves.toHaveProperty('reportFile', outPath)
+  })
+
+  it('returns full inline payload when outputFile is absent', async () => {
+    const result = await scanCodeUsageOp({ projectDir: playgroundDir })
+    expect(result).toHaveProperty('usages')
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('reportFile')
+  })
+})
+
+// ─── cleanupUnusedTranslations ───────────────────────────────────────────────
+
+describe('cleanupUnusedTranslations — outputFile', () => {
+  it('writes full JSON to disk and returns { reportFile, summary } in dry-run mode', async () => {
+    const outPath = join(tmpDir, 'cleanup.json')
+    const result = await cleanupUnusedTranslations({
+      projectDir: playgroundDir,
+      dryRun: true,
+      outputFile: outPath,
+    })
+
+    expect(result).toHaveProperty('reportFile', outPath)
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('orphanKeys')
+
+    const raw = await readFile(outPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed).toHaveProperty('tool', 'cleanup_unused_translations')
+  })
+
+  it('accepts /tmp paths (outside project dir) when outputFile is explicit', async () => {
+    const outPath = join(tmpDir, 'cleanup-tmp.json')
+    await expect(
+      cleanupUnusedTranslations({ projectDir: playgroundDir, dryRun: true, outputFile: outPath }),
+    ).resolves.toHaveProperty('reportFile', outPath)
+  })
+
+  it('returns full inline payload when outputFile is absent', async () => {
+    const result = await cleanupUnusedTranslations({ projectDir: playgroundDir, dryRun: true })
+    expect(result).toHaveProperty('summary')
+    expect(result).not.toHaveProperty('reportFile')
+  })
+})

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -262,11 +262,15 @@ export function createServer(): McpServer {
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+        outputFile: z
+          .string()
+          .optional()
+          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/missing-translations.json"'),
       },
     },
-    async ({ layer, referenceLocale, targetLocales, locales, projectDir }) => {
+    async ({ layer, referenceLocale, targetLocales, locales, projectDir, outputFile }) => {
       try {
-        const result = await getMissingTranslations({ layer, referenceLocale, targetLocales, locales, projectDir })
+        const result = await getMissingTranslations({ layer, referenceLocale, targetLocales, locales, projectDir, outputFile })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('finding missing translations', error)
@@ -295,11 +299,15 @@ export function createServer(): McpServer {
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+        outputFile: z
+          .string()
+          .optional()
+          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/empty-translations.json"'),
       },
     },
-    async ({ layer, locale, projectDir }) => {
+    async ({ layer, locale, projectDir, outputFile }) => {
       try {
-        const result = await findEmptyTranslations({ layer, locale, projectDir })
+        const result = await findEmptyTranslations({ layer, locale, projectDir, outputFile })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('find_empty_translations', error)
@@ -580,11 +588,15 @@ export function createServer(): McpServer {
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+        outputFile: z
+          .string()
+          .optional()
+          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/orphan-keys.json"'),
       },
     },
-    async ({ layer, locale, scanDirs, excludeDirs, projectDir }) => {
+    async ({ layer, locale, scanDirs, excludeDirs, projectDir, outputFile }) => {
       try {
-        const result = await findOrphanKeysOp({ layer, locale, scanDirs, excludeDirs, projectDir })
+        const result = await findOrphanKeysOp({ layer, locale, scanDirs, excludeDirs, projectDir, outputFile })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('finding orphan keys', error)
@@ -617,11 +629,15 @@ export function createServer(): McpServer {
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+        outputFile: z
+          .string()
+          .optional()
+          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/scan-code-usage.json"'),
       },
     },
-    async ({ keys, scanDirs, excludeDirs, projectDir }) => {
+    async ({ keys, scanDirs, excludeDirs, projectDir, outputFile }) => {
       try {
-        const result = await scanCodeUsageOp({ keys, scanDirs, excludeDirs, projectDir })
+        const result = await scanCodeUsageOp({ keys, scanDirs, excludeDirs, projectDir, outputFile })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('scanning code usage', error)
@@ -662,11 +678,15 @@ export function createServer(): McpServer {
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+        outputFile: z
+          .string()
+          .optional()
+          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/cleanup-unused.json"'),
       },
     },
-    async ({ layer, locale, scanDirs, excludeDirs, dryRun, projectDir }) => {
+    async ({ layer, locale, scanDirs, excludeDirs, dryRun, projectDir, outputFile }) => {
       try {
-        const result = await cleanupUnusedTranslations({ layer, locale, scanDirs, excludeDirs, dryRun, projectDir })
+        const result = await cleanupUnusedTranslations({ layer, locale, scanDirs, excludeDirs, dryRun, projectDir, outputFile })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('cleaning up unused translations', error)


### PR DESCRIPTION
Closes #124

## Problem

`find_orphan_keys`, `get_missing_translations`, etc. can return megabytes of JSON. In agent sessions this floods the context window and causes freezes.

## Solution

Add optional `outputFile` parameter to all 5 large-output tools. When provided, full JSON is written to disk and the caller receives only a compact summary.

```
# CLI
the-i18n-cli orphans --output-file /tmp/orphans.json
# → Wrote report to: /tmp/orphans.json
# → { totalKeys: 7243, orphanCount: 1103, ... }

# MCP
find_orphan_keys({ outputFile: "/tmp/orphans.json" })
# → { reportFile: "/tmp/orphans.json", summary: { ... } }
```

## Changes

**`operations.ts`** — `outputFile?: string` added to 5 ops:
- `getMissingTranslations`, `findEmptyTranslations`, `findOrphanKeysOp`, `scanCodeUsageOp`, `cleanupUnusedTranslations`
- Path resolution: `opts.outputFile ?? resolveReportFilePath(config)`
- Explicit `outputFile` bypasses `validateReportPath` — `/tmp/` and other out-of-project paths allowed

**CLI commands** — `--output-file` flag on `orphans`, `missing`, `empty`, `cleanup`, `scan`

**`_shared.ts`** — `outputResult` detects `reportFile` key and prints `Wrote report to: <path>` + summary

**MCP `server.ts`** — `outputFile` on all 5 tool schemas with description explaining context-overflow use case

**Tests** — 15 new tests: write-to-disk, `/tmp` path acceptance, inline fallback

## Notes

- Existing config-level `reportOutput` in `.i18n-mcp.json` still works — `outputFile` is per-call override
- 519 tests passing