### PR TITLE
fix(cli): honor projectConfig.locales override in all adapters

### DIFF
--- a/packages/cli/src/adapters/laravel/index.ts
+++ b/packages/cli/src/adapters/laravel/index.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
+import { applyLocaleOverride } from '../../config/locale-override'
 import { log } from '../../utils/logger'
 import { ConfigError } from '../../utils/errors'
 
@@ -68,10 +69,13 @@ export class LaravelAdapter implements FrameworkAdapter {
 
     const allCodes = mergeLocaleCodes(localeSubdirs, configLocales)
 
-    const locales: LocaleDefinition[] = allCodes.map(code => ({
-      code,
-      language: code,
-    }))
+    const locales: LocaleDefinition[] = applyLocaleOverride(
+      allCodes.map(code => ({
+        code,
+        language: code,
+      })),
+      projectConfig?.locales,
+    )
 
     const localeDirs: LocaleDir[] = [{
       path: langDir,

--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -6,6 +6,7 @@ import type { I18nConfig, LocaleDefinition, LocaleDir, AppInfo } from '../../con
 import { findNuxtConfig, discoverNuxtApps, deriveLayerName } from '../../config/discovery'
 import { loadKit } from '../../config/nuxt-loader'
 import { loadProjectConfig } from '../../config/project-config'
+import { applyLocaleOverride } from '../../config/locale-override'
 import { log } from '../../utils/logger'
 import { ConfigError } from '../../utils/errors'
 import { resolveLayerOwnership } from './layer-dedup'
@@ -216,7 +217,7 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
     rootDir: discoveryRoot,
     defaultLocale,
     fallbackLocale,
-    locales: allLocales,
+    locales: applyLocaleOverride(allLocales, projectConfig?.locales),
     localeDirs: allLocaleDirs,
     layerRootDirs: allLayerRootDirs,
     projectConfig: projectConfig ?? undefined,
@@ -283,7 +284,7 @@ async function extractI18nConfig(
     rootDir: appDir,
     defaultLocale,
     fallbackLocale,
-    locales,
+    locales: applyLocaleOverride(locales, projectConfig?.locales),
     localeDirs,
     layerRootDirs,
     projectConfig: projectConfig ?? undefined,

--- a/packages/cli/src/config/locale-override.ts
+++ b/packages/cli/src/config/locale-override.ts
@@ -1,0 +1,49 @@
+import type { LocaleDefinition } from './types'
+import { log } from '../utils/logger'
+
+/**
+ * Apply the optional `locales` override from `.i18n-mcp.json` on top of the
+ * locales auto-discovered by a framework adapter.
+ *
+ * Semantics:
+ * - If `projectLocales` is unset/empty → return `discovered` unchanged.
+ * - Else → restrict to the configured codes, preserving the order from
+ *   `projectLocales` and keeping the metadata (file, language, name) from
+ *   the discovered entries. Configured codes with no matching discovered
+ *   entry get a minimal `{code, language: code}` fallback and a warning.
+ */
+export function applyLocaleOverride(
+  discovered: LocaleDefinition[],
+  projectLocales: string[] | undefined,
+): LocaleDefinition[] {
+  if (!projectLocales || projectLocales.length === 0) {
+    return discovered
+  }
+
+  const byCode = new Map(discovered.map(l => [l.code, l]))
+  const missing: string[] = []
+
+  const result = projectLocales.map((code) => {
+    const found = byCode.get(code)
+    if (found) return found
+    missing.push(code)
+    return { code, language: code }
+  })
+
+  if (missing.length > 0) {
+    log.warn(
+      `Configured locales not found in framework auto-detection: ${missing.join(', ')}. `
+      + 'Translations for these codes may fail to write — make sure the locale files exist.',
+    )
+  }
+
+  const dropped = discovered.filter(l => !projectLocales.includes(l.code))
+  if (dropped.length > 0) {
+    log.debug(
+      `Locale override active: dropped ${dropped.length} auto-detected locale(s) `
+      + `(${dropped.map(l => l.code).join(', ')})`,
+    )
+  }
+
+  return result
+}

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -71,7 +71,7 @@ export interface ProjectConfig {
   localeDirs?: Array<string | { path: string; layer: string }>
   /** Default locale code (required for generic adapter activation). */
   defaultLocale?: string
-  /** Explicit list of locale codes. If absent, auto-discovered from files on disk. */
+  /** Explicit list of locale codes. If set, overrides framework auto-detection (all adapters). Auto-discovered when absent. */
   locales?: string[]
   /** Model preferences for `translate_missing` sampling requests. Overrides the built-in defaults (fast/cheap model bias). */
   samplingPreferences?: {

--- a/packages/cli/tests/adapters/laravel-adapter.test.ts
+++ b/packages/cli/tests/adapters/laravel-adapter.test.ts
@@ -292,6 +292,19 @@ describe('LaravelAdapter.resolve', () => {
 
     expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
   })
+
+  it('honors locales override from .i18n-mcp.json (filters auto-detected)', async () => {
+    createLaravelProject(tempDir, { locales: ['en', 'de', 'fr', 'es'] })
+    writeFileSync(
+      join(tempDir, '.i18n-mcp.json'),
+      JSON.stringify({ locales: ['en', 'de'] }),
+    )
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'de'])
+  })
 })
 
 describe('Adapter registry: Laravel vs Nuxt', () => {

--- a/packages/cli/tests/config/locale-override.test.ts
+++ b/packages/cli/tests/config/locale-override.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { applyLocaleOverride } from '../../src/config/locale-override'
+import type { LocaleDefinition } from '../../src/config/types'
+
+const discovered: LocaleDefinition[] = [
+  { code: 'en', language: 'en-US', file: 'en.json' },
+  { code: 'de', language: 'de-DE', file: 'de.json' },
+  { code: 'fr', language: 'fr-FR', file: 'fr.json' },
+]
+
+describe('applyLocaleOverride', () => {
+  it('returns discovered unchanged when override is undefined', () => {
+    expect(applyLocaleOverride(discovered, undefined)).toBe(discovered)
+  })
+
+  it('returns discovered unchanged when override is empty array', () => {
+    expect(applyLocaleOverride(discovered, [])).toBe(discovered)
+  })
+
+  it('filters discovered locales to the configured codes, preserving metadata', () => {
+    const result = applyLocaleOverride(discovered, ['de', 'en'])
+    expect(result).toHaveLength(2)
+    expect(result.map(l => l.code)).toEqual(['de', 'en'])
+    expect(result[0].file).toBe('de.json')
+    expect(result[1].file).toBe('en.json')
+  })
+
+  it('preserves the order from the override list, not the discovered order', () => {
+    const result = applyLocaleOverride(discovered, ['fr', 'en', 'de'])
+    expect(result.map(l => l.code)).toEqual(['fr', 'en', 'de'])
+  })
+
+  it('drops discovered locales not in the override', () => {
+    const result = applyLocaleOverride(discovered, ['en'])
+    expect(result.map(l => l.code)).toEqual(['en'])
+  })
+
+  it('creates minimal entries for configured codes missing from discovery', () => {
+    const result = applyLocaleOverride(discovered, ['en', 'pt'])
+    expect(result).toHaveLength(2)
+    expect(result[1]).toEqual({ code: 'pt', language: 'pt' })
+  })
+})


### PR DESCRIPTION
The `locales` field in .i18n-mcp.json is documented as 'overrides framework auto-detection', but only the generic adapter actually used it. Nuxt and Laravel adapters silently ignored it and always used the framework-detected locale list.

This breaks projects that need to decouple the translator's locale scope from the framework config. Example: a Nuxt app that restricts `i18n.locales` in dev (to avoid OOM on locale-file batch saves) would also restrict what MCP translates — even though MCP runs in its own process and shouldn't care about dev runtime concerns.

Fix: add a small `applyLocaleOverride` helper that filters the auto-discovered locale list to the configured codes (preserving file/ language/name metadata) and warns on codes the framework didn't detect. Wire it into Nuxt + Laravel adapters at the boundary where the final LocaleDefinition[] is built.

Generic adapter behavior unchanged (already honored override via `??`).

Tests: 6 unit tests for the helper + 1 Laravel integration test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added locale override support: Project configuration (`.i18n-mcp.json`) now allows explicit specification of supported locales, overriding framework auto-discovery for Laravel and Nuxt adapters.

* **Documentation**
  * Updated configuration documentation to clarify locale override behavior and auto-discovery fallback semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->