### PR TITLE
feat: add namespaced JSON support — unlocks Next.js, React, Remix (#145)

### DIFF
--- a/packages/cli/src/io/locale-data.ts
+++ b/packages/cli/src/io/locale-data.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { join, extname } from 'node:path'
 import { readdir, mkdir, unlink } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { readLocale, writeLocale } from './locale-io'
@@ -9,7 +9,7 @@ import { FileIOError } from '../utils/errors'
 /**
  * A single locale file entry with its path and optional namespace.
  * - Nuxt: one entry with namespace = null (flat file)
- * - Laravel: one entry per .php file, namespace = filename without extension
+ * - Laravel / Next.js / React: one entry per file, namespace = filename without extension
  */
 export interface LocaleEntry {
   /** Absolute path to the locale file */
@@ -23,7 +23,8 @@ export interface LocaleEntry {
  *
  * - Nuxt (json): Returns a single entry `[{path: ".../en-US.json", namespace: null}]`
  * - Laravel (php-array): Scans `{langDir}/{localeCode}/*.php` and returns one entry per file
- *   e.g., `[{path: ".../en/auth.php", namespace: "auth"}, ...]`
+ * - Next.js / React (json): Scans `{localeDir}/{localeCode}/*.json` and returns one entry per file
+ *   e.g., `[{path: ".../en/common.json", namespace: "common"}, ...]`
  *
  * Returns an empty array if the locale directory doesn't exist (e.g., new locale).
  */
@@ -39,6 +40,11 @@ export async function resolveLocaleEntries(
     return resolvePhpEntries(localeDir, locale.code)
   }
 
+  // Namespaced JSON (Next.js/React: messages/en/common.json)
+  const jsonEntries = await resolveJsonEntries(localeDir, locale.code)
+  if (jsonEntries.length > 0) return jsonEntries
+
+  // Flat JSON (Nuxt: i18n/en-US.json)
   if (!locale.file) return []
   return [{ path: join(localeDir, locale.file), namespace: null }]
 }
@@ -47,8 +53,8 @@ export async function resolveLocaleEntries(
  * Read all locale data for a locale in a layer, merged into a single object.
  *
  * - Nuxt: Returns the JSON file contents as-is
- * - Laravel: Reads each namespace .php file and mounts under its namespace key
- *   e.g., `{ auth: { failed: "..." }, validation: { required: "..." } }`
+ * - Laravel / Next.js / React: Reads each namespace file and mounts under its namespace key
+ *   e.g., `{ auth: { failed: "..." }, common: { welcome: "Hello" } }`
  *
  * Missing files are treated as empty objects (no error thrown).
  */
@@ -94,7 +100,7 @@ export async function readLocaleData(
  * and may modify it in-place. After mutation:
  *
  * - Nuxt: Writes the entire object back to the single JSON file
- * - Laravel: Splits by top-level namespace keys and writes each to its .php file.
+ * - Laravel / Next.js / React: Splits by top-level namespace keys and writes each to its file.
  *   New namespaces create new files. Empty namespaces delete the content (write empty object).
  *
  * Returns the set of file paths that were written.
@@ -109,11 +115,20 @@ export async function mutateLocaleData(
 
   const filesWritten = new Set<string>()
 
-  if (config.localeFileFormat === 'php-array') {
+  const entries = await resolveLocaleEntries(config, layer, locale)
+  const isNamespaced = config.localeFileFormat === 'php-array'
+    || entries.some(e => e.namespace !== null)
+    || await hasNamespacedJsonLayout(config, layer)
+
+  if (isNamespaced) {
+    // Per-namespace write (PHP arrays or namespaced JSON)
     const localeDir = resolveLayerDir(config, layer)
     if (!localeDir) return filesWritten
 
     const localePath = join(localeDir, locale.code)
+    const fileExt = entries.length > 0
+      ? extname(entries[0].path) // '.php' or '.json'
+      : config.localeFileFormat === 'php-array' ? '.php' : '.json'
 
     const preSnapshots = new Map<string, string>()
     for (const [ns, nsData] of Object.entries(data)) {
@@ -137,7 +152,7 @@ export async function mutateLocaleData(
         continue
       }
       if (JSON.stringify(nsData) !== preSnapshots.get(namespace)) {
-        const filePath = join(localePath, `${namespace}.php`)
+        const filePath = join(localePath, `${namespace}${fileExt}`)
         await writeLocale(filePath, nsData as Record<string, unknown>)
         filesWritten.add(filePath)
       }
@@ -146,12 +161,12 @@ export async function mutateLocaleData(
     const expectedFiles = new Set(
       Object.keys(data)
         .filter(ns => typeof data[ns] === 'object' && data[ns] !== null)
-        .map(ns => `${ns}.php`),
+        .map(ns => `${ns}${fileExt}`),
     )
     try {
       const existingFiles = await readdir(localePath)
       for (const file of existingFiles) {
-        if (file.endsWith('.php') && !expectedFiles.has(file)) {
+        if (file.endsWith(fileExt) && !expectedFiles.has(file)) {
           await unlink(join(localePath, file))
         }
       }
@@ -159,6 +174,7 @@ export async function mutateLocaleData(
     catch {}
   }
   else {
+    // Flat file write (Nuxt-style single JSON file)
     const snapshot = JSON.stringify(data)
     mutate(data)
 
@@ -166,9 +182,7 @@ export async function mutateLocaleData(
       return filesWritten
     }
 
-    const entries = await resolveLocaleEntries(config, layer, locale)
     if (entries.length === 0) return filesWritten
-
     const filePath = entries[0].path
     await writeLocale(filePath, data)
     filesWritten.add(filePath)
@@ -187,6 +201,51 @@ function resolveLayerDir(config: I18nConfig, layer: string): string | null {
     if (aliasDir) return aliasDir.path
   }
   return dir.path
+}
+
+async function hasNamespacedJsonLayout(config: I18nConfig, layer: string): Promise<boolean> {
+  const localeDir = resolveLayerDir(config, layer)
+  if (!localeDir) return false
+
+  try {
+    const entries = await readdir(localeDir)
+    for (const entry of entries) {
+      const subPath = join(localeDir, entry)
+      try {
+        if (existsSync(subPath)) {
+          const subFiles = await readdir(subPath)
+          if (subFiles.some(f => f.endsWith('.json'))) return true
+        }
+      }
+      catch { /* skip unreadable dirs */ }
+    }
+  }
+  catch { /* locale dir not readable */ }
+
+  return false
+}
+
+async function resolveJsonEntries(localeDir: string, localeCode: string): Promise<LocaleEntry[]> {
+  const localePath = join(localeDir, localeCode)
+
+  if (!existsSync(localePath)) return []
+
+  let files: string[]
+  try {
+    files = await readdir(localePath)
+  }
+  catch (err) {
+    log.debug(`Failed to read locale directory ${localePath}: ${err instanceof Error ? err.message : String(err)}`)
+    return []
+  }
+
+  return files
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(f => ({
+      path: join(localePath, f),
+      namespace: f.replace(/\.json$/, ''),
+    }))
 }
 
 async function resolvePhpEntries(langDir: string, localeCode: string): Promise<LocaleEntry[]> {

--- a/packages/cli/tests/io/locale-data.test.ts
+++ b/packages/cli/tests/io/locale-data.test.ts
@@ -35,6 +35,22 @@ function makeNuxtConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
   }
 }
 
+function makeNextJsConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+  return {
+    rootDir: tempDir,
+    defaultLocale: 'en',
+    fallbackLocale: { default: ['en'] },
+    locales: [
+      { code: 'en', language: 'en' },
+      { code: 'de', language: 'de' },
+    ],
+    localeDirs: [{ path: join(tempDir, 'messages'), layer: 'root', layerRootDir: tempDir }],
+    layerRootDirs: [tempDir],
+    localeFileFormat: 'json',
+    ...overrides,
+  }
+}
+
 function makeLaravelConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
   return {
     rootDir: tempDir,
@@ -73,6 +89,17 @@ async function setupLaravelLocales() {
   await writeFile(join(enDir, 'auth.php'), `<?php\nreturn ['failed' => 'Invalid credentials', 'throttle' => 'Too many attempts'];\n`)
   await writeFile(join(enDir, 'validation.php'), `<?php\nreturn ['required' => 'This field is required'];\n`)
   await writeFile(join(deDir, 'auth.php'), `<?php\nreturn ['failed' => 'Ungueltige Anmeldedaten'];\n`)
+}
+
+async function setupNextJsLocales() {
+  const enDir = join(tempDir, 'messages', 'en')
+  const deDir = join(tempDir, 'messages', 'de')
+  await mkdir(enDir, { recursive: true })
+  await mkdir(deDir, { recursive: true })
+
+  await writeFile(join(enDir, 'common.json'), JSON.stringify({ save: 'Save', cancel: 'Cancel' }))
+  await writeFile(join(enDir, 'auth.json'), JSON.stringify({ login: 'Login', logout: 'Logout' }))
+  await writeFile(join(deDir, 'common.json'), JSON.stringify({ save: 'Speichern', cancel: 'Abbrechen' }))
 }
 
 describe('resolveLocaleEntries', () => {
@@ -142,6 +169,34 @@ describe('resolveLocaleEntries', () => {
     expect(entries).toHaveLength(1)
     expect(entries[0].path).toBe(join(tempDir, 'locales', 'en.json'))
   })
+
+  it('returns one entry per .json file for Next.js namespaced JSON', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual({
+      path: join(tempDir, 'messages', 'en', 'auth.json'),
+      namespace: 'auth',
+    })
+    expect(entries[1]).toEqual({
+      path: join(tempDir, 'messages', 'en', 'common.json'),
+      namespace: 'common',
+    })
+  })
+
+  it('falls back to flat JSON when no namespaced subdirectory exists', async () => {
+    await setupNuxtLocales()
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    const entries = await resolveLocaleEntries(config, 'root', locale)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].namespace).toBeNull()
+    expect(entries[0].path).toBe(join(tempDir, 'locales', 'en.json'))
+  })
 })
 
 describe('readLocaleData', () => {
@@ -193,6 +248,29 @@ describe('readLocaleData', () => {
 
     const data = await readLocaleData(config, 'root', { code: 'fr', language: 'fr', file: 'fr.json' })
     expect(data).toEqual({})
+  })
+
+  it('reads Next.js namespaced JSON as namespace-keyed object', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+
+    const data = await readLocaleData(config, 'root', config.locales[0])
+
+    expect(data).toEqual({
+      auth: { login: 'Login', logout: 'Logout' },
+      common: { save: 'Save', cancel: 'Cancel' },
+    })
+  })
+
+  it('reads partial Next.js locale (missing namespace files)', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+
+    const data = await readLocaleData(config, 'root', config.locales[1])
+
+    expect(data).toEqual({
+      common: { save: 'Speichern', cancel: 'Abbrechen' },
+    })
   })
 })
 
@@ -353,5 +431,60 @@ describe('mutateLocaleData', () => {
 
     const written = await mutateLocaleData(config, 'root', locale, () => {})
     expect(written.size).toBe(0)
+  })
+
+  it('mutates Next.js namespace and writes only changed files', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+
+    const written = await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.auth as Record<string, string>).login = 'Sign In'
+    })
+
+    expect(written.size).toBe(1)
+    expect(written.has(join(tempDir, 'messages', 'en', 'auth.json'))).toBe(true)
+    expect(written.has(join(tempDir, 'messages', 'en', 'common.json'))).toBe(false)
+
+    clearFileCache()
+    const result = await readLocaleData(config, 'root', locale)
+    expect((result.auth as Record<string, string>).login).toBe('Sign In')
+    expect((result.common as Record<string, string>).save).toBe('Save')
+  })
+
+  it('creates new namespace file for Next.js', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data as Record<string, unknown>).profile = { title: 'My Profile' }
+    })
+
+    clearFileCache()
+    const result = await readLocaleData(config, 'root', locale)
+    expect((result.profile as Record<string, string>).title).toBe('My Profile')
+
+    const content = await readFile(join(tempDir, 'messages', 'en', 'profile.json'), 'utf-8')
+    expect(JSON.parse(content)).toEqual({ title: 'My Profile' })
+  })
+
+  it('removes orphaned JSON files when namespace is deleted', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      delete data.auth
+    })
+
+    clearFileCache()
+    const after = await readLocaleData(config, 'root', locale)
+    expect(after.auth).toBeUndefined()
+    expect(after.common).toBeDefined()
+
+    const { existsSync } = await import('node:fs')
+    expect(existsSync(join(tempDir, 'messages', 'en', 'auth.json'))).toBe(false)
+    expect(existsSync(join(tempDir, 'messages', 'en', 'common.json'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem
The generic adapter and all JSON readers assume **one flat JSON file per locale** (`en-US.json`). But the React ecosystem (Next.js `next-intl`, `react-i18next`, `remix-i18next`) uses **namespace-per-file** layouts:

```
messages/en/common.json
messages/en/auth.json
messages/de/common.json
messages/de/auth.json
```

This was already handled for PHP arrays (Laravel's `lang/en/auth.php`) but not for JSON.

## Changes
- Add `resolveJsonEntries()` — scans `{localeDir}/{code}/*.json` (same pattern as existing `resolvePhpEntries()`)
- `resolveLocaleEntries()` probes namespaced JSON before falling back to flat JSON
- `mutateLocaleData()` uses generic per-namespace write/cleanup for all namespaced formats (PHP arrays + namespaced JSON) — file extension auto-detected
- Add `hasNamespacedJsonLayout()` for new locales with zero entries yet
- 9 new tests for namespaced JSON read/write/mutate/cleanup

## Files
- `packages/cli/src/io/locale-data.ts` — ~80 lines added
- `packages/cli/tests/io/locale-data.test.ts` — 9 test cases added

## Closes
Closes #145