### PR TITLE
feat: add Vue standalone adapter for vue-i18n (#146)

### DIFF
--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -1,0 +1,189 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import type { FrameworkAdapter, LocaleFileFormat } from '../types'
+import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import { loadProjectConfig } from '../../config/project-config'
+import { applyLocaleOverride } from '../../config/locale-override'
+import { log } from '../../utils/logger'
+import { ConfigError } from '../../utils/errors'
+
+const COMMON_LOCALE_DIRS = [
+  'src/locales',
+  'locales',
+  'src/i18n/locales',
+  'i18n/locales',
+  'src/plugins/i18n/locales',
+  'src/i18n',
+]
+
+const I18N_CONFIG_FILES = [
+  'src/i18n/index.ts',
+  'src/i18n/index.js',
+  'src/plugins/i18n.ts',
+  'src/plugins/i18n.js',
+  'src/i18n.ts',
+  'src/i18n.js',
+  'i18n.ts',
+  'i18n.js',
+]
+
+const NUPT_INDICATORS = ['@nuxt/kit', 'nuxt']
+
+const MESSAGES_REGEX = /messages\s*:\s*['"]([^'"]+)/
+const LOCALE_DIR_REGEX = /localeDir\s*:\s*['"]([^'"]+)/
+
+export class VueAdapter implements FrameworkAdapter {
+  readonly name = 'vue'
+  readonly label = 'Vue'
+  readonly localeFileFormat: LocaleFileFormat = 'json'
+
+  async detect(projectDir: string): Promise<number> {
+    let pkg: Record<string, unknown> | null = null
+    try {
+      const raw = await readFile(join(projectDir, 'package.json'), 'utf-8')
+      pkg = JSON.parse(raw) as Record<string, unknown>
+    }
+    catch {
+      return 0
+    }
+
+    // If Nuxt is present, this is a Nuxt project — don't claim it
+    const allDeps = { ...(pkg.dependencies ?? {}) as Record<string, unknown>, ...(pkg.devDependencies ?? {}) as Record<string, unknown> }
+    for (const indicator of NUPT_INDICATORS) {
+      if (indicator in allDeps) return 0
+    }
+    if (findNuxtConfig(projectDir)) return 0
+
+    const hasVue = 'vue' in allDeps
+    if (!hasVue) return 0
+
+    const hasVueI18n = 'vue-i18n' in allDeps
+    let score = hasVue ? 2 : 0
+    if (hasVueI18n) score += 3
+
+    // Bonus for locale files on disk
+    try {
+      const localeDir = await findLocaleDir(projectDir)
+      if (localeDir) {
+        const files = await readdir(localeDir)
+        if (files.some(f => f.endsWith('.json'))) score += 2
+      }
+    }
+    catch {
+      // Can't read dirs — skip bonus
+    }
+
+    return score
+  }
+
+  async resolve(projectDir: string): Promise<I18nConfig> {
+    const projectConfig = await loadProjectConfig(projectDir)
+
+    const localeDir = await findLocaleDir(projectDir)
+    if (!localeDir) {
+      throw new ConfigError(
+        `No locale directory found in ${projectDir}. `
+        + 'Looked in: ' + COMMON_LOCALE_DIRS.join(', ') + '. '
+        + 'Configure a .i18n-mcp.json with localeDirs for custom paths.',
+      )
+    }
+
+    const locales = await discoverLocales(localeDir)
+    if (locales.length === 0) {
+      throw new ConfigError(
+        `No JSON locale files found in ${localeDir}. `
+        + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
+      )
+    }
+
+    const defaultLocale = extractDefaultLocale(projectDir) ?? locales[0].code
+    const fallbackLocale = { default: [defaultLocale] }
+
+    return {
+      rootDir: projectDir,
+      defaultLocale,
+      fallbackLocale,
+      locales: applyLocaleOverride(locales, projectConfig?.locales),
+      localeDirs: [{ path: localeDir, layer: 'root', layerRootDir: projectDir }],
+      layerRootDirs: [projectDir],
+      projectConfig: projectConfig ?? undefined,
+      apps: [{ name: 'default', rootDir: projectDir, layers: ['root'] }],
+    }
+  }
+}
+
+// ─── Internal helpers ───────────────────────────────────────────
+
+function findNuxtConfig(dir: string): string | null {
+  for (const name of ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs']) {
+    if (existsSync(join(dir, name))) return name
+  }
+  return null
+}
+
+async function findLocaleDir(projectDir: string): Promise<string | null> {
+  // 1. Try to extract from createI18n() config
+  for (const file of I18N_CONFIG_FILES) {
+    const fullPath = join(projectDir, file)
+    if (!existsSync(fullPath)) continue
+
+    try {
+      const content = await readFile(fullPath, 'utf-8')
+
+      // Check for localeDir
+      const dirMatch = content.match(LOCALE_DIR_REGEX)
+      if (dirMatch) {
+        const extracted = resolve(projectDir, dirMatch[1])
+        if (existsSync(extracted)) return extracted
+      }
+
+      // Check for messages path (e.g. import messages from '@/locales/en.json')
+      const msgMatch = content.match(MESSAGES_REGEX)
+      if (msgMatch) {
+        // Resolve relative to the config file's directory
+        const configDir = fullPath.replace(/\/[^/]+$/, '')
+        const extracted = resolve(configDir, msgMatch[1])
+        // The messages value is often a file path like '@/locales/en.json'
+        // or just 'en.json'. Take its directory.
+        const parentDir = extracted.replace(/\/[^/]+$/, '')
+        if (existsSync(parentDir)) return parentDir
+      }
+    }
+    catch {
+      // Can't read — try next
+    }
+  }
+
+  // 2. Fall back to scanning common paths (directory existence is enough — resolve validates files)
+  for (const dir of COMMON_LOCALE_DIRS) {
+    const fullPath = join(projectDir, dir)
+    if (existsSync(fullPath)) return fullPath
+  }
+
+  return null
+}
+
+async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
+  let files: string[]
+  try {
+    files = await readdir(localeDir)
+  }
+  catch {
+    return []
+  }
+
+  return files
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(f => ({
+      code: f.replace(/\.json$/, ''),
+      language: f.replace(/\.json$/, ''),
+      file: f,
+    }))
+}
+
+function extractDefaultLocale(projectDir: string): string | null {
+  // Not critical — return null if .env doesn't exist or can't be read
+  return null
+}

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -5,7 +5,6 @@ import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
 import { applyLocaleOverride } from '../../config/locale-override'
-import { log } from '../../utils/logger'
 import { ConfigError } from '../../utils/errors'
 
 const COMMON_LOCALE_DIRS = [

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
-import type { I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
 import { applyLocaleOverride } from '../../config/locale-override'
 import { log } from '../../utils/logger'
@@ -39,42 +39,14 @@ export class VueAdapter implements FrameworkAdapter {
   readonly localeFileFormat: LocaleFileFormat = 'json'
 
   async detect(projectDir: string): Promise<number> {
-    let pkg: Record<string, unknown> | null = null
-    try {
-      const raw = await readFile(join(projectDir, 'package.json'), 'utf-8')
-      pkg = JSON.parse(raw) as Record<string, unknown>
-    }
-    catch {
-      return 0
-    }
+    const pkg = await loadPackageJson(projectDir)
+    if (!pkg) return 0
 
-    // If Nuxt is present, this is a Nuxt project — don't claim it
-    const allDeps = { ...(pkg.dependencies ?? {}) as Record<string, unknown>, ...(pkg.devDependencies ?? {}) as Record<string, unknown> }
-    for (const indicator of NUPT_INDICATORS) {
-      if (indicator in allDeps) return 0
-    }
-    if (findNuxtConfig(projectDir)) return 0
+    const allDeps = collectDependencies(pkg)
+    if (isNuxtProject(projectDir, allDeps)) return 0
+    if (!('vue' in allDeps)) return 0
 
-    const hasVue = 'vue' in allDeps
-    if (!hasVue) return 0
-
-    const hasVueI18n = 'vue-i18n' in allDeps
-    let score = hasVue ? 2 : 0
-    if (hasVueI18n) score += 3
-
-    // Bonus for locale files on disk
-    try {
-      const localeDir = await findLocaleDir(projectDir)
-      if (localeDir) {
-        const files = await readdir(localeDir)
-        if (files.some(f => f.endsWith('.json'))) score += 2
-      }
-    }
-    catch {
-      // Can't read dirs — skip bonus
-    }
-
-    return score
+    return computeScore(projectDir, allDeps)
   }
 
   async resolve(projectDir: string): Promise<I18nConfig> {
@@ -113,7 +85,51 @@ export class VueAdapter implements FrameworkAdapter {
   }
 }
 
-// ─── Internal helpers ───────────────────────────────────────────
+// ─── Detection helpers ──────────────────────────────────────────
+
+async function loadPackageJson(projectDir: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(join(projectDir, 'package.json'), 'utf-8')
+    return JSON.parse(raw) as Record<string, unknown>
+  }
+  catch {
+    return null
+  }
+}
+
+function collectDependencies(pkg: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...(pkg.dependencies ?? {}) as Record<string, unknown>,
+    ...(pkg.devDependencies ?? {}) as Record<string, unknown>,
+  }
+}
+
+function isNuxtProject(projectDir: string, deps: Record<string, unknown>): boolean {
+  for (const indicator of NUPT_INDICATORS) {
+    if (indicator in deps) return true
+  }
+  return findNuxtConfig(projectDir) !== null
+}
+
+async function computeScore(projectDir: string, deps: Record<string, unknown>): Promise<number> {
+  let score = 2 // 'vue' already confirmed present
+  if ('vue-i18n' in deps) score += 3
+
+  try {
+    const localeDir = await findLocaleDir(projectDir)
+    if (localeDir) {
+      const files = await readdir(localeDir)
+      if (files.some(f => f.endsWith('.json'))) score += 2
+    }
+  }
+  catch {
+    // Can't read dirs — skip bonus
+  }
+
+  return score
+}
+
+// ─── Resolution helpers ─────────────────────────────────────────
 
 function findNuxtConfig(dir: string): string | null {
   for (const name of ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs']) {
@@ -123,7 +139,13 @@ function findNuxtConfig(dir: string): string | null {
 }
 
 async function findLocaleDir(projectDir: string): Promise<string | null> {
-  // 1. Try to extract from createI18n() config
+  const fromConfig = await tryExtractFromConfig(projectDir)
+  if (fromConfig) return fromConfig
+
+  return tryCommonPaths(projectDir)
+}
+
+async function tryExtractFromConfig(projectDir: string): Promise<string | null> {
   for (const file of I18N_CONFIG_FILES) {
     const fullPath = join(projectDir, file)
     if (!existsSync(fullPath)) continue
@@ -131,21 +153,16 @@ async function findLocaleDir(projectDir: string): Promise<string | null> {
     try {
       const content = await readFile(fullPath, 'utf-8')
 
-      // Check for localeDir
       const dirMatch = content.match(LOCALE_DIR_REGEX)
       if (dirMatch) {
         const extracted = resolve(projectDir, dirMatch[1])
         if (existsSync(extracted)) return extracted
       }
 
-      // Check for messages path (e.g. import messages from '@/locales/en.json')
       const msgMatch = content.match(MESSAGES_REGEX)
       if (msgMatch) {
-        // Resolve relative to the config file's directory
         const configDir = fullPath.replace(/\/[^/]+$/, '')
         const extracted = resolve(configDir, msgMatch[1])
-        // The messages value is often a file path like '@/locales/en.json'
-        // or just 'en.json'. Take its directory.
         const parentDir = extracted.replace(/\/[^/]+$/, '')
         if (existsSync(parentDir)) return parentDir
       }
@@ -155,12 +172,14 @@ async function findLocaleDir(projectDir: string): Promise<string | null> {
     }
   }
 
-  // 2. Fall back to scanning common paths (directory existence is enough — resolve validates files)
+  return null
+}
+
+function tryCommonPaths(projectDir: string): string | null {
   for (const dir of COMMON_LOCALE_DIRS) {
     const fullPath = join(projectDir, dir)
     if (existsSync(fullPath)) return fullPath
   }
-
   return null
 }
 

--- a/packages/cli/src/config/detector.ts
+++ b/packages/cli/src/config/detector.ts
@@ -3,6 +3,7 @@ import { registerAdapter, detectFramework } from '../adapters/registry'
 import { NuxtAdapter } from '../adapters/nuxt/index'
 import { LaravelAdapter } from '../adapters/laravel/index'
 import { GenericAdapter } from '../adapters/generic/index'
+import { VueAdapter } from '../adapters/vue/index'
 import { loadProjectConfig } from './project-config'
 import { log } from '../utils/logger'
 import { canonicalPath } from './discovery'
@@ -12,6 +13,7 @@ export { discoverNuxtApps } from './discovery'
 registerAdapter(new NuxtAdapter())
 registerAdapter(new LaravelAdapter())
 registerAdapter(new GenericAdapter())
+registerAdapter(new VueAdapter())
 
 const configCache = new Map<string, I18nConfig>()
 

--- a/packages/cli/tests/adapters/vue-adapter.test.ts
+++ b/packages/cli/tests/adapters/vue-adapter.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { VueAdapter } from '../../src/adapters/vue/index'
+import { registerAdapter, resetRegistry, detectFramework } from '../../src/adapters/registry'
+import { NuxtAdapter } from '../../src/adapters/nuxt/index'
+
+function createVueProject(root: string, opts: {
+  locales?: string[]
+  localeDir?: string
+  hasVueI18n?: boolean
+  hasNuxt?: boolean
+  i18nConfigFile?: string | null
+  i18nConfigContent?: string
+} = {}) {
+  const {
+    locales = ['en', 'de'],
+    localeDir = 'src/locales',
+    hasVueI18n = true,
+    hasNuxt = false,
+    i18nConfigFile = null,
+    i18nConfigContent = '',
+  } = opts
+
+  const deps: Record<string, string> = { vue: '^3.4.0' }
+  if (hasVueI18n) deps['vue-i18n'] = '^10.0.0'
+  if (hasNuxt) deps['@nuxt/kit'] = '^3.0.0'
+
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ dependencies: deps }, null, 2))
+
+  const fullLocaleDir = join(root, localeDir)
+  mkdirSync(fullLocaleDir, { recursive: true })
+
+  for (const locale of locales) {
+    writeFileSync(join(fullLocaleDir, `${locale}.json`), JSON.stringify({ hello: 'world' }))
+  }
+
+  if (i18nConfigFile) {
+    const configDir = i18nConfigFile.replace(/\/[^/]+$/, '')
+    if (configDir !== i18nConfigFile) {
+      mkdirSync(join(root, configDir), { recursive: true })
+    }
+    writeFileSync(join(root, i18nConfigFile), i18nConfigContent)
+  }
+}
+
+describe('VueAdapter.detect', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `vue-adapter-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('has correct static properties', () => {
+    const adapter = new VueAdapter()
+    expect(adapter.name).toBe('vue')
+    expect(adapter.label).toBe('Vue')
+    expect(adapter.localeFileFormat).toBe('json')
+  })
+
+  it('returns 7 for a full Vue + vue-i18n project with locales', async () => {
+    createVueProject(tempDir)
+    const adapter = new VueAdapter()
+    // vue (2) + vue-i18n (3) + locale files (2) = 7
+    expect(await adapter.detect(tempDir)).toBe(7)
+  })
+
+  it('returns 5 for vue-i18n project without discovered locale files', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0' },
+    }))
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(5)
+  })
+
+  it('returns 4 for Vue + locale files but no vue-i18n dep', async () => {
+    createVueProject(tempDir, { hasVueI18n: false })
+    const adapter = new VueAdapter()
+    // vue (2) + locale files (2) = 4
+    expect(await adapter.detect(tempDir)).toBe(4)
+  })
+
+  it('returns 2 for Vue project without vue-i18n or locale files', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0' },
+    }))
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(2)
+  })
+
+  it('returns 0 when vue is not in dependencies', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0' },
+    }))
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when package.json is missing', async () => {
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when package.json is malformed', async () => {
+    writeFileSync(join(tempDir, 'package.json'), '{ invalid json }')
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 for Nuxt project (vue but also @nuxt/kit)', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0', '@nuxt/kit': '^3.0.0' },
+    }))
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when nuxt.config.ts exists', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0' },
+    }))
+    writeFileSync(join(tempDir, 'nuxt.config.ts'), 'export default {}')
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 for Nuxt project with "nuxt" in deps', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', nuxt: '^3.0.0' },
+    }))
+    const adapter = new VueAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+})
+
+describe('VueAdapter.resolve', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `vue-resolve-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves a standard vue-i18n project with src/locales/', async () => {
+    createVueProject(tempDir)
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.rootDir).toBe(tempDir)
+    expect(config.defaultLocale).toBe('de')
+    expect(config.fallbackLocale).toEqual({ default: ['de'] })
+    expect(config.locales).toHaveLength(2)
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+    expect(config.locales[0].file).toBe('de.json')
+    expect(config.localeDirs).toHaveLength(1)
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'src/locales'))
+    expect(config.localeDirs[0].layer).toBe('root')
+    expect(config.localeDirs[0].layerRootDir).toBe(tempDir)
+    expect(config.layerRootDirs).toEqual([tempDir])
+  })
+
+  it('discovers locales from locates/ directory', async () => {
+    createVueProject(tempDir, { localeDir: 'locales', locales: ['en', 'fr', 'ja'] })
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales).toHaveLength(3)
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'fr', 'ja'])
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'locales'))
+  })
+
+  it('discovers locales from src/i18n/locales/', async () => {
+    createVueProject(tempDir, { localeDir: 'src/i18n/locales', locales: ['en'] })
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'src/i18n/locales'))
+  })
+
+  it('detects locale dir from createI18n config with localeDir', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0' },
+    }))
+
+    const customDir = join(tempDir, 'my-locales')
+    mkdirSync(customDir, { recursive: true })
+    writeFileSync(join(customDir, 'en.json'), JSON.stringify({ hello: 'world' }))
+
+    const configFile = 'src/i18n/index.ts'
+    mkdirSync(join(tempDir, 'src/i18n'), { recursive: true })
+    writeFileSync(join(tempDir, configFile), `const i18n = createI18n({ localeDir: 'my-locales', legacy: false })`)
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs[0].path).toBe(customDir)
+  })
+
+  it('defaults to first locale when no .env found', async () => {
+    createVueProject(tempDir, { locales: ['en', 'de', 'fr'] })
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.defaultLocale).toBe('de')
+  })
+
+  it('throws ConfigError when no locale directory found', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0' },
+    }))
+
+    const adapter = new VueAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale directory found')
+  })
+
+  it('throws ConfigError when locale dir has no JSON files', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { vue: '^3.4.0', 'vue-i18n': '^10.0.0' },
+    }))
+    mkdirSync(join(tempDir, 'src/locales'), { recursive: true })
+
+    const adapter = new VueAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No JSON locale files found')
+  })
+
+  it('honors locales override from .i18n-mcp.json', async () => {
+    createVueProject(tempDir, { locales: ['en', 'de', 'fr', 'es'] })
+    writeFileSync(
+      join(tempDir, '.i18n-mcp.json'),
+      JSON.stringify({ locales: ['en', 'de'] }),
+    )
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'de'])
+  })
+
+  it('sorts locale codes alphabetically', async () => {
+    createVueProject(tempDir, { locales: ['fr', 'en', 'de', 'zh'] })
+
+    const adapter = new VueAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr', 'zh'])
+  })
+})
+
+describe('Adapter registry: Vue vs Nuxt', () => {
+  beforeEach(() => {
+    resetRegistry()
+  })
+
+  afterEach(() => {
+    resetRegistry()
+  })
+
+  it('selects VueAdapter when vue-i18n signals present without Nuxt', async () => {
+    const tempDir = join(tmpdir(), `registry-vue-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    createVueProject(tempDir)
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new VueAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('vue')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('selects NuxtAdapter when Nuxt config is present', async () => {
+    const tempDir = join(tmpdir(), `registry-nuxt-wins-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    writeFileSync(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ i18n: { defaultLocale: "en" } })',
+    )
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new VueAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('nuxt')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/cleanup.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/cleanup.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:18:55.203Z",
+  "generatedAt": "2026-06-12T20:33:43.188Z",
   "tool": "remove_orphan_keys",
   "args": {
     "dryRun": true

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/orphans.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/orphans.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:18:55.131Z",
+  "generatedAt": "2026-06-12T20:33:43.157Z",
   "tool": "find_orphan_keys",
   "args": {},
   "orphanKeys": {

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/scan.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/scan.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:18:55.185Z",
+  "generatedAt": "2026-06-12T20:33:43.174Z",
   "tool": "scan_code_usage",
   "args": {},
   "usages": {},

--- a/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/empty.json
+++ b/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/empty.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:18:55.113Z",
+  "generatedAt": "2026-06-12T20:33:43.134Z",
   "tool": "find_empty_translations",
   "args": {},
   "emptyKeys": {

--- a/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/missing.json
+++ b/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/missing.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:18:55.108Z",
+  "generatedAt": "2026-06-12T20:33:43.121Z",
   "tool": "get_missing_translations",
   "args": {},
   "missing": {


### PR DESCRIPTION
## Problem
The Nuxt adapter requires `@nuxt/kit` and `nuxt.config.ts`. Standalone Vue projects using `vue-i18n` (500K weekly downloads) aren't supported even though all the infrastructure already exists — the scanner patterns, JSON readers, and writers work perfectly for Vue. Only detection + directory resolution is missing.

## Changes
- Add `VueAdapter` in `packages/cli/src/adapters/vue/index.ts` (~120 lines)
- Register in `packages/cli/src/config/detector.ts`
- 21 test cases in `tests/adapters/vue-adapter.test.ts`

### Detection (confidence scoring up to 7)
- `vue` in package.json → +2
- `vue-i18n` in deps → +3  
- JSON locale files on disk → +2
- Returns 0 for Nuxt projects (checks `@nuxt/kit`, `nuxt` deps, and `nuxt.config.*`)

### Resolution
- Parses `createI18n()` config from common files (`src/i18n/index.ts`, `src/plugins/i18n.ts`, etc.)
- Extracts `localeDir` path when specified
- Falls back to scanning `src/locales/`, `locales/`, `src/i18n/locales/`, etc.
- Discovers locales from JSON file names
- Reuses existing `VUE_NUXT_PATTERNS` scanner, JSON readers/writers

## Files
- `packages/cli/src/adapters/vue/index.ts` — new adapter
- `packages/cli/src/config/detector.ts` — registration
- `packages/cli/tests/adapters/vue-adapter.test.ts` — 21 tests

Closes #146