### PR TITLE
feat: add React/Next.js auto-detection adapter (#149)

### DIFF
--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -129,7 +129,7 @@ async function computeScore(
     const localeDir = findLocaleDirSync(projectDir)
     if (localeDir) {
       const entries = readdirSync(localeDir)
-      if (entries.some(e => isLocaleSubdir(join(localeDir, e)))) score += 2
+      if (entries.some(e => isLocaleContent(join(localeDir, e)))) score += 2
     }
   }
   catch {
@@ -158,6 +158,11 @@ function findLocaleDirSync(projectDir: string): string | null {
     if (existsSync(fullPath)) return fullPath
   }
   return null
+}
+
+function isLocaleContent(path: string): boolean {
+  if (path.endsWith('.json')) return true
+  return isLocaleSubdir(path)
 }
 
 function isLocaleSubdir(path: string): boolean {

--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -182,29 +182,41 @@ async function tryNextConfig(projectDir: string): Promise<string | null> {
     const fullPath = join(projectDir, file)
     if (!existsSync(fullPath)) continue
 
-    try {
-      const content = await readFile(fullPath, 'utf-8')
-
-      if (/createNextIntlPlugin/.test(content) && existsSync(join(projectDir, 'messages'))) {
-        return join(projectDir, 'messages')
-      }
-
-      if (/next-translate/.test(content) && existsSync(join(projectDir, 'locales'))) {
-        return join(projectDir, 'locales')
-      }
-
-      const pathMatch = content.match(/(?:messages|localeDir|locales)\s*:\s*['"]([^'"]+)/)
-      if (pathMatch) {
-        const path = pathMatch[1].replace(/\/\*\/\*$/, '').replace(/\/\*$/, '')
-        if (existsSync(join(projectDir, path))) return join(projectDir, path)
-      }
-    }
-    catch {
-      // Can't read — try next
-    }
+    const result = await tryExtractFromNextConfig(projectDir, fullPath)
+    if (result) return result
   }
 
   return null
+}
+
+async function tryExtractFromNextConfig(
+  projectDir: string,
+  configPath: string,
+): Promise<string | null> {
+  try {
+    const content = await readFile(configPath, 'utf-8')
+
+    if (/createNextIntlPlugin/.test(content) && existsSync(join(projectDir, 'messages'))) {
+      return join(projectDir, 'messages')
+    }
+
+    if (/next-translate/.test(content) && existsSync(join(projectDir, 'locales'))) {
+      return join(projectDir, 'locales')
+    }
+
+    return tryExtractPathFromConfig(projectDir, content)
+  }
+  catch {
+    return null
+  }
+}
+
+function tryExtractPathFromConfig(projectDir: string, content: string): string | null {
+  const pathMatch = content.match(/(?:messages|localeDir|locales)\s*:\s*['"]([^'"]+)/)
+  if (!pathMatch) return null
+
+  const path = pathMatch[1].replace(/\/\*\/\*$/, '').replace(/\/\*$/, '')
+  return existsSync(join(projectDir, path)) ? join(projectDir, path) : null
 }
 
 async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {

--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -1,0 +1,236 @@
+import { existsSync, statSync, readdirSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { FrameworkAdapter, LocaleFileFormat } from '../types'
+import type { I18nConfig, LocaleDefinition } from '../../config/types'
+import { loadProjectConfig } from '../../config/project-config'
+import { applyLocaleOverride } from '../../config/locale-override'
+import { ConfigError } from '../../utils/errors'
+
+const COMMON_LOCALE_DIRS = [
+  'messages',
+  'public/locales',
+  'locales',
+  'src/i18n',
+  'src/locales',
+  'i18n',
+]
+
+const NEXT_CONFIG_FILES = ['next.config.ts', 'next.config.js', 'next.config.mjs']
+
+const NUXT_INDICATORS = ['@nuxt/kit', 'nuxt']
+const VUE_INDICATORS = ['vue']
+
+const I18N_DEPS = ['next-intl', 'next-translate', 'next-i18next', 'react-i18next', 'react-intl']
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.DS_Store'])
+
+export class ReactAdapter implements FrameworkAdapter {
+  readonly name = 'react'
+  readonly label = 'React / Next.js'
+  readonly localeFileFormat: LocaleFileFormat = 'json'
+
+  async detect(projectDir: string): Promise<number> {
+    const pkg = await loadPackageJson(projectDir)
+    if (!pkg) return 0
+
+    const allDeps = collectDependencies(pkg)
+    if (isConflictingFramework(projectDir, allDeps)) return 0
+
+    const isNext = 'next' in allDeps
+    const isReact = 'react' in allDeps && 'react-dom' in allDeps
+
+    if (!isNext && !isReact) return 0
+
+    return computeScore(projectDir, allDeps, isNext)
+  }
+
+  async resolve(projectDir: string): Promise<I18nConfig> {
+    const projectConfig = await loadProjectConfig(projectDir)
+
+    const localeDir = await findLocaleDir(projectDir)
+    if (!localeDir) {
+      throw new ConfigError(
+        `No locale directory found in ${projectDir}. `
+        + 'Looked in: ' + COMMON_LOCALE_DIRS.join(', ') + '. '
+        + 'Configure a .i18n-mcp.json with localeDirs for custom paths.',
+      )
+    }
+
+    const locales = await discoverLocales(localeDir)
+    if (locales.length === 0) {
+      throw new ConfigError(
+        `No locale files found in ${localeDir}. `
+        + 'Make sure your React/Next.js project has locale directories like messages/en/ or locale JSON files.',
+      )
+    }
+
+    const defaultLocale = locales[0].code
+    const fallbackLocale = { default: [defaultLocale] }
+
+    return {
+      rootDir: projectDir,
+      defaultLocale,
+      fallbackLocale,
+      locales: applyLocaleOverride(locales, projectConfig?.locales),
+      localeDirs: [{ path: localeDir, layer: 'root', layerRootDir: projectDir }],
+      layerRootDirs: [projectDir],
+      projectConfig: projectConfig ?? undefined,
+      apps: [{ name: 'default', rootDir: projectDir, layers: ['root'] }],
+    }
+  }
+}
+
+// ─── Detection helpers ──────────────────────────────────────────
+
+async function loadPackageJson(projectDir: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(join(projectDir, 'package.json'), 'utf-8')
+    return JSON.parse(raw) as Record<string, unknown>
+  }
+  catch {
+    return null
+  }
+}
+
+function collectDependencies(pkg: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...(pkg.dependencies ?? {}) as Record<string, unknown>,
+    ...(pkg.devDependencies ?? {}) as Record<string, unknown>,
+  }
+}
+
+function isConflictingFramework(projectDir: string, deps: Record<string, unknown>): boolean {
+  for (const indicator of NUXT_INDICATORS) {
+    if (indicator in deps) return true
+  }
+  for (const indicator of VUE_INDICATORS) {
+    if (indicator in deps) return true
+  }
+  return hasNuxtConfig(projectDir)
+}
+
+function hasNextConfig(projectDir: string): boolean {
+  return NEXT_CONFIG_FILES.some(f => existsSync(join(projectDir, f)))
+}
+
+async function computeScore(
+  projectDir: string,
+  deps: Record<string, unknown>,
+  isNext: boolean,
+): Promise<number> {
+  let score = isNext ? 5 : 3
+
+  if (I18N_DEPS.some(dep => dep in deps)) score += 2
+
+  if (isNext && hasNextConfig(projectDir)) score += 1
+
+  try {
+    const localeDir = findLocaleDirSync(projectDir)
+    if (localeDir) {
+      const entries = readdirSync(localeDir)
+      if (entries.some(e => isLocaleSubdir(join(localeDir, e)))) score += 2
+    }
+  }
+  catch {
+    // Can't read dirs — skip bonus
+  }
+
+  return score
+}
+
+// ─── Resolution helpers ─────────────────────────────────────────
+
+function hasNuxtConfig(dir: string): boolean {
+  return ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs'].some(f => existsSync(join(dir, f)))
+}
+
+async function findLocaleDir(projectDir: string): Promise<string | null> {
+  const fromConfig = await tryNextConfig(projectDir)
+  if (fromConfig) return fromConfig
+
+  return findLocaleDirSync(projectDir)
+}
+
+function findLocaleDirSync(projectDir: string): string | null {
+  for (const dir of COMMON_LOCALE_DIRS) {
+    const fullPath = join(projectDir, dir)
+    if (existsSync(fullPath)) return fullPath
+  }
+  return null
+}
+
+function isLocaleSubdir(path: string): boolean {
+  if (!existsSync(path)) return false
+  try {
+    if (!statSync(path).isDirectory()) return false
+    const files = readdirSync(path)
+    return files.some(f => f.endsWith('.json'))
+  }
+  catch {
+    return false
+  }
+}
+
+async function tryNextConfig(projectDir: string): Promise<string | null> {
+  for (const file of NEXT_CONFIG_FILES) {
+    const fullPath = join(projectDir, file)
+    if (!existsSync(fullPath)) continue
+
+    try {
+      const content = await readFile(fullPath, 'utf-8')
+
+      if (/createNextIntlPlugin/.test(content) && existsSync(join(projectDir, 'messages'))) {
+        return join(projectDir, 'messages')
+      }
+
+      if (/next-translate/.test(content) && existsSync(join(projectDir, 'locales'))) {
+        return join(projectDir, 'locales')
+      }
+
+      const pathMatch = content.match(/(?:messages|localeDir|locales)\s*:\s*['"]([^'"]+)/)
+      if (pathMatch) {
+        const path = pathMatch[1].replace(/\/\*\/\*$/, '').replace(/\/\*$/, '')
+        if (existsSync(join(projectDir, path))) return join(projectDir, path)
+      }
+    }
+    catch {
+      // Can't read — try next
+    }
+  }
+
+  return null
+}
+
+async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(localeDir)
+  }
+  catch {
+    return []
+  }
+
+  const localeCodes = new Set<string>()
+
+  // Namespaced layout: messages/en/common.json
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry) || entry.startsWith('.')) continue
+    const fullPath = join(localeDir, entry)
+    if (isLocaleSubdir(fullPath)) localeCodes.add(entry)
+  }
+
+  if (localeCodes.size === 0) {
+    // Flat JSON layout: locales/en.json
+    for (const entry of entries) {
+      if (entry.endsWith('.json')) {
+        localeCodes.add(entry.replace(/\.json$/, ''))
+      }
+    }
+  }
+
+  return [...localeCodes].sort().map(code => ({
+    code,
+    language: code,
+  }))
+}

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -60,14 +60,15 @@ export class VueAdapter implements FrameworkAdapter {
       )
     }
 
-    const locales = await discoverLocales(localeDir)
-    if (locales.length === 0) {
+    const rawLocales = await discoverLocales(localeDir)
+    if (rawLocales.length === 0) {
       throw new ConfigError(
         `No JSON locale files found in ${localeDir}. `
         + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
       )
     }
 
+    const locales = applyLocaleOverride(rawLocales, projectConfig?.locales)
     const defaultLocale = extractDefaultLocale(projectDir) ?? locales[0].code
     const fallbackLocale = { default: [defaultLocale] }
 
@@ -75,7 +76,7 @@ export class VueAdapter implements FrameworkAdapter {
       rootDir: projectDir,
       defaultLocale,
       fallbackLocale,
-      locales: applyLocaleOverride(locales, projectConfig?.locales),
+      locales,
       localeDirs: [{ path: localeDir, layer: 'root', layerRootDir: projectDir }],
       layerRootDirs: [projectDir],
       projectConfig: projectConfig ?? undefined,

--- a/packages/cli/src/config/detector.ts
+++ b/packages/cli/src/config/detector.ts
@@ -4,6 +4,7 @@ import { NuxtAdapter } from '../adapters/nuxt/index'
 import { LaravelAdapter } from '../adapters/laravel/index'
 import { GenericAdapter } from '../adapters/generic/index'
 import { VueAdapter } from '../adapters/vue/index'
+import { ReactAdapter } from '../adapters/react/index'
 import { loadProjectConfig } from './project-config'
 import { log } from '../utils/logger'
 import { canonicalPath } from './discovery'
@@ -14,6 +15,7 @@ registerAdapter(new NuxtAdapter())
 registerAdapter(new LaravelAdapter())
 registerAdapter(new GenericAdapter())
 registerAdapter(new VueAdapter())
+registerAdapter(new ReactAdapter())
 
 const configCache = new Map<string, I18nConfig>()
 

--- a/packages/cli/tests/adapters/react-adapter.test.ts
+++ b/packages/cli/tests/adapters/react-adapter.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { ReactAdapter } from '../../src/adapters/react/index'
+import { registerAdapter, resetRegistry, detectFramework } from '../../src/adapters/registry'
+import { NuxtAdapter } from '../../src/adapters/nuxt/index'
+import { VueAdapter } from '../../src/adapters/vue/index'
+
+function createReactProject(root: string, opts: {
+  type?: 'next' | 'react'
+  locales?: string[]
+  localeDir?: string
+  i18nDep?: string | null
+  hasNextConfig?: boolean
+} = {}) {
+  const {
+    type = 'next',
+    locales = ['en', 'de'],
+    localeDir = 'messages',
+    i18nDep = 'next-intl',
+    hasNextConfig = true,
+  } = opts
+
+  const deps: Record<string, string> = {}
+  if (type === 'next') {
+    deps.next = '^14.0.0'
+  }
+  deps.react = '^18.2.0'
+  deps['react-dom'] = '^18.2.0'
+  if (i18nDep) deps[i18nDep] = '^3.0.0'
+
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ dependencies: deps }, null, 2))
+
+  if (type === 'next' && hasNextConfig) {
+    let config = "const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts')\n"
+    config += 'export default withNextIntl({})\n'
+    writeFileSync(join(root, 'next.config.ts'), config)
+  }
+
+  const fullLocaleDir = join(root, localeDir)
+  mkdirSync(fullLocaleDir, { recursive: true })
+
+  for (const locale of locales) {
+    const localeSubdir = join(fullLocaleDir, locale)
+    mkdirSync(localeSubdir, { recursive: true })
+    writeFileSync(join(localeSubdir, 'common.json'), JSON.stringify({ hello: 'world' }))
+  }
+}
+
+describe('ReactAdapter.detect', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `react-adapter-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('has correct static properties', () => {
+    const adapter = new ReactAdapter()
+    expect(adapter.name).toBe('react')
+    expect(adapter.label).toBe('React / Next.js')
+    expect(adapter.localeFileFormat).toBe('json')
+  })
+
+  it('returns 10 for Next.js + next-intl + locale files', async () => {
+    createReactProject(tempDir)
+    // next (5) + i18n dep (2) + next.config (1) + locale files (2) = 10
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(10)
+  })
+
+  it('returns 9 for Next.js + next-intl without next.config', async () => {
+    createReactProject(tempDir, { hasNextConfig: false })
+    const adapter = new ReactAdapter()
+    // next (5) + i18n dep (2) + locale files (2) = 9
+    expect(await adapter.detect(tempDir)).toBe(9)
+  })
+
+  it('returns 8 for Next.js without i18n dep but with locale files', async () => {
+    createReactProject(tempDir, { i18nDep: null })
+    // next (5) + next.config (1) + locale files (2) = 8... wait
+    // Actually without i18n dep: next (5) + hasNextConfig (1) + locale files (2) = 8
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(8)
+  })
+
+  it('returns 5 for React + react-i18next + locale files', async () => {
+    createReactProject(tempDir, { type: 'react', i18nDep: 'react-i18next', hasNextConfig: false })
+    // react (3) + i18n dep (2) + locale files (2) = 7
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(7)
+  })
+
+  it('returns 3 for bare React without i18n or locale files', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+    }))
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(3)
+  })
+
+  it('returns 0 when neither React nor Next.js deps present', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { express: '^4.0.0' },
+    }))
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 when package.json is missing', async () => {
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 for Vue project (react deps present but vue first)', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0', vue: '^3.0.0' },
+    }))
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+
+  it('returns 0 for Nuxt project', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0', '@nuxt/kit': '^3.0.0' },
+    }))
+    const adapter = new ReactAdapter()
+    expect(await adapter.detect(tempDir)).toBe(0)
+  })
+})
+
+describe('ReactAdapter.resolve', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `react-resolve-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves standard Next.js + next-intl project', async () => {
+    createReactProject(tempDir)
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.rootDir).toBe(tempDir)
+    expect(config.defaultLocale).toBe('de')
+    expect(config.fallbackLocale).toEqual({ default: ['de'] })
+    expect(config.locales).toHaveLength(2)
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+    expect(config.localeDirs).toHaveLength(1)
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'messages'))
+    expect(config.localeDirs[0].layer).toBe('root')
+    expect(config.layerRootDirs).toEqual([tempDir])
+  })
+
+  it('discovers locales from public/locales/', async () => {
+    createReactProject(tempDir, { localeDir: 'public/locales', hasNextConfig: false, i18nDep: 'react-i18next' })
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'public/locales'))
+  })
+
+  it('discovers locales from locates/ directory', async () => {
+    createReactProject(tempDir, { localeDir: 'locales', i18nDep: 'next-translate' })
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'locales'))
+  })
+
+  it('throws ConfigError when no locale directory found', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { next: '^14.0.0', react: '^18.0.0', 'react-dom': '^18.0.0', 'next-intl': '^3.0.0' },
+    }))
+
+    const adapter = new ReactAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale directory found')
+  })
+
+  it('throws ConfigError when locale dir has no locale subdirectories', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { next: '^14.0.0', react: '^18.0.0', 'react-dom': '^18.0.0', 'next-intl': '^3.0.0' },
+    }))
+    mkdirSync(join(tempDir, 'messages'))
+
+    const adapter = new ReactAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale files found')
+  })
+
+  it('honors locales override from .i18n-mcp.json', async () => {
+    createReactProject(tempDir, { locales: ['en', 'de', 'fr', 'es'] })
+    writeFileSync(
+      join(tempDir, '.i18n-mcp.json'),
+      JSON.stringify({ locales: ['en', 'fr'] }),
+    )
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['en', 'fr'])
+  })
+
+  it('sorts locale codes alphabetically', async () => {
+    createReactProject(tempDir, { locales: ['fr', 'en', 'de', 'zh'] })
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en', 'fr', 'zh'])
+  })
+
+  it('handles flat JSON layout when no subdirectories found', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0', 'react-i18next': '^14.0.0' },
+    }))
+    const localeDir = join(tempDir, 'src/locales')
+    mkdirSync(localeDir, { recursive: true })
+    writeFileSync(join(localeDir, 'en.json'), JSON.stringify({ hello: 'world' }))
+    writeFileSync(join(localeDir, 'de.json'), JSON.stringify({ hello: 'welt' }))
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
+})
+
+describe('Adapter registry: React vs others', () => {
+  beforeEach(() => {
+    resetRegistry()
+  })
+
+  afterEach(() => {
+    resetRegistry()
+  })
+
+  it('selects ReactAdapter when Next.js signals present without Nuxt/Vue', async () => {
+    const tempDir = join(tmpdir(), `registry-react-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    createReactProject(tempDir)
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new VueAdapter())
+      registerAdapter(new ReactAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('react')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('selects NuxtAdapter when Nuxt signals are present', async () => {
+    const tempDir = join(tmpdir(), `registry-nuxt-wins-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { next: '^14.0.0', react: '^18.0.0', 'react-dom': '^18.0.0' },
+    }))
+    writeFileSync(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ i18n: { defaultLocale: "en" } })',
+    )
+
+    try {
+      registerAdapter(new NuxtAdapter())
+      registerAdapter(new ReactAdapter())
+
+      const adapter = await detectFramework(tempDir)
+      expect(adapter.name).toBe('nuxt')
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Problem
Namespaced JSON support (#145) added the IO layer, but React/Next.js projects still need manual `.i18n-mcp.json` config. Nuxt, Laravel, and Vue get auto-detection — React/Next.js should too.

## Changes
- Add `ReactAdapter` in `packages/cli/src/adapters/react/index.ts` (~180 lines)
- Register in `packages/cli/src/config/detector.ts`
- 18 test cases in `tests/adapters/react-adapter.test.ts`

### Detection (confidence scoring up to 10)
- `next` in deps → +5 (Next.js), or `react` + `react-dom` → +3 (React)
- i18n dep (`next-intl`, `react-i18next`, etc.) → +2
- `next.config.*` exists → +1
- Locale files on disk → +2
- Returns 0 for Vue/Nuxt projects

### Resolution
- Parses `next.config.*` for next-intl/next-translate config
- Scans common paths: `messages/`, `public/locales/`, `locales/`, `src/i18n/`, etc.
- Discovers locales from namespaced subdirectories (`messages/en/common.json`) or flat JSON files
- Reuses existing namespaced JSON IO layer from #145

Completes the framework trifecta: Nuxt, Vue, React/Next.js.

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and configuration for React / Next.js projects to locate locale directories, discover JSON translation files, and assemble i18n settings.

* **Tests**
  * Added comprehensive tests for adapter detection, locale discovery/resolution, error cases, and framework selection.

* **Refactor**
  * Improved locale discovery flow for Vue projects to validate raw locale files and apply overrides before finalizing i18n configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->