### PR TITLE
feat: search all layers, compact outputs for get_translations and translate_missing (#150, #151, #152)

### DIFF
--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -587,6 +587,7 @@ export async function getTranslations(opts: {
   layer: string
   locale: string
   keys: string[]
+  compact?: boolean
   projectDir?: string
 }): Promise<Record<string, Record<string, unknown>>> {
   const { layer, locale, keys } = opts
@@ -613,6 +614,33 @@ export async function getTranslations(opts: {
     results[loc.code] = Object.fromEntries(
       keys.map(k => [k, getNestedValue(data, k) ?? null]),
     )
+  }
+
+  // Compact mode: summarize by key across all locales
+  if (opts.compact && locale === '*' && localesToRead.length > 1) {
+    const byKey: Record<string, { status: string; totalPresent: number; empty?: string[]; missing?: string[] }> = {}
+    for (const key of keys) {
+      let present = 0
+      const empty: string[] = []
+      const missing: string[] = []
+      for (const loc of localesToRead) {
+        const val = results[loc.code]?.[key]
+        if (val === undefined || val === null) {
+          missing.push(loc.code)
+        } else if (val === '') {
+          empty.push(loc.code)
+        } else {
+          present++
+        }
+      }
+      byKey[key] = {
+        status: present === localesToRead.length ? 'ok' : present > 0 ? 'partial' : 'missing',
+        totalPresent: present,
+        ...(empty.length > 0 && { empty }),
+        ...(missing.length > 0 && { missing }),
+      }
+    }
+    return { byKey } as unknown as Record<string, Record<string, unknown>>
   }
 
   return results
@@ -990,12 +1018,12 @@ export async function searchTranslations(opts: {
   const queryLower = query.toLowerCase()
 
   // Determine layers to search
-  const layersToSearch = layer
+  const layersToSearch = (layer && layer !== '*')
     ? config.localeDirs.filter(d => d.layer === layer)
     : config.localeDirs.filter(d => !d.aliasOf)
 
   if (layersToSearch.length === 0) {
-    if (layer) {
+    if (layer && layer !== '*') {
       findLayerOrThrow(config, layer)
     }
     throw new ToolError('No locale directories found. Run detect_i18n_config to verify the project setup.', 'LAYER_NOT_FOUND')
@@ -1250,6 +1278,7 @@ export async function translateMissing(opts: {
   keys?: string[]
   batchSize?: number
   dryRun?: boolean
+  compact?: boolean
   projectDir?: string
   samplingFn?: SamplingFn
   progressFn?: ProgressFn
@@ -1526,6 +1555,21 @@ export async function translateMissing(opts: {
     output.summary = {
       ...(output.summary as Record<string, unknown>),
       message: 'Sampling not supported by this host. Use the fallbackContexts to translate inline, then call write_translations (mode: "upsert") to write the results.',
+    }
+  }
+
+  if (opts.compact) {
+    const byLocale = Object.entries(results).map(([code, r]) => ({
+      locale: code,
+      translated: r.translated.length,
+      failed: r.failed.length,
+    }))
+    return {
+      summary: {
+        totalTranslated,
+        totalFailed,
+        byLocale,
+      },
     }
   }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -152,6 +152,10 @@ export function createServer(): McpServer {
         locale: z
           .string()
           .describe('Locale code, locale file name, or "*" to read all locales. Examples: "en", "en-US", "en-US.json", "*".'),
+        compact: z
+          .boolean()
+          .optional()
+          .describe('When true and locale is "*", returns a compact summary grouped by key instead of per-locale detail. Default: false.'),
         keys: z
           .array(z.string())
           .describe('Dot-separated key paths to read. Example: ["common.actions.save", "auth.login.title"].'),
@@ -161,9 +165,9 @@ export function createServer(): McpServer {
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
       },
     },
-    async ({ layer, locale, keys, projectDir }) => {
+    async ({ layer, locale, keys, compact, projectDir }) => {
       try {
-        const result = await getTranslations({ layer, locale, keys, projectDir })
+        const result = await getTranslations({ layer, locale, keys, compact, projectDir })
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('getting translations', error)
@@ -280,7 +284,7 @@ export function createServer(): McpServer {
         layer: z
           .string()
           .optional()
-          .describe('Layer name to search in (e.g., "root", "app-admin"). If omitted, searches all layers. Call discover to discover available layers.'),
+          .describe('Layer name to search in (e.g., "root", "app-admin"), or "*" for all layers. If omitted, searches all layers. Call discover to discover available layers.'),
         locale: z
           .string()
           .optional()
@@ -414,13 +418,17 @@ export function createServer(): McpServer {
           .boolean()
           .optional()
           .describe('When true, returns which keys would be translated without calling the LLM or writing files. Default: false.'),
+        compact: z
+          .boolean()
+          .optional()
+          .describe('When true, returns a compact summary (totalTranslated, totalFailed, byLocale) instead of full per-locale results. Default: false.'),
         projectDir: z
           .string()
           .optional()
           .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
       },
     },
-    async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, projectDir }, extra) => {
+    async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, compact, projectDir }, extra) => {
       try {
         // Check sampling support from MCP client capabilities
         const clientCapabilities = server.server.getClientCapabilities()
@@ -491,6 +499,7 @@ export function createServer(): McpServer {
           keys,
           batchSize,
           dryRun,
+          compact,
           projectDir,
           samplingFn,
           progressFn,


### PR DESCRIPTION
## Changes

### #150 — search_translations across all layers
- Accept `layer: "*"` to explicitly search all non-alias layers
- Each match already includes the layer for disambiguation

### #151 — translate_missing compact output
- Add `compact: true` option
- Returns `{ summary: { totalTranslated, totalFailed, byLocale: [...] } }` instead of full per-locale results

### #152 — get_translations compact output
- Add `compact: true` option for `locale: "*"` queries
- Returns `{ byKey: { [key]: { status, totalPresent, empty?, missing? } } }` grouped by key

## Files
- `packages/cli/src/core/operations.ts` — operation logic
- `packages/mcp/src/server.ts` — Zod schemas + param passthrough

Closes #150, closes #151, closes #152