### PR TITLE
feat: add list_namespaces MCP tool (#153)

### DIFF
--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -2187,3 +2187,89 @@ export async function scaffoldLocaleFiles(opts: {
     dryRun: opts.dryRun ?? false,
   }
 }
+
+// ─── list_namespaces ────────────────────────────────────────────
+
+export interface NamespaceNode {
+  keyCount: number
+  children?: Record<string, NamespaceNode>
+}
+
+export interface ListNamespacesResult {
+  layers: Record<string, { namespaces: Record<string, NamespaceNode> }>
+}
+
+/**
+ * Build a prefix tree of all translation keys grouped by layer and namespace.
+ * Useful for agents to browse available keys without guesswork.
+ */
+export async function listNamespaces(opts: {
+  layer?: string
+  locale?: string
+  projectDir?: string
+}): Promise<ListNamespacesResult> {
+  const dir = opts.projectDir ?? process.cwd()
+  const config = await detectI18nConfig(dir)
+
+  const layersToScan = (opts.layer && opts.layer !== '*')
+    ? config.localeDirs.filter(d => d.layer === opts.layer)
+    : config.localeDirs.filter(d => !d.aliasOf)
+
+  const localeToUse = opts.locale
+    ? findLocaleImpl(config, opts.locale) ?? config.locales[0]
+    : config.locales[0]
+
+  if (!localeToUse) {
+    throw new ToolError('No locales found in configuration.', 'LOCALE_NOT_FOUND')
+  }
+
+  const layers: Record<string, { namespaces: Record<string, NamespaceNode> }> = {}
+
+  for (const ld of layersToScan) {
+    let data: Record<string, unknown>
+    try {
+      data = await readLocaleData(config, ld.layer, localeToUse)
+    }
+    catch {
+      continue
+    }
+
+    const keys = getLeafKeys(data)
+    if (keys.length === 0) continue
+
+    const root: NamespaceNode = { keyCount: 0, children: {} }
+
+    for (const key of keys) {
+      const segments = key.split('.')
+      let node = root
+      for (const seg of segments) {
+        if (!node.children) node.children = {}
+        if (!node.children[seg]) {
+          node.children[seg] = { keyCount: 0 }
+        }
+        node = node.children[seg]
+      }
+      node.keyCount++ // leaf count at terminal node
+    }
+
+    // Propagate leaf counts upward
+    propagateCounts(root)
+
+    layers[ld.layer] = { namespaces: root.children ?? {} }
+  }
+
+  return { layers }
+}
+
+function propagateCounts(node: NamespaceNode): number {
+  if (!node.children || Object.keys(node.children).length === 0) {
+    return node.keyCount
+  }
+
+  let total = 0
+  for (const child of Object.values(node.children)) {
+    total += propagateCounts(child)
+  }
+  node.keyCount = total
+  return total
+}

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -2211,13 +2211,20 @@ export async function listNamespaces(opts: {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
 
+  // Validate and resolve layers
+  if (opts.layer && opts.layer !== '*') {
+    findLayerOrThrow(config, opts.layer)
+  }
   const layersToScan = (opts.layer && opts.layer !== '*')
     ? config.localeDirs.filter(d => d.layer === opts.layer)
     : config.localeDirs.filter(d => !d.aliasOf)
 
+  // Resolve locale: validate explicit, default to configured default locale
   const localeToUse = opts.locale
-    ? findLocaleImpl(config, opts.locale) ?? config.locales[0]
-    : config.locales[0]
+    ? findLocaleImpl(config, opts.locale) ?? (() => {
+        throw new ToolError(`Locale not found: "${opts.locale}". Available: ${config.locales.map(l => l.code).join(', ')}.`, 'LOCALE_NOT_FOUND')
+      })()
+    : findLocaleImpl(config, config.defaultLocale) ?? config.locales[0]
 
   if (!localeToUse) {
     throw new ToolError('No locales found in configuration.', 'LOCALE_NOT_FOUND')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ export {
   scanCodeUsage,
   removeOrphanKeys,
   scaffoldLocaleFiles,
+  listNamespaces,
   findLocaleImpl,
 } from './core/operations.js'
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -23,6 +23,7 @@ import {
   findOrphanKeys,
   removeOrphanKeys,
   scaffoldLocaleFiles,
+  listNamespaces,
   findLocaleImpl,
 } from 'the-i18n-cli'
 
@@ -133,6 +134,41 @@ export function createServer(): McpServer {
         })
       } catch (error) {
         return toolErrorResponse('discovering i18n setup', error)
+      }
+    },
+  )
+
+  // ─── Tool: list_namespaces ─────────────────────────────────────
+
+  server.registerTool(
+    'list_namespaces',
+    {
+      title: 'List Namespaces',
+      description:
+        'List the translation key tree grouped by namespace prefix. '
+        + 'Returns a hierarchical view of all keys with counts per namespace node. '
+        + 'Use this to explore available keys without guessing path prefixes.',
+      inputSchema: {
+        layer: z
+          .string()
+          .optional()
+          .describe('Layer name to filter by (e.g., "root", "app-admin"). If omitted or "*", scans all layers. Call discover to discover available layers.'),
+        locale: z
+          .string()
+          .optional()
+          .describe('Locale to read keys from (e.g., "en"). Defaults to the project default locale. Keys are the same across locales — only one is needed.'),
+        projectDir: z
+          .string()
+          .optional()
+          .describe('Absolute path to the project root. Defaults to server cwd. Example: "/home/user/my-app".'),
+      },
+    },
+    async ({ layer, locale, projectDir }) => {
+      try {
+        const result = await listNamespaces({ layer, locale, projectDir })
+        return jsonContent(result)
+      } catch (error) {
+        return toolErrorResponse('listing namespaces', error)
       }
     },
   )


### PR DESCRIPTION
## Problem
No way to browse existing translation keys without guessing paths via `search_translations`. Agents waste round trips trying keys in wrong layers.

## Solution
New `list_namespaces` tool returns a hierarchical prefix tree of all translation keys grouped by layer and namespace:

```json
{
  "layers": {
    "root": {
      "namespaces": {
        "common": { "keyCount": 312 },
        "common.actions": { "keyCount": 14 },
        "components": { "keyCount": 230 }
      }
    }
  }
}
```

- Builds prefix tree from all leaf keys per layer
- Node counts propagate upward (parent = sum of children)
- Filter by layer or locale

## Files
- `packages/cli/src/core/operations.ts` — `listNamespaces()` + `propagateCounts()`
- `packages/cli/src/index.ts` — public API export
- `packages/mcp/src/server.ts` — tool registration + schema

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a namespace listing feature to explore translation key hierarchies per layer.
  * Optional filtering by layer and locale (and project directory) when listing namespaces.
  * Counts of keys are aggregated at each namespace level to show subtree sizes.
  * Accessible via the CLI and the MCP server tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->