### PR TITLE
feat: add Laravel JSON locale file support (#96)

### DIFF
--- a/packages/cli/src/adapters/laravel/index.ts
+++ b/packages/cli/src/adapters/laravel/index.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
@@ -16,12 +16,10 @@ export class LaravelAdapter implements FrameworkAdapter {
   async detect(projectDir: string): Promise<number> {
     let score = 0
 
-    // Strong signal: artisan file is the hallmark of a Laravel project
     if (existsSync(join(projectDir, 'artisan'))) {
       score += 2
     }
 
-    // Strong signal: composer.json with laravel/framework dependency
     try {
       const raw = await readFile(join(projectDir, 'composer.json'), 'utf-8')
       const composer = JSON.parse(raw) as Record<string, unknown>
@@ -34,13 +32,11 @@ export class LaravelAdapter implements FrameworkAdapter {
       // composer.json missing or malformed — skip
     }
 
-    // Weak signal: lang/ directory with locale subdirectories
+    // Weak signal: lang/ with PHP subdirectories or JSON files
     const langDir = findLangDir(projectDir)
     if (langDir) {
-      const localeSubdirs = await findLocaleSubdirs(langDir)
-      if (localeSubdirs.length > 0) {
-        score += 1
-      }
+      const hasLocaleFiles = await hasLocaleContent(langDir)
+      if (hasLocaleFiles) score += 1
     }
 
     return score
@@ -57,22 +53,26 @@ export class LaravelAdapter implements FrameworkAdapter {
       )
     }
 
-    const localeSubdirs = await findLocaleSubdirs(langDir)
-    if (localeSubdirs.length === 0) {
+    // Determine file format: honor override, auto-detect, or default
+    const format = resolveFormat(langDir, projectConfig?.localeFileFormat)
+
+    // Discover locale codes based on format
+    const localeCodes = await discoverLocaleCodes(langDir, format)
+    if (localeCodes.length === 0) {
       throw new ConfigError(
-        `No locale subdirectories found in ${langDir}. `
-        + 'Expected directories like lang/en/, lang/de/, etc.',
+        getFormatError(langDir, format),
       )
     }
 
     const { defaultLocale, fallbackLocale, configLocales } = await extractLocaleConfig(projectDir)
 
-    const allCodes = mergeLocaleCodes(localeSubdirs, configLocales)
+    const allCodes = mergeLocaleCodes(localeCodes, configLocales)
 
     const locales: LocaleDefinition[] = applyLocaleOverride(
       allCodes.map(code => ({
         code,
         language: code,
+        ...(format === 'json' ? { file: `${code}.json` } : {}),
       })),
       projectConfig?.locales,
     )
@@ -84,7 +84,7 @@ export class LaravelAdapter implements FrameworkAdapter {
     }]
 
     log.info(
-      `Discovered ${locales.length} locale(s) in ${langDir}: `
+      `Discovered ${locales.length} locale(s) in ${langDir} (${format}): `
       + `${allCodes.join(', ')}`,
     )
 
@@ -96,10 +96,84 @@ export class LaravelAdapter implements FrameworkAdapter {
       localeDirs,
       layerRootDirs: [projectDir],
       projectConfig: projectConfig ?? undefined,
-      localeFileFormat: 'php-array',
+      localeFileFormat: format,
       apps: [{ name: 'root', rootDir: projectDir, layers: ['root'] }],
     }
   }
+}
+
+// ─── Format detection ───────────────────────────────────────────
+
+function resolveFormat(
+  langDir: string,
+  override?: LocaleFileFormat,
+): LocaleFileFormat {
+  if (override) return override
+
+  const hasJson = existsSync(join(langDir, 'en.json'))
+    || existsSync(join(langDir, 'de.json'))
+    || existsSync(join(langDir, 'fr.json'))
+  const hasPhp = hasPhpSubdirsSync(langDir)
+
+  // When both exist, prefer php-array (backward compatible)
+  if (hasPhp) return 'php-array'
+  if (hasJson) return 'json'
+
+  return 'php-array' // default
+}
+
+function hasPhpSubdirsSync(langDir: string): boolean {
+  try {
+    const entries = readdirSync(langDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === 'vendor') continue
+      const subEntries = readdirSync(join(langDir, entry.name))
+      if (subEntries.some(f => f.endsWith('.php'))) return true
+    }
+  }
+  catch { /* can't read */ }
+  return false
+}
+
+function getFormatError(langDir: string, format: LocaleFileFormat): string {
+  if (format === 'json') {
+    return `No JSON locale files found in ${langDir}. Expected files like lang/en.json, lang/de.json.`
+  }
+  return `No locale subdirectories found in ${langDir}. Expected directories like lang/en/, lang/de/.`
+}
+
+// ─── Locale discovery ───────────────────────────────────────────
+
+async function hasLocaleContent(langDir: string): Promise<boolean> {
+  // Check for JSON files (flat layout)
+  const entries = await readdir(langDir).catch(() => [] as string[])
+  if (entries.some(f => f.endsWith('.json'))) return true
+
+  // Check for PHP subdirectories (namespaced layout)
+  return hasPhpContent(langDir)
+}
+
+async function discoverLocaleCodes(
+  langDir: string,
+  format: LocaleFileFormat,
+): Promise<string[]> {
+  if (format === 'json') {
+    return discoverJsonLocales(langDir)
+  }
+  return findLocaleSubdirs(langDir)
+}
+
+async function discoverJsonLocales(langDir: string): Promise<string[]> {
+  const entries = await readdir(langDir).catch(() => [] as string[])
+  return entries
+    .filter(f => f.endsWith('.json'))
+    .map(f => f.replace(/\.json$/, ''))
+    .sort()
+}
+
+async function hasPhpContent(langDir: string): Promise<boolean> {
+  const subdirs = await findLocaleSubdirs(langDir)
+  return subdirs.length > 0
 }
 
 /**
@@ -139,12 +213,10 @@ async function findLocaleSubdirs(langDir: string): Promise<string[]> {
   return locales.sort()
 }
 
+// ─── Config parsing ─────────────────────────────────────────────
+
 /**
  * Extract default and fallback locale from config/app.php.
- * Uses regex to handle patterns like:
- *   'locale' => 'en',
- *   'locale' => env('APP_LOCALE', 'en'),
- *   'fallback_locale' => 'en',
  */
 async function extractLocaleConfig(projectDir: string): Promise<{
   defaultLocale: string
@@ -179,15 +251,7 @@ async function extractLocaleConfig(projectDir: string): Promise<{
   }
 }
 
-/**
- * Extract a string config value from a PHP config file.
- * Handles both direct string values and env() calls with defaults:
- *   'key' => 'value',
- *   'key' => env('ENV_VAR', 'default'),
- *   "key" => "value",
- */
 function extractPhpConfigValue(content: string, key: string): string | null {
-  // Match: 'key' => env('...', 'default')  or  "key" => env("...", "default")
   const envPattern = new RegExp(
     `['"]${key}['"]\\s*=>\\s*env\\s*\\(\\s*['"][^'"]*['"]\\s*,\\s*['"]([^'"]+)['"]\\s*\\)`,
   )
@@ -196,7 +260,6 @@ function extractPhpConfigValue(content: string, key: string): string | null {
     return envMatch[1]
   }
 
-  // Match: 'key' => 'value'  or  "key" => "value"
   const directPattern = new RegExp(
     `['"]${key}['"]\\s*=>\\s*['"]([^'"]+)['"]`,
   )

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
+import type { LocaleFileFormat } from '../adapters/types'
 import type { ProjectConfig } from './types.js'
 import { ConfigError } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
@@ -73,6 +74,7 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     '$schema', 'framework', 'context', 'layerRules', 'glossary',
     'translationPrompt', 'localeNotes', 'examples', 'orphanScan',
     'reportOutput', 'samplingPreferences', 'localeDirs', 'defaultLocale', 'locales',
+    'localeFileFormat',
   ])
   for (const key of Object.keys(config)) {
     if (!knownKeys.has(key)) {
@@ -260,5 +262,6 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     localeDirs: config.localeDirs as ProjectConfig['localeDirs'],
     defaultLocale: config.defaultLocale as string | undefined,
     locales: config.locales as string[] | undefined,
+    localeFileFormat: config.localeFileFormat as LocaleFileFormat | undefined,
   }
 }

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -73,6 +73,8 @@ export interface ProjectConfig {
   defaultLocale?: string
   /** Explicit list of locale codes. If set, overrides framework auto-detection (all adapters). Auto-discovered when absent. */
   locales?: string[]
+  /** Override the auto-detected locale file format. E.g., "json" or "php-array". Useful when both formats exist or auto-detection picks wrong. */
+  localeFileFormat?: LocaleFileFormat
   /** Model preferences for `translate_missing` sampling requests. Overrides the built-in defaults (fast/cheap model bias). */
   samplingPreferences?: {
     /** Ordered model name hints (substring match). First match wins. E.g., ["flash", "haiku"] */

--- a/packages/cli/tests/adapters/laravel-adapter.test.ts
+++ b/packages/cli/tests/adapters/laravel-adapter.test.ts
@@ -307,6 +307,86 @@ describe('LaravelAdapter.resolve', () => {
   })
 })
 
+describe('Laravel JSON locale files', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `laravel-json-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function createJsonProject() {
+    writeFileSync(join(tempDir, 'artisan'), '#!/usr/bin/env php')
+    writeFileSync(join(tempDir, 'composer.json'), JSON.stringify({
+      require: { 'laravel/framework': '^11.0' },
+    }))
+    mkdirSync(join(tempDir, 'lang'), { recursive: true })
+    writeFileSync(join(tempDir, 'lang', 'en.json'), JSON.stringify({ greeting: 'Hello' }))
+    writeFileSync(join(tempDir, 'lang', 'de.json'), JSON.stringify({ greeting: 'Hallo' }))
+  }
+
+  it('detect scores for JSON locale files', async () => {
+    createJsonProject()
+    const adapter = new LaravelAdapter()
+    // artisan (2) + composer (2) + hasLocaleContent (1) = 5
+    expect(await adapter.detect(tempDir)).toBe(5)
+  })
+
+  it('resolve detects JSON format and discovers locales', async () => {
+    createJsonProject()
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeFileFormat).toBe('json')
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+    expect(config.locales[0].file).toBe('de.json')
+    expect(config.localeDirs[0].path).toBe(join(tempDir, 'lang'))
+  })
+
+  it('resolve prefers php-array when both formats exist', async () => {
+    createJsonProject()
+    // Also add PHP subdirectory files
+    const enDir = join(tempDir, 'lang', 'en')
+    mkdirSync(enDir, { recursive: true })
+    writeFileSync(join(enDir, 'auth.php'), '<?php return [];')
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeFileFormat).toBe('php-array')
+  })
+
+  it('resolve honors localeFileFormat override from .i18n-mcp.json', async () => {
+    createJsonProject()
+    // Add PHP subdirectory to trigger php-array auto-detection
+    const enDir = join(tempDir, 'lang', 'en')
+    mkdirSync(enDir, { recursive: true })
+    writeFileSync(join(enDir, 'auth.php'), '<?php return [];')
+
+    writeFileSync(
+      join(tempDir, '.i18n-mcp.json'),
+      JSON.stringify({ localeFileFormat: 'json' }),
+    )
+
+    const adapter = new LaravelAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.localeFileFormat).toBe('json')
+  })
+
+  it('throws ConfigError when lang/ has no locale content', async () => {
+    writeFileSync(join(tempDir, 'artisan'), '#!/usr/bin/env php')
+    mkdirSync(join(tempDir, 'lang'))
+
+    const adapter = new LaravelAdapter()
+    await expect(adapter.resolve(tempDir)).rejects.toThrow('No locale')
+  })
+})
+
 describe('Adapter registry: Laravel vs Nuxt', () => {
   beforeEach(() => {
     resetRegistry()


### PR DESCRIPTION
## Problem
The Laravel adapter hardcodes `localeFileFormat: 'php-array'`. Laravel has supported JSON locale files (`lang/en.json`) since v5.4, and the official docs recommend this approach for apps with many translatable strings. Without JSON support, the tool is incomplete for a significant portion of the Laravel ecosystem.

## Changes
- **Auto-detect format**: scans `lang/` for `.json` files vs subdirectories with `.php` files
- **Backward compatible**: when both formats exist, `php-array` wins (existing behavior)
- **Override support**: `localeFileFormat` key in `.i18n-mcp.json` forces a specific format
- **JSON layout**: locale codes from `lang/en.json` → `en` (flat file, no namespaces)

### Config layer changes
- Add `localeFileFormat` to `ProjectConfig` type
- Add to `knownKeys` set in config validation
- Add to `loadProjectConfig()` return object

### Adapter changes
- `detect()`: score for JSON files too (via `hasLocaleContent()`)
- `resolve()`: detect format, discover JSON locale codes, set `localeFileFormat` dynamically
- New helpers: `resolveFormat()`, `discoverJsonLocales()`, `hasPhpSubdirsSync()`

## Files
- `packages/cli/src/adapters/laravel/index.ts` — main change
- `packages/cli/src/config/project-config.ts` — config plumbing
- `packages/cli/src/config/types.ts` — type definition
- `packages/cli/tests/adapters/laravel-adapter.test.ts` — 5 new tests

Closes #96