### PR TITLE
feat(cli): replace custom logger with consola, manual config validation with zod

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,15 +44,17 @@
   },
   "dependencies": {
     "citty": "^0.2.2",
+    "consola": "^3.4.2",
     "dependency-graph": "^1.0.0",
     "php-array-reader": "^2.1.3",
-    "tinyglobby": "^0.2.15"
+    "tinyglobby": "^0.2.15",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@nuxt/kit": "^3.0.0 || ^4.0.0",
-    "openai": "^4.0.0 || ^5.0.0",
     "@anthropic-ai/sdk": "^0.30.0",
-    "@google/genai": "^2.0.0"
+    "@google/genai": "^2.0.0",
+    "@nuxt/kit": "^3.0.0 || ^4.0.0",
+    "openai": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,11 +35,7 @@ export async function runCli(): Promise<void> {
   try {
     await runCommand(main, { rawArgs })
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error)
-    log.error(message)
-    if (rawArgs.includes('--debug') && error instanceof Error && error.stack) {
-      log.error(error.stack)
-    }
+    log.error(error)
     process.exitCode = 1
   }
 }

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -1,12 +1,57 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
-import type { LocaleFileFormat } from '../adapters/types'
+import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
 import { ConfigError } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
 const CONFIG_FILENAME = '.i18n-mcp.json'
+
+// ─── Zod schema ─────────────────────────────────────────────────
+
+const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
+
+const layerRuleSchema = z.object({
+  layer: z.string(),
+  description: z.string(),
+  when: z.string(),
+})
+
+const localeDirEntrySchema = z.union([
+  nonEmptyString,
+  z.object({
+    path: nonEmptyString,
+    layer: nonEmptyString,
+  }),
+])
+
+const projectConfigSchema = z.object({
+  $schema: z.string().optional(),
+  framework: z.string().optional(),
+  context: z.string().optional(),
+  layerRules: z.array(layerRuleSchema).optional(),
+  glossary: z.record(z.string(), z.string()).optional(),
+  translationPrompt: z.string().optional(),
+  localeNotes: z.record(z.string(), z.string()).optional(),
+  examples: z.array(z.record(z.string(), z.string())).optional(),
+  orphanScan: z.record(z.string(), z.object({
+    ignorePatterns: z.array(z.string()).optional(),
+  }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
+  localeDirs: z.array(localeDirEntrySchema).optional(),
+  defaultLocale: z.string().optional(),
+  locales: z.array(z.string()).optional(),
+  reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
+  localeFileFormat: z.enum(['json', 'php-array']).optional(),
+  samplingPreferences: z.object({
+    hints: z.array(z.string()).optional(),
+    costPriority: z.number().optional(),
+    speedPriority: z.number().optional(),
+    intelligencePriority: z.number().optional(),
+  }).optional(),
+}).strict()
+
+// ─── Config file discovery ──────────────────────────────────────
 
 /**
  * Walk up the directory tree from `startDir` to find the nearest config file.
@@ -63,205 +108,19 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     )
   }
 
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new ConfigError(`${CONFIG_FILENAME} must contain a JSON object at the root level`)
-  }
+  const result = projectConfigSchema.safeParse(parsed)
 
-  const config = parsed as Record<string, unknown>
-
-  // Reject unknown top-level keys (matches schema additionalProperties: false)
-  const knownKeys = new Set([
-    '$schema', 'framework', 'context', 'layerRules', 'glossary',
-    'translationPrompt', 'localeNotes', 'examples', 'orphanScan',
-    'reportOutput', 'samplingPreferences', 'localeDirs', 'defaultLocale', 'locales',
-    'localeFileFormat',
-  ])
-  for (const key of Object.keys(config)) {
-    if (!knownKeys.has(key)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: unknown property "${key}". Allowed: ${[...knownKeys].filter(k => k !== '$schema').join(', ')}`)
-    }
-  }
-
-  if ('framework' in config && typeof config.framework !== 'string') {
-    throw new ConfigError(`${CONFIG_FILENAME}: "framework" must be a string`)
-  }
-
-  if ('context' in config && typeof config.context !== 'string') {
-    throw new ConfigError(`${CONFIG_FILENAME}: "context" must be a string`)
-  }
-
-  // Validate layerRules
-  if ('layerRules' in config) {
-    if (!Array.isArray(config.layerRules)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "layerRules" must be an array`)
-    }
-    for (let i = 0; i < config.layerRules.length; i++) {
-      const rule = config.layerRules[i]
-      if (typeof rule !== 'object' || rule === null || Array.isArray(rule)) {
-        throw new ConfigError(`${CONFIG_FILENAME}: "layerRules[${i}]" must be an object`)
-      }
-      const ruleObj = rule as Record<string, unknown>
-      if (typeof ruleObj.layer !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "layerRules[${i}].layer" must be a string`)
-      }
-      if (typeof ruleObj.description !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "layerRules[${i}].description" must be a string`)
-      }
-      if (typeof ruleObj.when !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "layerRules[${i}].when" must be a string`)
-      }
-    }
-  }
-
-  // Validate glossary
-  if ('glossary' in config) {
-    if (typeof config.glossary !== 'object' || config.glossary === null || Array.isArray(config.glossary)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "glossary" must be an object (Record<string, string>)`)
-    }
-    const glossary = config.glossary as Record<string, unknown>
-    for (const [key, value] of Object.entries(glossary)) {
-      if (typeof value !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "glossary.${key}" must be a string`)
-      }
-    }
-  }
-
-  // Validate translationPrompt
-  if ('translationPrompt' in config && typeof config.translationPrompt !== 'string') {
-    throw new ConfigError(`${CONFIG_FILENAME}: "translationPrompt" must be a string`)
-  }
-
-  // Validate localeNotes
-  if ('localeNotes' in config) {
-    if (typeof config.localeNotes !== 'object' || config.localeNotes === null || Array.isArray(config.localeNotes)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "localeNotes" must be an object (Record<string, string>)`)
-    }
-    const localeNotes = config.localeNotes as Record<string, unknown>
-    for (const [key, value] of Object.entries(localeNotes)) {
-      if (typeof value !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "localeNotes.${key}" must be a string`)
-      }
-    }
-  }
-
-  // Validate examples
-  if ('examples' in config) {
-    if (!Array.isArray(config.examples)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "examples" must be an array`)
-    }
-    for (let i = 0; i < config.examples.length; i++) {
-      const example = config.examples[i]
-      if (typeof example !== 'object' || example === null || Array.isArray(example)) {
-        throw new ConfigError(`${CONFIG_FILENAME}: "examples[${i}]" must be an object`)
-      }
-      const exampleObj = example as Record<string, unknown>
-      for (const [key, value] of Object.entries(exampleObj)) {
-        if (typeof value !== 'string') {
-          throw new ConfigError(`${CONFIG_FILENAME}: "examples[${i}].${key}" must be a string`)
-        }
-      }
-    }
-  }
-
-  // Validate orphanScan
-  if ('orphanScan' in config) {
-    if (typeof config.orphanScan !== 'object' || config.orphanScan === null || Array.isArray(config.orphanScan)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan" must be an object`)
-    }
-    const orphanScan = config.orphanScan as Record<string, unknown>
-    for (const [layerName, layerConfig] of Object.entries(orphanScan)) {
-      if (typeof layerConfig !== 'object' || layerConfig === null || Array.isArray(layerConfig)) {
-        throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" must be an object`)
-      }
-      const layerObj = layerConfig as Record<string, unknown>
-      const knownLayerKeys = new Set(['ignorePatterns'])
-      const deprecatedLayerKeys = new Set(['includeParentLayer'])
-      for (const k of Object.keys(layerObj)) {
-        if (deprecatedLayerKeys.has(k)) {
-          continue // silently ignore removed options for backwards compatibility
-        }
-        if (!knownLayerKeys.has(k)) {
-          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}" has unknown property "${k}". Allowed: ignorePatterns`)
-        }
-      }
-      if ('ignorePatterns' in layerObj) {
-        if (!Array.isArray(layerObj.ignorePatterns)) {
-          throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns" must be an array of strings`)
-        }
-        for (let i = 0; i < layerObj.ignorePatterns.length; i++) {
-          if (typeof layerObj.ignorePatterns[i] !== 'string') {
-            throw new ConfigError(`${CONFIG_FILENAME}: "orphanScan.${layerName}.ignorePatterns[${i}]" must be a string`)
-          }
-        }
-      }
-    }
-  }
-
-  // Validate localeDirs
-  if ('localeDirs' in config) {
-    if (!Array.isArray(config.localeDirs)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs" must be an array`)
-    }
-    for (let i = 0; i < config.localeDirs.length; i++) {
-      const entry = config.localeDirs[i]
-      if (typeof entry === 'string') {
-        if (entry.trim() === '') {
-          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}]" must be a non-empty string`)
-        }
-      } else if (typeof entry === 'object' && entry !== null && !Array.isArray(entry)) {
-        const obj = entry as Record<string, unknown>
-        if (typeof obj.path !== 'string' || obj.path.trim() === '') {
-          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}].path" must be a non-empty string`)
-        }
-        if (typeof obj.layer !== 'string' || obj.layer.trim() === '') {
-          throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}].layer" must be a non-empty string`)
-        }
-      } else {
-        throw new ConfigError(`${CONFIG_FILENAME}: "localeDirs[${i}]" must be a string or { path, layer } object`)
-      }
-    }
-  }
-
-  // Validate defaultLocale
-  if ('defaultLocale' in config && typeof config.defaultLocale !== 'string') {
-    throw new ConfigError(`${CONFIG_FILENAME}: "defaultLocale" must be a string`)
-  }
-
-  // Validate locales
-  if ('locales' in config) {
-    if (!Array.isArray(config.locales)) {
-      throw new ConfigError(`${CONFIG_FILENAME}: "locales" must be an array of strings`)
-    }
-    for (let i = 0; i < config.locales.length; i++) {
-      if (typeof config.locales[i] !== 'string') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "locales[${i}]" must be a string`)
-      }
-    }
-  }
-
-  if ('reportOutput' in config) {
-    if (config.reportOutput !== true) {
-      if (typeof config.reportOutput !== 'string' || config.reportOutput.trim() === '') {
-        throw new ConfigError(`${CONFIG_FILENAME}: "reportOutput" must be a non-empty string (directory path) or true`)
-      }
-    }
+  if (!result.success) {
+    const messages = result.error.issues
+      .map(issue => {
+        const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+        return `  ${path}: ${issue.message}`
+      })
+      .join('\n')
+    throw new ConfigError(`Invalid ${CONFIG_FILENAME}:\n${messages}`)
   }
 
   log.debug(`Project config loaded successfully from ${configPath}`)
 
-  return {
-    framework: config.framework as string | undefined,
-    context: config.context as string | undefined,
-    layerRules: config.layerRules as ProjectConfig['layerRules'],
-    glossary: config.glossary as Record<string, string> | undefined,
-    translationPrompt: config.translationPrompt as string | undefined,
-    localeNotes: config.localeNotes as Record<string, string> | undefined,
-    examples: config.examples as Array<Record<string, string>> | undefined,
-    orphanScan: config.orphanScan as ProjectConfig['orphanScan'],
-    reportOutput: config.reportOutput as string | boolean | undefined,
-    localeDirs: config.localeDirs as ProjectConfig['localeDirs'],
-    defaultLocale: config.defaultLocale as string | undefined,
-    locales: config.locales as string[] | undefined,
-    localeFileFormat: config.localeFileFormat as LocaleFileFormat | undefined,
-  }
+  return result.data as ProjectConfig
 }

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -1,22 +1,3 @@
-const PREFIX = '[the-i18n-cli]'
+import { consola } from 'consola'
 
-function formatMessage(level: string, message: string): string {
-  return `${PREFIX} [${level}] ${message}`
-}
-
-export const log = {
-  info(message: string, ...args: unknown[]) {
-    console.error(formatMessage('info', message), ...args)
-  },
-  warn(message: string, ...args: unknown[]) {
-    console.error(formatMessage('warn', message), ...args)
-  },
-  error(message: string, ...args: unknown[]) {
-    console.error(formatMessage('error', message), ...args)
-  },
-  debug(message: string, ...args: unknown[]) {
-    if (process.env.DEBUG) {
-      console.error(formatMessage('debug', message), ...args)
-    }
-  },
-}
+export const log = consola.withTag('the-i18n-cli')

--- a/packages/cli/tests/config/project-config.test.ts
+++ b/packages/cli/tests/config/project-config.test.ts
@@ -134,7 +134,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ orphanScan: 'invalid' }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan" must be an object')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/orphanScan/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -169,7 +169,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ orphanScan: { root: 'invalid' } }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root" must be an object')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/orphanScan/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -241,7 +241,7 @@ describe('loadProjectConfig', () => {
       await writeFile(configPath, JSON.stringify({
         orphanScan: { root: { ignorePatterns: 'not-an-array' } }
       }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns" must be an array of strings')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/orphanScan|ignorePatterns/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -252,7 +252,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ reportOutput: false }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"reportOutput" must be a non-empty string (directory path) or true')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/reportOutput/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -265,7 +265,7 @@ describe('loadProjectConfig', () => {
       await writeFile(configPath, JSON.stringify({
         orphanScan: { root: { ignorePatterns: ['valid.*', 123] } }
       }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"orphanScan.root.ignorePatterns[1]" must be a string')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/orphanScan|ignorePatterns/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -276,7 +276,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ reportOutput: 42 }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"reportOutput" must be a non-empty string (directory path) or true')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/reportOutput/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -287,7 +287,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ reportOutput: '' }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"reportOutput" must be a non-empty string (directory path) or true')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/reportOutput/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }
@@ -298,7 +298,7 @@ describe('loadProjectConfig', () => {
     const configPath = resolve(tmpDir, '.i18n-mcp.json')
     try {
       await writeFile(configPath, JSON.stringify({ reportOutput: '   ' }), 'utf-8')
-      await expect(loadProjectConfig(tmpDir)).rejects.toThrow('"reportOutput" must be a non-empty string (directory path) or true')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/reportOutput/)
     } finally {
       if (existsSync(configPath)) await unlink(configPath)
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       citty:
         specifier: ^0.2.2
         version: 0.2.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       dependency-graph:
         specifier: ^1.0.0
         version: 1.0.0
@@ -53,6 +56,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@nuxt/kit':
         specifier: ^4.4.2


### PR DESCRIPTION
## PR A: Foundation — Logging & Config

Closes #170

### Changes

1. **Custom logger → consola**  
   `utils/logger.ts`: 22-line custom implementation replaced by `consola.withTag("the-i18n-cli")`  
   All 50+ call sites (`log.info/warn/error/debug`) keep the same API unchanged.

2. **Manual config validation → zod**  
   `config/project-config.ts`: ~170 lines of `typeof`/`Array.isArray` manual checks replaced by a single `z.object({...}).strict().safeParse(parsed)`  
   zod is already a dependency of the MCP package — no new ecosystem dep.

3. **CLI error handling simplified**  
   `cli.ts`: consola handles error formatting, stack traces, and debug mode via `DEBUG` env var natively.

### Not included (validated out)
- **c12**: Config walk-up (`findConfigFile`) is 12 lines — not worth a new dependency for 12 lines.
- **defu**: `resolveSamplingPreferences` has a type mismatch (user hints are `string[]`, defaults are `{name: string}[]`). Current `??` pattern is already clean at 4 lines.

### Stats
- **Net: -156 lines** (+84, -240)
- All 579 tests pass
- Build + typecheck clean