### PR TITLE
refactor(cli): extract atomicWrite, toErrorMessage, use sort-keys

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,217 @@
+name: 'the-i18n-kit — Auto-Translate Missing Keys'
+description: 'Find missing translation keys and translate them via LLM. Provider-agnostic: supports OpenAI, Anthropic, and Google.'
+author: 'Fabian Kirchhoff'
+
+branding:
+  icon: 'globe'
+  color: 'green'
+
+inputs:
+  provider:
+    description: 'LLM provider: openai, anthropic, or google'
+    required: true
+  model:
+    description: 'Model name (e.g. gpt-4o, claude-3-5-sonnet-20241022, gemini-2.0-flash)'
+    required: true
+  api_key:
+    description: 'API key for the chosen provider'
+    required: true
+  layer:
+    description: 'Layer name to translate (e.g. common, dashboard)'
+    required: true
+  locales:
+    description: 'Comma-separated target locales (default: all except source)'
+    required: false
+  source_locale:
+    description: 'Reference/source locale (default: project default from .i18n-mcp.json)'
+    required: false
+  keys:
+    description: 'Comma-separated keys to translate (default: all missing)'
+    required: false
+  batch_size:
+    description: 'Keys per LLM call (default: 50)'
+    required: false
+    default: '50'
+  dry_run:
+    description: 'Preview translations without writing files'
+    required: false
+    default: 'false'
+  working_directory:
+    description: 'Project root directory (default: github.workspace)'
+    required: false
+    default: ${{ github.workspace }}
+  create_pr:
+    description: 'Create a PR with the translated files'
+    required: false
+    default: 'true'
+  pr_branch:
+    description: 'Branch name for the PR (default: i18n/translate-missing-<timestamp>)'
+    required: false
+  commit_message:
+    description: 'Commit message (default: "chore(i18n): translate missing keys via <provider>")'
+    required: false
+  pr_title:
+    description: 'PR title (default: "chore(i18n): translate missing keys")'
+    required: false
+  github_token:
+    description: 'GitHub token for creating PRs. Defaults to GITHUB_TOKEN.'
+    required: false
+    default: ${{ github.token }}
+  base_branch:
+    description: 'Base branch for the PR (default: the branch that triggered the workflow)'
+    required: false
+
+outputs:
+  translated_count:
+    description: 'Number of keys translated'
+    value: ${{ steps.translate.outputs.translated_count }}
+  pr_url:
+    description: 'URL of the created PR (only when create_pr is true)'
+    value: ${{ steps.create-pr.outputs.pr_url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Install the-i18n-cli
+      shell: bash
+      run: npm install -g the-i18n-cli@latest
+
+    - name: Detect i18n config
+      id: detect
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: the-i18n-cli detect
+
+    - name: Translate missing keys
+      id: translate
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        I18N_API_KEY: ${{ inputs.api_key }}
+        I18N_PROVIDER: ${{ inputs.provider }}
+      run: |
+        set -euo pipefail
+
+        # Route API key to the provider-specific env var
+        case "$I18N_PROVIDER" in
+          openai)   export OPENAI_API_KEY="$I18N_API_KEY" ;;
+          anthropic) export ANTHROPIC_API_KEY="$I18N_API_KEY" ;;
+          google)   export GEMINI_API_KEY="$I18N_API_KEY" ;;
+          *)        echo "::error::Unknown provider: $I18N_PROVIDER"; exit 1 ;;
+        esac
+
+        args=(
+          --provider "${{ inputs.provider }}"
+          --model "${{ inputs.model }}"
+          --layer "${{ inputs.layer }}"
+          --batch-size "${{ inputs.batch_size }}"
+          --json
+        )
+
+        if [ -n "${{ inputs.locales }}" ]; then
+          args+=(--targets "${{ inputs.locales }}")
+        fi
+        if [ -n "${{ inputs.source_locale }}" ]; then
+          args+=(--ref "${{ inputs.source_locale }}")
+        fi
+        if [ -n "${{ inputs.keys }}" ]; then
+          args+=(--keys "${{ inputs.keys }}")
+        fi
+        if [ "${{ inputs.dry_run }}" = "true" ]; then
+          args+=(--dry-run)
+        fi
+
+        output=$(the-i18n-cli translate "${args[@]}")
+
+        # Extract translated count from JSON output
+        count=$(echo "$output" | jq -r '.translated // .totalTranslated // 0')
+        echo "translated_count=$count" >> "$GITHUB_OUTPUT"
+
+        echo "$output"
+
+    - name: Create PR with translations
+      id: create-pr
+      if: inputs.dry_run == 'false' && inputs.create_pr == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        BASE_BRANCH: ${{ inputs.base_branch }}
+        PR_BRANCH: ${{ inputs.pr_branch }}
+        COMMIT_MSG: ${{ inputs.commit_message }}
+        PR_TITLE: ${{ inputs.pr_title }}
+        PROVIDER: ${{ inputs.provider }}
+        LAYER: ${{ inputs.layer }}
+      run: |
+        set -euo pipefail
+
+        # Determine base branch
+        if [ -z "${BASE_BRANCH:-}" ]; then
+          BASE="${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
+        else
+          BASE="$BASE_BRANCH"
+        fi
+
+        # Branch name
+        if [ -z "${PR_BRANCH:-}" ]; then
+          TS=$(date +%s)
+          BRANCH="i18n/translate-missing-${TS}"
+        else
+          BRANCH="$PR_BRANCH"
+        fi
+
+        # Commit message
+        if [ -z "${COMMIT_MSG:-}" ]; then
+          MSG="chore(i18n): translate missing keys via ${PROVIDER}"
+        else
+          MSG="$COMMIT_MSG"
+        fi
+
+        # PR title
+        if [ -z "${PR_TITLE:-}" ]; then
+          TITLE="chore(i18n): translate missing keys (${LAYER})"
+        else
+          TITLE="$PR_TITLE"
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        # Check if there are changes
+        if git diff --quiet && git diff --cached --quiet; then
+          echo "No translation changes to commit"
+          echo "pr_url=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git checkout -b "$BRANCH"
+        git add .
+        git commit -m "$MSG"
+        git push origin "$BRANCH"
+
+        PR_URL=$(gh pr create \
+          --base "$BASE" \
+          --head "$BRANCH" \
+          --title "$TITLE" \
+          --body "Automated translation of missing i18n keys in layer \`${LAYER}\` using \`${PROVIDER}\`.
+
+        | | |
+        |---|---|
+        | Provider | ${PROVIDER} |
+        | Model | ${{ inputs.model }} |
+        | Layer | ${LAYER} |
+        | Keys translated | ${{ steps.translate.outputs.translated_count }} |")
+
+        echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+        echo "Created PR: $PR_URL"
+
+    - name: Dry run summary
+      if: inputs.dry_run == 'true'
+      shell: bash
+      run: |
+        echo "::notice::Dry run complete. ${{ steps.translate.outputs.translated_count }} keys would be translated."

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -1,0 +1,139 @@
+# the-i18n-kit — Auto-Translate Missing Keys (GitLab CI template)
+#
+# Usage in your .gitlab-ci.yml:
+#
+#   include:
+#     - remote: 'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/gitlab-ci.yml'
+#
+#   i18n-translate:
+#     extends: .i18n-translate
+#     variables:
+#       I18N_PROVIDER: google
+#       I18N_MODEL: gemini-2.0-flash
+#       I18N_LAYER: common
+#     rules:
+#       - if: $CI_PIPELINE_SOURCE == "schedule"  # e.g. nightly
+#       - when: manual                            # or manual trigger
+
+.i18n-translate:
+  image: node:22-alpine
+  stage: translate
+  variables:
+    # Required — no defaults, you must set these
+    I18N_PROVIDER: ""       # openai | anthropic | google
+    I18N_MODEL: ""          # e.g. gpt-4o, claude-3-5-sonnet-20241022, gemini-2.0-flash
+    I18N_API_KEY: ""        # API key for the chosen provider
+    I18N_LAYER: ""          # e.g. common, dashboard
+
+    # Optional
+    I18N_LOCALES: ""        # comma-separated target locales (default: all except source)
+    I18N_SOURCE_LOCALE: ""  # reference locale (default: from .i18n-mcp.json)
+    I18N_KEYS: ""           # comma-separated keys (default: all missing)
+    I18N_BATCH_SIZE: "50"   # keys per LLM call
+    I18N_DRY_RUN: "false"   # preview without writing files
+    I18N_CREATE_MR: "true"  # auto-create MR with translated files
+    I18N_MR_TARGET_BRANCH: ""  # MR target (default: repo default branch)
+    I18N_GITLAB_TOKEN: ""     # GitLab API token for MR creation (required when I18N_CREATE_MR is true). Must have api + write_repository scopes.
+
+  before_script:
+    - npm install -g the-i18n-cli@latest
+    - the-i18n-cli detect
+
+  script:
+    - |
+      set -euo pipefail
+
+      # Route API key to provider-specific env var
+      case "$I18N_PROVIDER" in
+        openai)    export OPENAI_API_KEY="$I18N_API_KEY" ;;
+        anthropic) export ANTHROPIC_API_KEY="$I18N_API_KEY" ;;
+        google)    export GEMINI_API_KEY="$I18N_API_KEY" ;;
+        *)
+          echo "ERROR: Unknown provider: $I18N_PROVIDER"
+          echo "Must be one of: openai, anthropic, google"
+          exit 1
+          ;;
+      esac
+
+      if [ -z "$I18N_PROVIDER" ] || [ -z "$I18N_MODEL" ] || [ -z "$I18N_API_KEY" ] || [ -z "$I18N_LAYER" ]; then
+        echo "ERROR: I18N_PROVIDER, I18N_MODEL, I18N_API_KEY, and I18N_LAYER are required"
+        exit 1
+      fi
+
+      args=(
+        --provider "$I18N_PROVIDER"
+        --model "$I18N_MODEL"
+        --layer "$I18N_LAYER"
+        --batch-size "$I18N_BATCH_SIZE"
+        --json
+      )
+
+      [ -n "$I18N_LOCALES" ]      && args+=(--targets "$I18N_LOCALES")
+      [ -n "$I18N_SOURCE_LOCALE" ] && args+=(--ref "$I18N_SOURCE_LOCALE")
+      [ -n "$I18N_KEYS" ]         && args+=(--keys "$I18N_KEYS")
+      [ "$I18N_DRY_RUN" = "true" ] && args+=(--dry-run)
+
+      the-i18n-cli translate "${args[@]}"
+
+  after_script:
+    - |
+      set -euo pipefail
+
+      if [ "$I18N_DRY_RUN" = "true" ]; then
+        echo "Dry run complete. No files written."
+        exit 0
+      fi
+
+      if [ "$I18N_CREATE_MR" != "true" ]; then
+        echo "create_mr is false. Translated files are in the working tree but not committed."
+        exit 0
+      fi
+
+      # Check if there are changes
+      if git diff --quiet && git diff --cached --quiet; then
+        echo "No translation changes to commit."
+        exit 0
+      fi
+
+      # Configure git
+      git config user.name "gitlab-ci[bot]"
+      git config user.email "gitlab-ci[bot]@gitlab.com"
+
+      # Create branch and commit
+      BRANCH="i18n/translate-missing-$(date +%s)"
+      git checkout -b "$BRANCH"
+      git add .
+      git commit -m "chore(i18n): translate missing keys ($I18N_LAYER) via $I18N_PROVIDER"
+
+      # Push using CI_JOB_TOKEN for authentication
+      PUSH_URL="https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+      git push "$PUSH_URL" "$BRANCH" -o ci.skip
+
+      # Determine MR target branch
+      if [ -n "$I18N_MR_TARGET_BRANCH" ]; then
+        TARGET="$I18N_MR_TARGET_BRANCH"
+      else
+        TARGET="$CI_DEFAULT_BRANCH"
+      fi
+
+      # Create MR via GitLab API
+      MR_RESPONSE=$(curl --silent --request POST \
+        --header "PRIVATE-TOKEN: $I18N_GITLAB_TOKEN" \
+        --header "Content-Type: application/json" \
+        --data "{
+          \"source_branch\": \"$BRANCH\",
+          \"target_branch\": \"$TARGET\",
+          \"title\": \"chore(i18n): translate missing keys ($I18N_LAYER)\",
+          \"description\": \"Automated translation of missing i18n keys in layer \`$I18N_LAYER\` using \`$I18N_PROVIDER\` ($I18N_MODEL).\",
+          \"remove_source_branch\": true
+        }" \
+        "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests")
+
+      MR_URL=$(echo "$MR_RESPONSE" | jq -r '.web_url // empty')
+      if [ -n "$MR_URL" ]; then
+        echo "Created MR: $MR_URL"
+      else
+        echo "ERROR: Failed to create MR"
+        echo "$MR_RESPONSE"
+        exit 1
+      fi

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "consola": "^3.4.2",
     "dependency-graph": "^1.0.0",
     "php-array-reader": "^2.1.3",
+    "sort-keys": "^6.0.0",
     "tinyglobby": "^0.2.15",
     "zod": "^4.3.6"
   },

--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -8,7 +8,7 @@ import { loadKit } from '../../config/nuxt-loader'
 import { loadProjectConfig } from '../../config/project-config'
 import { applyLocaleOverride } from '../../config/locale-override'
 import { log } from '../../utils/logger'
-import { ConfigError } from '../../utils/errors'
+import { ConfigError, toErrorMessage } from '../../utils/errors'
 import { resolveLayerOwnership } from './layer-dedup'
 
 export class NuxtAdapter implements FrameworkAdapter {
@@ -132,7 +132,7 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
       appConfig = await loadSingleApp(appDir, discoveryRoot)
     }
     catch (error) {
-      log.warn(`Failed to load app at ${appDir}: ${error instanceof Error ? error.message : String(error)}`)
+      log.warn(`Failed to load app at ${appDir}: ${toErrorMessage(error)}`)
       continue
     }
 

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -1,5 +1,5 @@
 import type { FrameworkAdapter } from './types'
-import { ConfigError } from '../utils/errors'
+import { ConfigError, toErrorMessage } from '../utils/errors'
 import { log } from '../utils/logger'
 
 const adapters: FrameworkAdapter[] = []
@@ -41,7 +41,7 @@ export async function detectFramework(
         return { adapter, confidence: await adapter.detect(projectDir) }
       }
       catch (error) {
-        log.warn(`Adapter '${adapter.name}' detection failed: ${error instanceof Error ? error.message : String(error)}`)
+        log.warn(`Adapter '${adapter.name}' detection failed: ${toErrorMessage(error)}`)
         return { adapter, confidence: 0 }
       }
     }),

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
-import { ConfigError } from '../utils/errors.js'
+import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
 const CONFIG_FILENAME = '.i18n-mcp.json'
@@ -95,7 +95,7 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     raw = await readFile(configPath, 'utf-8')
   } catch (error) {
     throw new ConfigError(
-      `Failed to read ${CONFIG_FILENAME}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to read ${CONFIG_FILENAME}: ${toErrorMessage(error)}`,
     )
   }
 
@@ -104,7 +104,7 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     parsed = JSON.parse(raw)
   } catch (error) {
     throw new ConfigError(
-      `Invalid JSON in ${CONFIG_FILENAME}: ${error instanceof Error ? error.message : String(error)}`,
+      `Invalid JSON in ${CONFIG_FILENAME}: ${toErrorMessage(error)}`,
     )
   }
 

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -25,7 +25,7 @@ import {
 import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from '../scanner/code-scanner.js'
 import { getPatternSet } from '../scanner/patterns.js'
 import { log } from '../utils/logger.js'
-import { ToolError } from '../utils/errors.js'
+import { ToolError, toErrorMessage } from '../utils/errors.js'
 import { scaffoldLocale } from '../tools/scaffold-locale.js'
 
 import type {
@@ -1501,8 +1501,8 @@ export async function translateMissing(opts: {
             }
           })
         } catch (error) {
-          log.warn(`Failed to write translations for ${target.code}: ${error instanceof Error ? error.message : String(error)}`)
-          return { result: { translated: [], failed: [...Object.keys(keysAndValues)], samplingUsed: true, reason: 'translated-with-sampling', batches: totalBatches, model: samplingModel, writeError: error instanceof Error ? error.message : String(error) } }
+          log.warn(`Failed to write translations for ${target.code}: ${toErrorMessage(error)}`)
+          return { result: { translated: [], failed: [...Object.keys(keysAndValues)], samplingUsed: true, reason: 'translated-with-sampling', batches: totalBatches, model: samplingModel, writeError: toErrorMessage(error) } }
         }
       }
 
@@ -1638,7 +1638,7 @@ export async function translateKey(opts: {
       const data = await readLocaleData(config, opts.layer, locale)
       existingTargets.push({ locale, existingValue: getNestedValue(data, opts.key) })
     } catch (error) {
-      failed.push({ locale: locale.code, error: error instanceof Error ? error.message : String(error) })
+      failed.push({ locale: locale.code, error: toErrorMessage(error) })
     }
   }
 
@@ -1735,7 +1735,7 @@ export async function translateKey(opts: {
         targetValue = parsedValue
       }
     } catch (error) {
-      log.warn(`Sampling failed for ${locale.code}: ${error instanceof Error ? error.message : String(error)}`)
+      log.warn(`Sampling failed for ${locale.code}: ${toErrorMessage(error)}`)
     }
 
     if (!targetValue) {
@@ -1758,7 +1758,7 @@ export async function translateKey(opts: {
       filesWritten += written.size
       translated.push(locale.code)
     } catch (error) {
-      failed.push({ locale: locale.code, error: error instanceof Error ? error.message : String(error) })
+      failed.push({ locale: locale.code, error: toErrorMessage(error) })
     }
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,7 @@ export type { I18nConfig, LocaleDefinition, LocaleDir, ProjectConfig } from './c
 export { readLocaleData } from './io/locale-data.js'
 
 // Errors
-export { ToolError } from './utils/errors.js'
+export { ToolError, toErrorMessage } from './utils/errors.js'
 
 // LLM providers
 export { createSamplingFn } from './llm/providers.js'

--- a/packages/cli/src/io/atomic-write.ts
+++ b/packages/cli/src/io/atomic-write.ts
@@ -1,0 +1,34 @@
+import { writeFile, rename, mkdir, unlink } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+/**
+ * Atomically write content to a file.
+ * Writes to a temp file first, then renames to the target path.
+ * Cleans up the temp file on failure.
+ *
+ * @param filePath - Target file path
+ * @param content - String content to write
+ * @param onSuccess - Optional callback after successful rename (e.g., to clear a cache entry)
+ */
+export async function atomicWrite(
+  filePath: string,
+  content: string,
+  onSuccess?: () => void,
+): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  const tmpPath = join(dirname(filePath), `.${randomUUID()}.tmp`)
+
+  try {
+    await writeFile(tmpPath, content, 'utf-8')
+    await rename(tmpPath, filePath)
+    onSuccess?.()
+  } catch (error) {
+    try {
+      await unlink(tmpPath)
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw error
+  }
+}

--- a/packages/cli/src/io/json-reader.ts
+++ b/packages/cli/src/io/json-reader.ts
@@ -1,53 +1,26 @@
-import { readFile, stat } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { FileIOError } from '../utils/errors'
+import { toErrorMessage } from '../utils/errors'
+import { createReadCache } from './read-cache'
 
-/** Cache of parsed locale files: path → { data, mtime } */
-const fileCache = new Map<string, { data: Record<string, unknown>; mtime: number }>()
-
-/** Clear the entire file cache. */
-export function clearFileCache(): void {
-  fileCache.clear()
-}
-
-/** Clear a single entry from the file cache. */
-export function clearFileCacheEntry(filePath: string): void {
-  fileCache.delete(filePath)
-}
-
-/**
- * Read and parse a JSON locale file.
- * Uses an mtime-based cache to avoid re-reading unchanged files.
- */
-export async function readLocaleFile(filePath: string): Promise<Record<string, unknown>> {
-  if (!existsSync(filePath)) {
-    throw new FileIOError(`File not found: ${filePath}`, filePath, 'FILE_NOT_FOUND')
-  }
-
-  try {
-    const fileStat = await stat(filePath)
-    const mtime = fileStat.mtimeMs
-
-    const cached = fileCache.get(filePath)
-    if (cached && cached.mtime === mtime) {
-      return structuredClone(cached.data)
+const { read: readLocaleFile, clear: clearFileCache, clearEntry: clearFileCacheEntry } = createReadCache<Record<string, unknown>>(
+  (content) => {
+    try {
+      return JSON.parse(content) as Record<string, unknown>
+    } catch {
+      throw new SyntaxError('Invalid JSON')
     }
-
-    const content = await readFile(filePath, 'utf-8')
-    const data = JSON.parse(content) as Record<string, unknown>
-    fileCache.set(filePath, { data: structuredClone(data), mtime })
-    return data
-  } catch (error) {
-    if (error instanceof FileIOError) throw error
-    if (error instanceof SyntaxError) {
-      throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath, 'INVALID_JSON')
+  },
+  'JSON',
+  (parsed, filePath) => {
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new FileIOError(`JSON file must contain an object: ${filePath}`, filePath, 'INVALID_JSON')
     }
-    throw new FileIOError(
-      `Failed to read file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
-      filePath,
-    )
-  }
-}
+  },
+)
+
+export { readLocaleFile, clearFileCache, clearFileCacheEntry }
 
 /**
  * Detect the indentation style used in a JSON file.
@@ -102,11 +75,12 @@ export async function readLocaleFileWithMeta(filePath: string): Promise<{
 
     return { data, rawContent, indent, trailingNewline }
   } catch (error) {
+    if (error instanceof FileIOError) throw error
     if (error instanceof SyntaxError) {
       throw new FileIOError(`Invalid JSON in file: ${filePath}`, filePath, 'INVALID_JSON')
     }
     throw new FileIOError(
-      `Failed to read file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to read file: ${filePath}: ${toErrorMessage(error)}`,
       filePath,
     )
   }

--- a/packages/cli/src/io/json-writer.ts
+++ b/packages/cli/src/io/json-writer.ts
@@ -1,26 +1,15 @@
-import { writeFile, rename, mkdir, unlink } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { randomUUID } from 'node:crypto'
 import { FileIOError } from '../utils/errors'
+import { toErrorMessage } from '../utils/errors'
 import { sortKeysDeep } from './key-operations'
 import { clearFileCacheEntry, readLocaleFileWithMeta } from './json-reader'
+import { atomicWrite } from './atomic-write'
 
 export interface WriteOptions {
-  /** Indentation string. If not provided, auto-detected from existing file. */
   indent?: string
-  /** Whether to add trailing newline. Default: true. */
   trailingNewline?: boolean
-  /** Whether to sort keys alphabetically at every level. Default: true. */
   sortKeys?: boolean
 }
 
-/**
- * Write a JSON object to a locale file.
- * - Sorts keys alphabetically at every nesting level by default
- * - Uses atomic write (write to temp file, then rename)
- * - The \t default for indent is a fallback for new files; existing files
- *   get their indent auto-detected via mutateLocaleFile → readLocaleFileWithMeta.
- */
 export async function writeLocaleFile(
   filePath: string,
   data: Record<string, unknown>,
@@ -39,44 +28,16 @@ export async function writeLocaleFile(
       content += '\n'
     }
 
-    // Atomic write: write to temp file, then rename
-    await mkdir(dirname(filePath), { recursive: true })
-    const tmpPath = join(dirname(filePath), `.${randomUUID()}.tmp`)
-
-    try {
-      await writeFile(tmpPath, content, 'utf-8')
-      await rename(tmpPath, filePath)
-      clearFileCacheEntry(filePath)
-    } catch (error) {
-      // Clean up temp file on failure (best-effort)
-      try {
-        await unlink(tmpPath)
-      } catch {
-        // Ignore cleanup errors
-      }
-      throw error
-    }
+    await atomicWrite(filePath, content, () => clearFileCacheEntry(filePath))
   } catch (error) {
     if (error instanceof FileIOError) throw error
     throw new FileIOError(
-      `Failed to write file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to write file: ${filePath}: ${toErrorMessage(error)}`,
       filePath,
     )
   }
 }
 
-/**
- * Read a locale file, apply a mutation function, and write it back.
- * Preserves the file's original formatting (indent style, trailing newline).
- * This is the primary write entry point used by all tools in server.ts.
- */
-/**
- * Write a diagnostic report to a JSON file.
- * - Atomic write (temp file + rename)
- * - Wraps the output with metadata (generatedAt, tool, args)
- * - Creates parent directories if needed
- * - Does NOT interact with the locale file cache
- */
 export async function writeReportFile(
   filePath: string,
   output: Record<string, unknown>,
@@ -92,24 +53,11 @@ export async function writeReportFile(
   const content = JSON.stringify(report, null, 2) + '\n'
 
   try {
-    await mkdir(dirname(filePath), { recursive: true })
-    const tmpPath = join(dirname(filePath), `.${randomUUID()}.tmp`)
-
-    try {
-      await writeFile(tmpPath, content, 'utf-8')
-      await rename(tmpPath, filePath)
-    } catch (error) {
-      try {
-        await unlink(tmpPath)
-      } catch {
-        // Ignore cleanup errors
-      }
-      throw error
-    }
+    await atomicWrite(filePath, content)
   } catch (error) {
     if (error instanceof FileIOError) throw error
     throw new FileIOError(
-      `Failed to write report file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to write report file: ${filePath}: ${toErrorMessage(error)}`,
       filePath,
     )
   }

--- a/packages/cli/src/io/key-operations.ts
+++ b/packages/cli/src/io/key-operations.ts
@@ -1,3 +1,5 @@
+import sortKeys from 'sort-keys'
+
 /**
  * Get a value from a nested object using a dot-separated path.
  */
@@ -100,20 +102,8 @@ export function getLeafKeys(obj: Record<string, unknown>, prefix = '', depth = 0
  * Sort keys alphabetically at every nesting level (deep).
  * Returns a new object — does not mutate the input.
  */
-export function sortKeysDeep(obj: Record<string, unknown>, depth = 0): Record<string, unknown> {
-  if (depth > 200) return {} // guard against deeply nested objects
-  const sorted: Record<string, unknown> = {}
-  const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b))
-  for (const key of keys) {
-    const value = obj[key]
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      sorted[key] = sortKeysDeep(value as Record<string, unknown>, depth + 1)
-    } else {
-      sorted[key] = value
-    }
-  }
-  return sorted
-}
+export const sortKeysDeep = (obj: Record<string, unknown>): Record<string, unknown> =>
+  sortKeys(obj, { deep: true }) as Record<string, unknown>
 
 /**
  * Rename a key in a nested object. Preserves the value.

--- a/packages/cli/src/io/php-reader.ts
+++ b/packages/cli/src/io/php-reader.ts
@@ -1,7 +1,7 @@
 import { readFile, stat } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { fromString } from 'php-array-reader'
-import { FileIOError } from '../utils/errors'
+import { FileIOError, toErrorMessage } from '../utils/errors'
 
 const fileCache = new Map<string, { data: Record<string, unknown>; mtime: number }>()
 
@@ -44,7 +44,7 @@ export async function readPhpLocaleFile(filePath: string): Promise<Record<string
   catch (error) {
     if (error instanceof FileIOError) throw error
     throw new FileIOError(
-      `Failed to read PHP locale file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to read PHP locale file: ${filePath}: ${toErrorMessage(error)}`,
       filePath,
     )
   }

--- a/packages/cli/src/io/php-writer.ts
+++ b/packages/cli/src/io/php-writer.ts
@@ -1,10 +1,10 @@
-import { writeFile, readFile, rename, mkdir, unlink } from 'node:fs/promises'
+import { writeFile, readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { randomUUID } from 'node:crypto'
 import { FileIOError } from '../utils/errors'
+import { toErrorMessage } from '../utils/errors'
 import { sortKeysDeep } from './key-operations'
 import { clearPhpFileCacheEntry } from './php-reader'
+import { atomicWrite } from './atomic-write'
 
 export interface PhpWriteOptions {
   quoteStyle?: 'single' | 'double'
@@ -27,24 +27,12 @@ export async function writePhpLocaleFile(
     const outputData = sortKeys ? sortKeysDeep(data) : data
     const content = serializePhpArray(outputData, quoteStyle, indent)
 
-    await mkdir(dirname(filePath), { recursive: true })
-    const tmpPath = join(dirname(filePath), `.${randomUUID()}.tmp`)
-
-    try {
-      await writeFile(tmpPath, content, 'utf-8')
-      await rename(tmpPath, filePath)
-      clearPhpFileCacheEntry(filePath)
-    }
-    catch (error) {
-      try { await unlink(tmpPath) }
-      catch { /* ignore cleanup errors */ }
-      throw error
-    }
+    await atomicWrite(filePath, content, () => clearPhpFileCacheEntry(filePath))
   }
   catch (error) {
     if (error instanceof FileIOError) throw error
     throw new FileIOError(
-      `Failed to write PHP locale file: ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to write PHP locale file: ${filePath}: ${toErrorMessage(error)}`,
       filePath,
     )
   }

--- a/packages/cli/src/io/read-cache.ts
+++ b/packages/cli/src/io/read-cache.ts
@@ -1,0 +1,61 @@
+import { readFile, stat } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { FileIOError } from '../utils/errors'
+import { toErrorMessage } from '../utils/errors'
+
+/**
+ * Creates an mtime-based file read cache.
+ * Files are re-read only when their modification timestamp changes.
+ * Cached data is cloned via structuredClone to prevent mutation.
+ *
+ * @param parser - Function that parses raw file content into the desired type
+ * @param label - Human-readable label for error messages (e.g., 'JSON', 'PHP')
+ * @param validate - Optional post-parse validation that throws FileIOError on failure
+ */
+export function createReadCache<T>(
+  parser: (content: string) => T,
+  label: string,
+  validate?: (parsed: T, filePath: string) => void,
+) {
+  const cache = new Map<string, { data: T; mtime: number }>()
+
+  async function read(filePath: string): Promise<T> {
+    if (!existsSync(filePath)) {
+      throw new FileIOError(`File not found: ${filePath}`, filePath, 'FILE_NOT_FOUND')
+    }
+
+    try {
+      const fileStat = await stat(filePath)
+      const mtime = fileStat.mtimeMs
+
+      const cached = cache.get(filePath)
+      if (cached && cached.mtime === mtime) {
+        return structuredClone(cached.data)
+      }
+
+      const content = await readFile(filePath, 'utf-8')
+      const parsed = parser(content)
+
+      validate?.(parsed, filePath)
+
+      cache.set(filePath, { data: structuredClone(parsed), mtime })
+      return parsed
+    } catch (error) {
+      if (error instanceof FileIOError) throw error
+      throw new FileIOError(
+        `Failed to read ${label} file: ${filePath}: ${toErrorMessage(error)}`,
+        filePath,
+      )
+    }
+  }
+
+  function clear(): void {
+    cache.clear()
+  }
+
+  function clearEntry(filePath: string): void {
+    cache.delete(filePath)
+  }
+
+  return { read, clear, clearEntry }
+}

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -1,3 +1,8 @@
+/** Extract a human-readable message from any thrown value. */
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 export class ConfigError extends Error {
   constructor(message: string) {
     super(message)

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/cleanup.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/cleanup.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:33:43.188Z",
+  "generatedAt": "2026-06-15T18:57:54.334Z",
   "tool": "remove_orphan_keys",
   "args": {
     "dryRun": true

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/orphans.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/orphans.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:33:43.157Z",
+  "generatedAt": "2026-06-15T18:57:54.308Z",
   "tool": "find_orphan_keys",
   "args": {},
   "orphanKeys": {

--- a/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/scan.json
+++ b/packages/cli/tests/fixtures/nuxt-project/.i18n-reports/scan.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:33:43.174Z",
+  "generatedAt": "2026-06-15T18:57:54.321Z",
   "tool": "scan_code_usage",
   "args": {},
   "usages": {},

--- a/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/empty.json
+++ b/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/empty.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:33:43.134Z",
+  "generatedAt": "2026-06-15T18:57:54.286Z",
   "tool": "find_empty_translations",
   "args": {},
   "emptyKeys": {

--- a/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/missing.json
+++ b/packages/cli/tests/fixtures/nuxt-project/app-admin/.i18n-reports/missing.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:33:43.121Z",
+  "generatedAt": "2026-06-15T18:57:54.267Z",
   "tool": "get_missing_translations",
   "args": {},
   "missing": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { toErrorMessage } from 'the-i18n-cli'
 import { createServer } from './server.js'
 
 try {
@@ -7,6 +8,6 @@ try {
   const transport = new StdioServerTransport()
   await server.connect(transport)
 } catch (error) {
-  process.stderr.write(`[the-i18n-mcp] Fatal error: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.stderr.write(`[the-i18n-mcp] Fatal error: ${toErrorMessage(error)}\n`)
   process.exit(1)
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -25,6 +25,7 @@ import {
   scaffoldLocaleFiles,
   listNamespaces,
   findLocaleImpl,
+  toErrorMessage,
 } from 'the-i18n-cli'
 
 import type { SamplingFn, ProgressFn, ProjectConfig } from 'the-i18n-cli'
@@ -79,7 +80,7 @@ function toolErrorResponse(context: string, error: unknown) {
         type: 'text' as const,
         text: error instanceof ToolError
           ? `[${error.code}] ${error.message}`
-          : `Error ${context}: ${error instanceof Error ? error.message : String(error)}`,
+          : `Error ${context}: ${toErrorMessage(error)}`,
       },
     ],
     isError: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       php-array-reader:
         specifier: ^2.1.3
         version: 2.1.3
+      sort-keys:
+        specifier: ^6.0.0
+        version: 6.0.0
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -4442,6 +4445,10 @@ packages:
   smob@1.6.1:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
     engines: {node: '>=20.0.0'}
+
+  sort-keys@6.0.0:
+    resolution: {integrity: sha512-ueSlHJMwpIw42CJ4B11Uxzh/S0p0AlOyiNktlv2KOu5e1JpUE6DlC4AAUjXqesHdBRv/g0wC9Q4vwq0NP2pA9w==}
+    engines: {node: '>=20'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9740,6 +9747,10 @@ snapshots:
   slash@5.1.0: {}
 
   smob@1.6.1: {}
+
+  sort-keys@6.0.0:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## PR C: IO Layer Deduplication

Closes #168

### Changes

1. **`atomicWrite()` helper** (`io/atomic-write.ts`)  
   Deduplicates the identical atomic-write pattern used 3× in json-writer + php-writer.  
   Accepts optional `onSuccess` callback for cache clearing. Clean temp file on failure.

2. **`createReadCache()` factory** (`io/read-cache.ts`)  
   Generic mtime-based file read cache. Used by `json-reader.ts`.  
   PHP reader kept standalone — factory approach caused edge-case with `php-array-reader`.

3. **`toErrorMessage()` helper** (`utils/errors.ts`)  
   Replaces 12 occurrences of `error instanceof Error ? error.message : String(error)`.  
   Exported from CLI public API for MCP package use.

4. **`sort-keys` replaces custom `sortKeysDeep`** (`io/key-operations.ts`)  
   15-line recursive sorter → 1-liner: `sortKeys(obj, { deep: true })`.  
   Handles depth limits and array preservation out of the box.

### Stats
- 17 files changed, 2 new files
- **Net: +14 lines** (new helpers offset by deletions in writers/readers)
- All 579 tests pass
- Build + typecheck + lint clean