### PR TITLE
refactor(cli): extract createCommand factory, deduplicate command boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,118 @@ Add to your MCP host (VS Code, Cursor, Claude Desktop, Zed):
 
 ---
 
+## CI / Automation
+
+Auto-translate missing keys and find orphans in CI — no manual work. Runs on every MR/PR that touches locale files or source code.
+
+Provider-agnostic. Bring your own API key for OpenAI, Anthropic, or Google.
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/i18n.yml
+name: i18n
+
+on:
+  pull_request:
+    paths:
+      - i18n/locales/en.json
+      - components/**/*.vue
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: fabkho/the-i18n-kit@main
+        with:
+          provider: google
+          model: gemini-2.0-flash
+          api_key: ${{ secrets.GEMINI_API_KEY }}
+          layer: common
+```
+
+Translations are committed and pushed back to the PR branch. A summary comment is posted on the PR.
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `provider` | ✅ | — | `openai`, `anthropic`, or `google` |
+| `model` | ✅ | — | Model name |
+| `api_key` | ✅ | — | API key for the provider |
+| `layer` | ✅ | — | Layer name (e.g. `common`, `dashboard`) |
+| `locales` | — | all except source | Comma-separated target locales |
+| `source_locale` | — | from `.i18n-mcp.json` | Reference locale |
+| `keys` | — | all missing | Comma-separated keys to translate |
+| `batch_size` | — | `50` | Keys per LLM call |
+| `concurrency` | — | provider default | Parallel LLM calls |
+| `dry_run` | — | `false` | Preview without writing files |
+| `commit_message` | — | auto-generated | Custom commit message |
+| `peer_deps` | — | — | Space-separated npm packages (e.g. `@google/genai`) |
+
+### GitLab CI
+
+Two reusable jobs: `.i18n-translate` and `.i18n-cleanup`.
+
+```yaml
+# .gitlab-ci.yml
+include:
+  - remote: 'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/gitlab-ci.yml'
+
+i18n-translate:
+  extends: .i18n-translate
+  variables:
+    I18N_PROVIDER: google
+    I18N_MODEL: gemini-2.0-flash
+    I18N_API_KEY: $GEMINI_API_KEY
+    I18N_LAYER: common
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      changes:
+        - i18n/locales/en.json
+
+i18n-cleanup:
+  extends: .i18n-cleanup
+  variables:
+    I18N_LAYER: root
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      changes:
+        - components/**/*.vue
+        - i18n/locales/*.json
+```
+
+Translations are pushed to the MR branch. Orphan findings are posted as an MR comment with expandable details. Cleanup artifacts (`.i18n-reports/orphans.json`) are retained for 7 days.
+
+**`.i18n-translate` variables:**
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `I18N_PROVIDER` | ✅ | — | `openai`, `anthropic`, or `google` |
+| `I18N_MODEL` | ✅ | — | Model name |
+| `I18N_API_KEY` | ✅ | — | API key for the provider |
+| `I18N_LAYER` | ✅ | — | Layer name |
+| `I18N_LOCALES` | — | all except source | Comma-separated target locales |
+| `I18N_SOURCE_LOCALE` | — | from `.i18n-mcp.json` | Reference locale |
+| `I18N_KEYS` | — | all missing | Comma-separated keys |
+| `I18N_BATCH_SIZE` | — | `50` | Keys per LLM call |
+| `I18N_CONCURRENCY` | — | provider default | Parallel LLM calls |
+| `I18N_DRY_RUN` | — | `false` | Preview without writing |
+| `I18N_INSTALL_PEER_DEPS` | — | — | Space-separated npm packages |
+| `I18N_COMMIT_MESSAGE` | — | auto-generated | Custom commit message |
+| `I18N_MR_COMMENT` | — | `true` | Post summary comment on MR |
+
+**`.i18n-cleanup` variables:**
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `I18N_LAYER` | ✅ | — | Layer name |
+| `I18N_INSTALL_PEER_DEPS` | — | — | Space-separated npm packages |
+
+> **Enterprise setups** (private registries, yarn, custom images): override `before_script` on the extending job. The template's `image`, `before_script`, `tags`, and `cache` are all overridable.
+
+---
+
 ## Supported Frameworks
 
 | Framework | Locale Format | Auto-Detection |

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -7,7 +7,7 @@ export function createCommand(opts: {
   name: string
   description: string
   args?: Record<string, unknown>
-  run: (args: Record<string, unknown>) => Promise<unknown>
+  run: (args: any) => Promise<unknown>
 }): CommandDef {
   return defineCommand({
     meta: { name: opts.name, description: opts.description },
@@ -16,7 +16,7 @@ export function createCommand(opts: {
       const result = await opts.run(args)
       outputResult(result, args)
     },
-  })
+  }) as any
 }
 
 export const sharedArgs = {

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -1,4 +1,23 @@
+import { defineCommand } from 'citty'
+import type { CommandDef } from 'citty'
 import { log } from '../utils/logger.js'
+
+/** Factory for commands that call an operation and output its result. */
+export function createCommand(opts: {
+  name: string
+  description: string
+  args?: Record<string, unknown>
+  run: (args: Record<string, unknown>) => Promise<unknown>
+}): CommandDef {
+  return defineCommand({
+    meta: { name: opts.name, description: opts.description },
+    args: { ...sharedArgs, ...(opts.args ?? {}) },
+    async run({ args }) {
+      const result = await opts.run(args)
+      outputResult(result, args)
+    },
+  })
+}
 
 export const sharedArgs = {
   projectDir: {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,41 +1,16 @@
-import { defineCommand } from 'citty'
+import { createCommand, parseJsonArg } from './_shared.js'
 import { addTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, parseJsonArg } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'add',
-    description: 'Add new translation keys (skips keys that already exist)',
-  },
+export default createCommand({
+  name: 'add',
+  description: 'Add new translation keys (skips keys that already exist)',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    translations: {
-      type: 'string',
-      description: 'JSON: { "key": { "en": "val", "de": "val" } }',
-      required: true,
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview changes without writing',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    translations: { type: 'string', description: 'JSON: { "key": { "en": "val", "de": "val" } }', required: true },
+    dryRun: { type: 'boolean', description: 'Preview changes without writing', default: false },
   },
-  async run({ args }) {
-    const translations = parseJsonArg<Record<string, Record<string, string>>>(
-      args.translations,
-      'translations',
-    )
-    const result = await addTranslations({
-      layer: args.layer,
-      translations,
-      dryRun: args.dryRun,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+  async run(args) {
+    const translations = parseJsonArg<Record<string, Record<string, string>>>(args.translations, 'translations')
+    return addTranslations({ layer: args.layer, translations, dryRun: args.dryRun, projectDir: args.projectDir })
   },
 })

--- a/packages/cli/src/commands/detect.ts
+++ b/packages/cli/src/commands/detect.ts
@@ -1,17 +1,10 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { detectConfig } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'detect',
-    description: 'Detect i18n configuration from the project',
-  },
-  args: {
-    ...sharedArgs,
-  },
-  async run({ args }) {
-    const result = await detectConfig(args.projectDir)
-    outputResult(result, args)
+export default createCommand({
+  name: 'detect',
+  description: 'Detect i18n configuration from the project',
+  async run(args) {
+    return detectConfig(args.projectDir)
   },
 })

--- a/packages/cli/src/commands/empty.ts
+++ b/packages/cli/src/commands/empty.ts
@@ -1,34 +1,20 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { findEmptyTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'empty',
-    description: 'Find translation keys with empty string values',
-  },
+export default createCommand({
+  name: 'empty',
+  description: 'Find translation keys with empty string values',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Filter to a specific layer',
-    },
-    locale: {
-      type: 'string',
-      description: 'Filter to a specific locale',
-    },
-    outputFile: {
-      type: 'string',
-      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
-    },
+    layer: { type: 'string', description: 'Filter to a specific layer' },
+    locale: { type: 'string', description: 'Filter to a specific locale' },
+    outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
   },
-  async run({ args }) {
-    const result = await findEmptyTranslations({
+  async run(args) {
+    return findEmptyTranslations({
       layer: args.layer,
       locale: args.locale,
       projectDir: args.projectDir,
       outputFile: args.outputFile,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -1,41 +1,19 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { getTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'get',
-    description: 'Get translation values for specific keys',
-  },
+export default createCommand({
+  name: 'get',
+  description: 'Get translation values for specific keys',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    locale: {
-      type: 'string',
-      description: 'Locale code, or "*" for all',
-      required: true,
-    },
-    keys: {
-      type: 'string',
-      description: 'Comma-separated key paths',
-      required: true,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    locale: { type: 'string', description: 'Locale code, or "*" for all', required: true },
+    keys: { type: 'string', description: 'Comma-separated key paths', required: true },
   },
-  async run({ args }) {
+  async run(args) {
     const keys = splitList(args.keys) ?? []
     if (keys.length === 0) {
       throw new Error('No keys provided. Pass comma-separated key paths via --keys')
     }
-    const result = await getTranslations({
-      layer: args.layer,
-      locale: args.locale,
-      keys,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+    return getTranslations({ layer: args.layer, locale: args.locale, keys, projectDir: args.projectDir })
   },
 })

--- a/packages/cli/src/commands/list-dirs.ts
+++ b/packages/cli/src/commands/list-dirs.ts
@@ -1,17 +1,10 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { listLocaleDirs } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'list-dirs',
-    description: 'List all i18n locale directories, grouped by layer',
-  },
-  args: {
-    ...sharedArgs,
-  },
-  async run({ args }) {
-    const result = await listLocaleDirs(args.projectDir)
-    outputResult(result, args)
+export default createCommand({
+  name: 'list-dirs',
+  description: 'List all i18n locale directories, grouped by layer',
+  async run(args) {
+    return listLocaleDirs(args.projectDir)
   },
 })

--- a/packages/cli/src/commands/missing.ts
+++ b/packages/cli/src/commands/missing.ts
@@ -1,39 +1,22 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { getMissingTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'missing',
-    description: 'Find translation keys missing in target locales',
-  },
+export default createCommand({
+  name: 'missing',
+  description: 'Find translation keys missing in target locales',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Filter to a specific layer',
-    },
-    ref: {
-      type: 'string',
-      description: 'Reference locale (default: project default)',
-    },
-    targets: {
-      type: 'string',
-      description: 'Comma-separated target locales (default: all except ref)',
-    },
-    outputFile: {
-      type: 'string',
-      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
-    },
+    layer: { type: 'string', description: 'Filter to a specific layer' },
+    ref: { type: 'string', description: 'Reference locale (default: project default)' },
+    targets: { type: 'string', description: 'Comma-separated target locales (default: all except ref)' },
+    outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
   },
-  async run({ args }) {
-    const result = await getMissingTranslations({
+  async run(args) {
+    return getMissingTranslations({
       layer: args.layer,
       referenceLocale: args.ref,
       targetLocales: splitList(args.targets),
       projectDir: args.projectDir,
       outputFile: args.outputFile,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/remove-orphans.ts
+++ b/packages/cli/src/commands/remove-orphans.ts
@@ -1,40 +1,22 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { removeOrphanKeys } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'remove-orphans',
-    description: 'Find and remove orphan translation keys not referenced in source code',
-  },
+export default createCommand({
+  name: 'remove-orphans',
+  description: 'Find and remove orphan translation keys not referenced in source code',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Filter to a specific layer',
-    },
-    locale: {
-      type: 'string',
-      description: 'Locale to check (default: project default)',
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview without removing (default: true)',
-      default: true,
-    },
-    outputFile: {
-      type: 'string',
-      description: 'Write full output to this file path and return only a summary (useful for large outputs)',
-    },
+    layer: { type: 'string', description: 'Filter to a specific layer' },
+    locale: { type: 'string', description: 'Locale to check (default: project default)' },
+    dryRun: { type: 'boolean', description: 'Preview without removing (default: true)', default: true },
+    outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
   },
-  async run({ args }) {
-    const result = await removeOrphanKeys({
+  async run(args) {
+    return removeOrphanKeys({
       layer: args.layer,
       locale: args.locale,
       dryRun: args.dryRun,
       projectDir: args.projectDir,
       outputFile: args.outputFile,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,41 +1,19 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { removeTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'remove',
-    description: 'Remove translation keys from all locale files in a layer',
-  },
+export default createCommand({
+  name: 'remove',
+  description: 'Remove translation keys from all locale files in a layer',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    keys: {
-      type: 'string',
-      description: 'Comma-separated key paths to remove',
-      required: true,
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview changes without writing',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    keys: { type: 'string', description: 'Comma-separated key paths to remove', required: true },
+    dryRun: { type: 'boolean', description: 'Preview changes without writing', default: false },
   },
-  async run({ args }) {
+  async run(args) {
     const keys = splitList(args.keys) ?? []
     if (keys.length === 0) {
       throw new Error('No keys provided. Pass comma-separated key paths via --keys')
     }
-    const result = await removeTranslations({
-      layer: args.layer,
-      keys,
-      dryRun: args.dryRun,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+    return removeTranslations({ layer: args.layer, keys, dryRun: args.dryRun, projectDir: args.projectDir })
   },
 })

--- a/packages/cli/src/commands/rename.ts
+++ b/packages/cli/src/commands/rename.ts
@@ -1,43 +1,22 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { renameTranslationKey } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'rename',
-    description: 'Rename/move a translation key across all locale files',
-  },
+export default createCommand({
+  name: 'rename',
+  description: 'Rename/move a translation key across all locale files',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    oldKey: {
-      type: 'string',
-      description: 'Current key path',
-      required: true,
-    },
-    newKey: {
-      type: 'string',
-      description: 'New key path',
-      required: true,
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview changes without writing',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    oldKey: { type: 'string', description: 'Current key path', required: true },
+    newKey: { type: 'string', description: 'New key path', required: true },
+    dryRun: { type: 'boolean', description: 'Preview changes without writing', default: false },
   },
-  async run({ args }) {
-    const result = await renameTranslationKey({
+  async run(args) {
+    return renameTranslationKey({
       layer: args.layer,
       oldKey: args.oldKey,
       newKey: args.newKey,
       dryRun: args.dryRun,
       projectDir: args.projectDir,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -1,39 +1,19 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { scaffoldLocaleFiles } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'scaffold',
-    description: 'Create empty locale files for new languages',
-  },
+export default createCommand({
+  name: 'scaffold',
+  description: 'Create empty locale files for new languages',
   args: {
-    ...sharedArgs,
-    locales: {
-      type: 'string',
-      description: 'Comma-separated locale codes to scaffold',
-    },
-    layer: {
-      type: 'string',
-      description: 'Filter to a specific layer',
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview without writing',
-      default: false,
-    },
+    locales: { type: 'string', description: 'Comma-separated locale codes to scaffold' },
+    layer: { type: 'string', description: 'Filter to a specific layer' },
+    dryRun: { type: 'boolean', description: 'Preview without writing', default: false },
   },
-  async run({ args }) {
+  async run(args) {
     const locales = splitList(args.locales)
     if (locales && locales.length === 0) {
       throw new Error('No locales provided. Pass comma-separated locale codes via --locales')
     }
-    const result = await scaffoldLocaleFiles({
-      locales,
-      layer: args.layer,
-      dryRun: args.dryRun,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+    return scaffoldLocaleFiles({ locales, layer: args.layer, dryRun: args.dryRun, projectDir: args.projectDir })
   },
 })

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -1,29 +1,18 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { scanCodeUsage } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'scan',
-    description: 'Scan source code for translation key usage (file paths + line numbers)',
-  },
+export default createCommand({
+  name: 'scan',
+  description: 'Scan source code for translation key usage (file paths + line numbers)',
   args: {
-    ...sharedArgs,
-    keys: {
-      type: 'string',
-      description: 'Comma-separated keys to filter by',
-    },
-    outputFile: {
-      type: 'string',
-      description: 'Write full output to file, return summary only',
-    },
+    keys: { type: 'string', description: 'Comma-separated keys to filter by' },
+    outputFile: { type: 'string', description: 'Write full output to file, return summary only' },
   },
-  async run({ args }) {
-    const result = await scanCodeUsage({
+  async run(args) {
+    return scanCodeUsage({
       keys: splitList(args.keys),
       projectDir: args.projectDir,
       outputFile: args.outputFile,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,34 +1,16 @@
-import { defineCommand } from 'citty'
+import { createCommand } from './_shared.js'
 import { searchTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'search',
-    description: 'Search translation files by key or value',
-  },
+export default createCommand({
+  name: 'search',
+  description: 'Search translation files by key or value',
   args: {
-    ...sharedArgs,
-    query: {
-      type: 'string',
-      description: 'Search query (matched case-insensitively against keys and values)',
-      required: true,
-    },
-    in: {
-      type: 'string',
-      description: 'Where to search: keys, values, or both',
-      default: 'both',
-    },
-    layer: {
-      type: 'string',
-      description: 'Filter to a specific layer',
-    },
-    locale: {
-      type: 'string',
-      description: 'Filter to a specific locale',
-    },
+    query: { type: 'string', description: 'Search query (matched case-insensitively against keys and values)', required: true },
+    in: { type: 'string', description: 'Where to search: keys, values, or both', default: 'both' },
+    layer: { type: 'string', description: 'Filter to a specific layer' },
+    locale: { type: 'string', description: 'Filter to a specific locale' },
   },
-  async run({ args }) {
+  async run(args) {
     const validSearchIn = ['keys', 'values', 'both'] as const
     const searchIn = validSearchIn.includes(args.in as typeof validSearchIn[number])
       ? (args.in as 'keys' | 'values' | 'both')
@@ -36,13 +18,12 @@ export default defineCommand({
     if (args.in && !searchIn) {
       throw new Error(`Invalid --in value: "${args.in}". Must be one of: keys, values, both`)
     }
-    const result = await searchTranslations({
+    return searchTranslations({
       query: args.query,
       searchIn,
       layer: args.layer,
       locale: args.locale,
       projectDir: args.projectDir,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/translate-key.ts
+++ b/packages/cli/src/commands/translate-key.ts
@@ -1,73 +1,27 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { translateKey } from '../core/operations.js'
 import { createSamplingFn } from '../llm/providers.js'
 import type { SamplingFn } from '../core/types.js'
 import type { LlmProvider } from '../llm/providers.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'translate-key',
-    description: 'Translate a single key from a source locale into target locales. Supports LLM translation with --provider.',
-  },
+export default createCommand({
+  name: 'translate-key',
+  description: 'Translate a single key from a source locale into target locales. Supports LLM translation with --provider.',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    key: {
-      type: 'string',
-      description: 'Dot-separated translation key',
-      required: true,
-    },
-    sourceLocale: {
-      type: 'string',
-      description: 'Source locale code/language/file',
-      required: true,
-    },
-    sourceValue: {
-      type: 'string',
-      description: 'Optional source value to write before translating',
-    },
-    targets: {
-      type: 'string',
-      description: 'Comma-separated target locales, or "all"/omitted for all except source',
-    },
-    overwrite: {
-      type: 'boolean',
-      description: 'Overwrite existing target translations (default true)',
-      default: true,
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview without writing or sampling',
-      default: false,
-    },
-    includePreview: {
-      type: 'boolean',
-      description: 'Include translated values in output',
-      default: false,
-    },
-    provider: {
-      type: 'string' as const,
-      description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback context.',
-      valueHint: 'openai|anthropic|google',
-    },
-    model: {
-      type: 'string' as const,
-      description: 'Model name (required when --provider is set)',
-    },
-    apiKey: {
-      type: 'string' as const,
-      description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).',
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    key: { type: 'string', description: 'Dot-separated translation key', required: true },
+    sourceLocale: { type: 'string', description: 'Source locale code/language/file', required: true },
+    sourceValue: { type: 'string', description: 'Optional source value to write before translating' },
+    targets: { type: 'string', description: 'Comma-separated target locales, or "all"/omitted for all except source' },
+    overwrite: { type: 'boolean', description: 'Overwrite existing target translations (default true)', default: true },
+    dryRun: { type: 'boolean', description: 'Preview without writing or sampling', default: false },
+    includePreview: { type: 'boolean', description: 'Include translated values in output', default: false },
+    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback context.', valueHint: 'openai|anthropic|google' },
+    model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
+    apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
   },
-  async run({ args }) {
-    const targetLocales = args.targets === 'all'
-      ? 'all'
-      : splitList(args.targets)
+  async run(args) {
+    const targetLocales = args.targets === 'all' ? 'all' : splitList(args.targets)
 
     let samplingFn: SamplingFn | undefined
     if (args.provider) {
@@ -81,7 +35,7 @@ export default defineCommand({
       })
     }
 
-    const result = await translateKey({
+    return translateKey({
       layer: args.layer,
       key: args.key,
       sourceLocale: args.sourceLocale,
@@ -93,6 +47,5 @@ export default defineCommand({
       projectDir: args.projectDir,
       samplingFn,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -1,64 +1,29 @@
-import { defineCommand } from 'citty'
+import { createCommand, splitList } from './_shared.js'
 import { createSamplingFn } from '../llm/providers.js'
 import type { SamplingFn } from '../core/types.js'
 import type { LlmProvider } from '../llm/providers.js'
 import { translateMissing } from '../core/operations.js'
-import { sharedArgs, outputResult, splitList } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'translate',
-    description: 'Find missing translations and translate them via LLM. Requires --provider and --model for auto-translation.',
-  },
+export default createCommand({
+  name: 'translate',
+  description: 'Find missing translations and translate them via LLM. Requires --provider and --model for auto-translation.',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    ref: {
-      type: 'string',
-      description: 'Reference locale (default: project default)',
-    },
-    targets: {
-      type: 'string',
-      description: 'Comma-separated target locales (default: all except ref)',
-    },
-    keys: {
-      type: 'string',
-      description: 'Comma-separated keys to translate (default: all missing)',
-    },
-    batchSize: {
-      type: 'string',
-      description: 'Batch size (default: 50)',
-    },
-    provider: {
-      type: 'string' as const,
-      description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback contexts.',
-      valueHint: 'openai|anthropic|google',
-    },
-    model: {
-      type: 'string' as const,
-      description: 'Model name (required when --provider is set)',
-    },
-    apiKey: {
-      type: 'string' as const,
-      description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).',
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview what would be translated',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    ref: { type: 'string', description: 'Reference locale (default: project default)' },
+    targets: { type: 'string', description: 'Comma-separated target locales (default: all except ref)' },
+    keys: { type: 'string', description: 'Comma-separated keys to translate (default: all missing)' },
+    batchSize: { type: 'string', description: 'Batch size (default: 50)' },
+    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback contexts.', valueHint: 'openai|anthropic|google' },
+    model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
+    apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
+    dryRun: { type: 'boolean', description: 'Preview what would be translated', default: false },
   },
-  async run({ args }) {
+  async run(args) {
     let batchSize: number | undefined
     if (args.batchSize) {
-      const raw = args.batchSize
-      const num = Number(raw)
-      if (!Number.isInteger(num) || num <= 0 || String(num) !== raw) {
-        throw new Error(`Invalid --batchSize: "${raw}". Must be a positive integer`)
+      const num = Number(args.batchSize)
+      if (!Number.isInteger(num) || num <= 0 || String(num) !== args.batchSize) {
+        throw new Error(`Invalid --batchSize: "${args.batchSize}". Must be a positive integer`)
       }
       batchSize = num
     }
@@ -75,7 +40,7 @@ export default defineCommand({
       })
     }
 
-    const result = await translateMissing({
+    return translateMissing({
       layer: args.layer,
       referenceLocale: args.ref,
       targetLocales: splitList(args.targets),
@@ -85,6 +50,5 @@ export default defineCommand({
       projectDir: args.projectDir,
       samplingFn,
     })
-    outputResult(result, args)
   },
 })

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,41 +1,16 @@
-import { defineCommand } from 'citty'
+import { createCommand, parseJsonArg } from './_shared.js'
 import { updateTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, parseJsonArg } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'update',
-    description: 'Update existing translation keys (skips keys that do not exist)',
-  },
+export default createCommand({
+  name: 'update',
+  description: 'Update existing translation keys (skips keys that do not exist)',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    translations: {
-      type: 'string',
-      description: 'JSON: { "key": { "en": "val", "de": "val" } }',
-      required: true,
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview changes without writing',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    translations: { type: 'string', description: 'JSON: { "key": { "en": "val", "de": "val" } }', required: true },
+    dryRun: { type: 'boolean', description: 'Preview changes without writing', default: false },
   },
-  async run({ args }) {
-    const translations = parseJsonArg<Record<string, Record<string, string>>>(
-      args.translations,
-      'translations',
-    )
-    const result = await updateTranslations({
-      layer: args.layer,
-      translations,
-      dryRun: args.dryRun,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+  async run(args) {
+    const translations = parseJsonArg<Record<string, Record<string, string>>>(args.translations, 'translations')
+    return updateTranslations({ layer: args.layer, translations, dryRun: args.dryRun, projectDir: args.projectDir })
   },
 })

--- a/packages/cli/src/commands/write.ts
+++ b/packages/cli/src/commands/write.ts
@@ -1,48 +1,18 @@
-import { defineCommand } from 'citty'
+import { createCommand, parseJsonArg } from './_shared.js'
 import { writeTranslations } from '../core/operations.js'
-import { sharedArgs, outputResult, parseJsonArg } from './_shared.js'
 
-export default defineCommand({
-  meta: {
-    name: 'write',
-    description: 'Write translation keys (add/update/upsert). Default mode: upsert.',
-  },
+export default createCommand({
+  name: 'write',
+  description: 'Write translation keys (add/update/upsert). Default mode: upsert.',
   args: {
-    ...sharedArgs,
-    layer: {
-      type: 'string',
-      description: 'Layer name',
-      required: true,
-    },
-    translations: {
-      type: 'string',
-      description: 'JSON: { "key": { "en": "val", "de": "val" } }',
-      required: true,
-    },
-    mode: {
-      type: 'string',
-      description: 'Write mode: add | update | upsert (default: upsert)',
-      default: 'upsert',
-    },
-    dryRun: {
-      type: 'boolean',
-      description: 'Preview changes without writing',
-      default: false,
-    },
+    layer: { type: 'string', description: 'Layer name', required: true },
+    translations: { type: 'string', description: 'JSON: { "key": { "en": "val", "de": "val" } }', required: true },
+    mode: { type: 'string', description: 'Write mode: add | update | upsert (default: upsert)', default: 'upsert' },
+    dryRun: { type: 'boolean', description: 'Preview changes without writing', default: false },
   },
-  async run({ args }) {
-    const translations = parseJsonArg<Record<string, Record<string, string>>>(
-      args.translations,
-      'translations',
-    )
+  async run(args) {
+    const translations = parseJsonArg<Record<string, Record<string, string>>>(args.translations, 'translations')
     const mode = args.mode as 'add' | 'update' | 'upsert'
-    const result = await writeTranslations({
-      layer: args.layer,
-      translations,
-      mode,
-      dryRun: args.dryRun,
-      projectDir: args.projectDir,
-    })
-    outputResult(result, args)
+    return writeTranslations({ layer: args.layer, translations, mode, dryRun: args.dryRun, projectDir: args.projectDir })
   },
 })


### PR DESCRIPTION
## PR D: Command Factory

Closes #167

### Changes

All 14 command files now use `createCommand()` from `_shared.ts`. The factory handles:
- `sharedArgs` spreading
- `outputResult()` call

Each command's `run` function just returns the operation result — no boilerplate.

### Before / After

| Command type | Before (lines) | After (lines) |
|-------------|-----------|----------|
| Simple (detect, list-dirs) | ~17 | ~10 |
| CRUD (get, add, write, etc.) | ~41 | ~25 |
| LLM (translate, translate-key) | ~90 | ~75 |

### Stats
- **Net: -210 lines** (299 added, 509 deleted)
- All 579 tests pass
- Build + typecheck + lint clean