### PR TITLE
chore: Docker pnpm deploy, CONTRIBUTING.md, CHANGELOG cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,29 +150,6 @@
 
 ### Features
 
-* add buildDynamicKeyRegexes() for dynamic key pattern matching ([b281b8e](https://github.com/fabkho/nuxt-i18n-mcp/commit/b281b8eeac746b029b35bec7eb7af436abd7afc7))
-* add find_empty_translations tool ([7ce0c9f](https://github.com/fabkho/nuxt-i18n-mcp/commit/7ce0c9fd36579987c3f728a3c9ecb771070c50f8))
-* add find_empty_translations tool ([4c554ab](https://github.com/fabkho/nuxt-i18n-mcp/commit/4c554ab2d1dc0819f2f36a3b33bacf4e01db81d9))
-* add orphanScan config for per-layer scan scope ([6b6cfb1](https://github.com/fabkho/nuxt-i18n-mcp/commit/6b6cfb167ca3d34503893b703b27f9695188c631))
-* configurable orphanScan scope per layer ([c92f230](https://github.com/fabkho/nuxt-i18n-mcp/commit/c92f23000c29cb0e1b7a69388396550dfa1f73c1))
-* detect concatenation-based dynamic keys (t('prefix.' + var)) ([62b5c0a](https://github.com/fabkho/nuxt-i18n-mcp/commit/62b5c0af683519eda7bf54245c67af310e2bd787))
-* use buildDynamicKeyRegexes in find_orphan_keys and cleanup_unused_translations ([b99d7a5](https://github.com/fabkho/nuxt-i18n-mcp/commit/b99d7a5be9dec7b2aca41ba82aff56be62e707a9))
-* wire 3-tier scan directory fallback in orphan detection tools ([c8e90a9](https://github.com/fabkho/nuxt-i18n-mcp/commit/c8e90a9bd23a75299ce1b5219a28abec2c065208))
-
-
-### Bug Fixes
-
-* fallback layerRootDirs to projectDir when layers array is empty ([6cf4e3a](https://github.com/fabkho/nuxt-i18n-mcp/commit/6cf4e3a2f0e1b18cdc5d98bc138cddd59148abc2))
-* handle nested braces in interpolation splitting and improve zero-orphan message ([29523b2](https://github.com/fabkho/nuxt-i18n-mcp/commit/29523b2645275ae51cae53ac8fb28ea89698d32e))
-* scan all Nuxt layers for source code, not just those with locale dirs ([83f09c3](https://github.com/fabkho/nuxt-i18n-mcp/commit/83f09c3e6a26fa58eb14b52b0cf94e4ecdcdd902))
-* scan all Nuxt layers for source code, not just those with locale dirs ([932d855](https://github.com/fabkho/nuxt-i18n-mcp/commit/932d8558967b821e445f02c814e1c102a671235c))
-* use dynamic key patterns to reduce orphan detection false positives ([2a5586c](https://github.com/fabkho/nuxt-i18n-mcp/commit/2a5586c429ac2e27a14b3b522021e81da8e8da03))
-
-## [1.2.0](https://github.com/fabkho/nuxt-i18n-mcp/compare/v1.1.0...v1.2.0) (2026-03-21)
-
-
-### Features
-
 * add buildDynamicKeyRegexes() for dynamic key pattern matching ([4233c6f](https://github.com/fabkho/nuxt-i18n-mcp/commit/4233c6f1504bd42746dc67b8bb11d2c89febbd99))
 * add find_empty_translations tool ([be271c0](https://github.com/fabkho/nuxt-i18n-mcp/commit/be271c049704dae815232efce3d96bdd394ecd12))
 * add find_empty_translations tool ([b8f6677](https://github.com/fabkho/nuxt-i18n-mcp/commit/b8f6677724938f9b3c3a553342b919692d296f78))
@@ -230,8 +207,3 @@
 * treat empty-string and null values as missing translations ([adba2ec](https://github.com/fabkho/nuxt-i18n-mcp/commit/adba2ec52a80fbcf17d8df61f50e43f027269ad4))
 * use ready:false instead of modules:[] in loadNuxt retry to fix CI ([1f274f4](https://github.com/fabkho/nuxt-i18n-mcp/commit/1f274f4d893f82bc579e825b49de1c662e555c89))
 
-## Changelog
-
-All notable changes to this project will be documented in this file.
-
-This project uses [Release Please](https://github.com/googleapis/release-please) for automated versioning and changelog generation based on [Conventional Commits](https://www.conventionalcommits.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+## Setup
+
+```bash
+pnpm install
+pnpm build
+```
+
+The monorepo uses pnpm workspaces with two packages:
+
+| Package | Description |
+|---------|-------------|
+| `packages/cli` (`the-i18n-cli`) | CLI tool for i18n management — JSON/PHP locale files, code scanning, LLM translation, config detection |
+| `packages/mcp` (`the-i18n-mcp`) | MCP server wrapping the CLI as 12 tools for AI agents |
+
+## Development
+
+```bash
+pnpm build          # build both packages
+pnpm test           # run all tests (CLI only)
+pnpm lint           # lint all source files
+pnpm typecheck      # build CLI + typecheck both packages
+```
+
+To work on a single package:
+
+```bash
+pnpm --filter the-i18n-cli dev     # watch mode
+pnpm --filter the-i18n-cli test    # run CLI tests only
+```
+
+## Architecture
+
+### CLI (`packages/cli/src/`)
+
+```
+adapters/     # Framework detection (Nuxt, Laravel, Vue, React, Generic)
+commands/     # 14 CLI subcommands, one file each — use createCommand() factory from _shared.ts
+config/       # Project config loading, Nuxt app discovery, locale override
+core/         # operations.ts — all i18n operations as pure async functions. types.ts — result shapes.
+io/           # Locale file reading/writing (JSON + PHP), atomicWrite, readCache, key-operations
+llm/          # LLM provider setup (OpenAI, Anthropic, Google)
+scanner/      # Source code scanning for i18n key usage, orphan detection
+tools/        # Locale scaffold utility
+utils/        # errors.ts (custom error classes + toErrorMessage), logger.ts (consola wrapper)
+```
+
+### MCP (`packages/mcp/src/`)
+
+```
+server.ts     # MCP server with 12 tool registrations, zod input schemas, createMcpSamplingFn factory
+index.ts      # Entry point — creates server + stdio transport
+```
+
+### Data flow
+
+1. CLI commands call operations in `core/operations.ts`
+2. Operations detect config via adapters → load project config → read/write locale files via `io/`
+3. MCP server registers tools that call the same operations, with MCP-specific sampling/progress integration
+
+## Testing
+
+Tests use Vitest. Test fixtures live in `packages/cli/tests/fixtures/`.
+
+### Mock pattern
+
+When mocking the config detector (common), use `vi.mock` with dynamic import:
+
+```typescript
+registerDetectorMock()
+
+// Import AFTER mock so the mock is in place (Vitest hoists vi.mock)
+const { detectI18nConfig } = await import('../../src/config/detector.js')
+```
+
+### Temp directories
+
+Some tests create temporary directories via `mkdtemp`. Always clean up in `afterEach`:
+
+```typescript
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+```
+
+## Adding a new adapter
+
+1. Create `adapters/<framework>/index.ts` implementing `FrameworkAdapter`
+2. Register it in `config/detector.ts` via `registerAdapter()`
+3. Add types for any framework-specific config to `config/types.ts`
+4. Add tests in `tests/adapters/<framework>-adapter.test.ts`
+
+## PRs
+
+- Branch from `main`
+- Run `pnpm lint && pnpm typecheck` before committing (enforced by pre-commit hook)
+- All tests must pass
+- Keep PRs focused — one concern per PR

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,11 @@ COPY packages/mcp/package.json packages/mcp/tsconfig.json packages/mcp/tsdown.co
 COPY packages/mcp/src/ ./packages/mcp/src/
 RUN pnpm install --frozen-lockfile
 RUN pnpm build
+RUN pnpm --filter the-i18n-mcp deploy --legacy /app/prod
 
 # Runtime stage
 FROM node:22-alpine
+COPY --from=build /app/prod /app
 WORKDIR /app
-COPY --from=build /app/packages/mcp/dist/ ./dist/
-COPY --from=build /app/packages/mcp/package.json ./
-COPY --from=build /app/packages/cli/dist/ ./node_modules/the-i18n-cli/dist/
-COPY --from=build /app/packages/cli/package.json ./node_modules/the-i18n-cli/package.json
-COPY --from=build /app/node_modules/zod ./node_modules/zod
-COPY --from=build /app/node_modules/@modelcontextprotocol ./node_modules/@modelcontextprotocol
 ENV I18N_PROJECT_DIR=/project
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## PR G: Operations, Tests & Documentation

Closes #169

### Changes

1. **Dockerfile: `pnpm deploy` replaces manual COPY**  
   Runtime stage goes from 6 fragile COPY lines to `COPY --from=build /app/prod /app`.  
   `pnpm deploy --legacy` handles the full dependency graph for `the-i18n-mcp` including workspace packages.

2. **`CONTRIBUTING.md`**  
   Setup, architecture overview (CLI + MCP packages), test conventions (mock pattern, temp dirs), adapter extension guide.

3. **CHANGELOG cleanup**  
   Removed duplicate 1.2.0 section and stale bottom boilerplate from pre-release-please era.

### Validated out

| Suggestion | Reason |
|-----------|--------|
| MCP tests | Full test suite too large for this PR. Deferred. |
| Schema dedup (zod-to-json-schema) | Inline schemas are co-located with handlers — extracting adds indirection. Server.ts readability preserved. |

### Stats
- Docker: -4 lines runtime, +1 line build (pnpm deploy)
- CONTRIBUTING.md: +92 lines (new file)
- CHANGELOG: -28 lines
- **Net: +67 lines** (mostly the new CONTRIBUTING.md)