### PR TITLE
feat(cli): expose toErrorMessage in public API

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 // Public API — re-export everything the MCP package (and other consumers) need
 
+// Error utilities (added for MCP error handling)
+
 // Core operations
 export {
   detectConfig,


### PR DESCRIPTION
Release-please trigger: the CLI 1.4.0 on npm is stale — PRs #175/#176 added `toErrorMessage` export but were `refactor:` commits that didn't trigger a version bump. MCP 3.5.0 imports `toErrorMessage` from CLI 1.4.0 which doesn't export it, breaking npm installs.

This commit forces a CLI version bump so release-please publishes the updated CLI with the `toErrorMessage` export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains no user-visible changes. Internal code documentation was updated to clarify error utility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->