### PR TITLE
fix(mcp): bump to republish with CLI 1.5.0 dependency

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 


### PR DESCRIPTION
MCP 3.5.0 on npm pins `the-i18n-cli@1.4.0` which lacks the `toErrorMessage` export. CLI 1.5.0 has it. This forces release-please to bump MCP to 3.5.1 so it republishes with the correct CLI dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes minor code formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->