### PR TITLE
fix(cli): guard stdout against third-party logs

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
-import { runCli } from './cli.js'
-runCli()
+// Install the stdout guard before anything else loads, so third-party logs
+// (e.g. Nuxt modules during config detection) can never pollute the
+// machine-readable output on stdout.
+import { guardStdout } from './utils/stdout-guard.js'
+guardStdout()
+const { runCli } = await import('./cli.js')
+await runCli()

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty'
 import type { CommandDef } from 'citty'
 import { log } from '../utils/logger.js'
+import { writeResult } from '../utils/stdout-guard.js'
 
 /** Factory for commands that call an operation and output its result. */
 export function createCommand(opts: {
@@ -43,11 +44,11 @@ export function outputResult(data: unknown, args: { json?: boolean }): void {
   ) {
     const { reportFile, ...rest } = data as Record<string, unknown>
     log.info(`Wrote report to: ${reportFile}`)
-    process.stdout.write(JSON.stringify(rest, null, 2) + '\n')
+    writeResult(JSON.stringify(rest, null, 2) + '\n')
     return
   }
   // JSON mode emits the full result (including reportFile when present) as pure JSON
-  process.stdout.write(JSON.stringify(data, null, 2) + '\n')
+  writeResult(JSON.stringify(data, null, 2) + '\n')
 }
 
 /** Split a comma-separated string into a trimmed array, or return undefined */

--- a/packages/cli/src/utils/stdout-guard.ts
+++ b/packages/cli/src/utils/stdout-guard.ts
@@ -1,0 +1,18 @@
+const realStdoutWrite = process.stdout.write.bind(process.stdout)
+
+/**
+ * Redirect all subsequent process.stdout writes to stderr. Third-party code
+ * loaded during config detection (e.g. Nuxt modules like nuxt-site-config)
+ * logs straight to stdout, which corrupts the machine-readable JSON output
+ * that CI pipes into jq. Command results still reach the real stdout via
+ * writeResult below.
+ */
+export function guardStdout(): void {
+  process.stdout.write = ((...args: Parameters<typeof process.stdout.write>) =>
+    process.stderr.write(...args)) as typeof process.stdout.write
+}
+
+/** Write to the real stdout, bypassing the guard. */
+export function writeResult(text: string): void {
+  realStdoutWrite(text)
+}


### PR DESCRIPTION
anny-ui's i18n-cleanup job failed on `jq: parse error`: [nuxt-site-config](https://gitlab.com/anny.co/frontend/anny-ui/-/pipelines/2743655129) logged two `[log]` lines straight to stdout during `loadNuxt`, above the CLI's JSON. 1.5.4 fixed the CLI's *own* logger; this fixes the class: the bin entry now installs a stdout guard before any module loads — every `process.stdout.write` from third-party code is rerouted to stderr, and only `outputResult` writes to the real stdout via a saved reference.

Verified against the playground (`remove-orphans` stdout parses clean) and the full suite (576 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output reliability by preventing unexpected logs from interfering with machine-readable results.
  * Preserved JSON output and report-file behavior while routing incidental startup messages separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->