### PR TITLE
fix(ci): cleanup jq backtick escapes + re-land --help stream fix

### DIFF
--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -226,7 +226,7 @@
 
       No orphan keys found in layer \`${I18N_LAYER}\`. All translation keys are referenced in source code."
       else
-        ORPHAN_LIST=$(jq -r '[.orphanKeys | to_entries[] | .value[] | "- \`\(.)\`"] | join("\n")' .i18n-reports/orphans.json)
+        ORPHAN_LIST=$(jq -r '[.orphanKeys | to_entries[] | .value[] | "- `\(.)`"] | join("\n")' .i18n-reports/orphans.json)
         COMMENT="## i18n Cleanup ⚠️
 
       **${ORPHAN_COUNT} orphan key(s) found** in layer \`${I18N_LAYER}\` — keys in locale files with no source code references.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,8 +1,17 @@
 #!/usr/bin/env node
 // Install the stdout guard before anything else loads, so third-party logs
 // (e.g. Nuxt modules during config detection) can never pollute the
-// machine-readable output on stdout.
+// machine-readable output on stdout. Help/version invocations skip the guard:
+// they never load third-party code and their output belongs on stdout
+// (mirrors the flag check in cli.ts, which cannot be imported before the
+// guard decision).
 import { guardStdout } from './utils/stdout-guard.js'
-guardStdout()
+
+const args = process.argv.slice(2)
+const isHelpOrVersion = args.includes('--help') || args.includes('-h')
+  || args.includes('--version') || args.includes('-v')
+if (!isHelpOrVersion) {
+  guardStdout()
+}
 const { runCli } = await import('./cli.js')
 await runCli()

--- a/packages/cli/tests/cli/bin-streams.test.ts
+++ b/packages/cli/tests/cli/bin-streams.test.ts
@@ -1,0 +1,65 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const binPath = resolve(__dirname, '../../dist/bin.js')
+const { version } = createRequire(import.meta.url)('../../package.json') as { version: string }
+
+/**
+ * Stream-level regression tests for the stdout guard: diagnostics must never
+ * pollute stdout (CI pipes it into jq), while --help/--version stay on stdout
+ * per CLI convention. Requires a built dist (CI builds before testing).
+ */
+async function runBin(args: string[], cwd?: string): Promise<{ stdout: string, stderr: string, code: number }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [binPath, ...args], { cwd })
+    return { stdout, stderr, code: 0 }
+  } catch (error) {
+    const e = error as { stdout?: string, stderr?: string, code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: e.code ?? 1 }
+  }
+}
+
+describe('bin stream routing', () => {
+  it('--help prints usage on stdout', async () => {
+    const { stdout, code } = await runBin(['--help'])
+    expect(code).toBe(0)
+    expect(stdout).toContain('USAGE')
+  })
+
+  it('subcommand --help prints usage on stdout', async () => {
+    const { stdout, code } = await runBin(['translate', '--help'])
+    expect(code).toBe(0)
+    expect(stdout).toContain('USAGE')
+  })
+
+  it('--version prints the version on stdout', async () => {
+    const { stdout, code } = await runBin(['--version'])
+    expect(code).toBe(0)
+    expect(stdout.trim()).toBe(version)
+  })
+
+  describe('guarded command output', () => {
+    let emptyDir: string
+
+    beforeAll(async () => {
+      emptyDir = await mkdtemp(join(tmpdir(), 'i18n-bin-streams-'))
+    })
+
+    afterAll(async () => {
+      await rm(emptyDir, { recursive: true, force: true })
+    })
+
+    it('keeps stdout empty when a command fails — diagnostics go to stderr', async () => {
+      const { stdout, stderr, code } = await runBin(['missing', '--layer', 'root'], emptyDir)
+      expect(code).toBe(1)
+      expect(stdout).toBe('')
+      expect(stderr).not.toBe('')
+    })
+  })
+})


### PR DESCRIPTION
Two fixes:

1. **Cleanup job jq compile error** (found via anny-ui verification MR !2000 on CLI 1.5.5): the orphan-list jq program used `\`` string escapes, which jq rejects — the job failed whenever orphans were found. Backticks inside a single-quoted jq program need no escaping. Expression validated against real `remove-orphans` output this time.

2. **Re-lands the `--help` stream fix** (cherry-pick): #199 was merged before this commit reached the branch, so 1.5.5 shipped with help output on stderr. Help/version invocations now skip the stdout guard; spawn-based stream tests pin the contract (580 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Markdown formatting in generated orphan-key merge request comments.
  - Ensured CLI help and version information are displayed correctly on standard output.
  - Improved error handling so failed commands keep diagnostics on standard error without producing unintended standard output.

- **Tests**
  - Added coverage for top-level and subcommand help, version output, and guarded command failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->