### PR TITLE
fix(cli): compact translate output keeps fallback contexts and locale metadata

### DIFF
--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -1557,12 +1557,18 @@ export async function translateMissing(opts: {
   // detail, never the fallback contexts, reasons, or locale metadata that
   // change what the caller does next.
   if (opts.compact) {
-    const byLocale = Object.entries(results).map(([code, r]) => ({
-      locale: code,
-      translated: r.translated.length,
-      failed: r.failed.length,
-      ...(r.reason ? { reason: r.reason } : {}),
-    }))
+    const byLocale = Object.entries(results).map(([code, r]) => {
+      // Reduce per-key arrays to counts; drop per-key placeholder detail;
+      // keep every other per-locale field (samplingUsed, reason, batches,
+      // model, writeError, …).
+      const { translated, failed, placeholderValidation: _placeholderValidation, ...rest } = r
+      return {
+        locale: code,
+        translated: translated.length,
+        failed: failed.length,
+        ...rest,
+      }
+    })
     return {
       summary: { ...summary, byLocale },
       ...(hasFallbackContexts ? { fallbackContexts } : {}),

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -1538,42 +1538,41 @@ export async function translateMissing(opts: {
   const totalTranslated = Object.values(results).reduce((sum, r) => sum + r.translated.length, 0)
   const totalFailed = Object.values(results).reduce((sum, r) => sum + r.failed.length, 0)
 
-  const output: Record<string, unknown> = {
-    results,
-    summary: {
-      samplingSupported,
-      totalTranslated,
-      totalFailed,
-      layer,
-      referenceLocale: localeRefInfo(refLocale),
-      targetLocales: targets.map(localeRefInfo),
-      dryRun: isDryRun,
-    },
+  const summary: Record<string, unknown> = {
+    samplingSupported,
+    totalTranslated,
+    totalFailed,
+    layer,
+    referenceLocale: localeRefInfo(refLocale),
+    targetLocales: targets.map(localeRefInfo),
+    dryRun: isDryRun,
   }
 
-  if (Object.keys(fallbackContexts).length > 0) {
-    output.fallbackContexts = fallbackContexts
-    output.summary = {
-      ...(output.summary as Record<string, unknown>),
-      message: 'Sampling not supported by this host. Use the fallbackContexts to translate inline, then call write_translations (mode: "upsert") to write the results.',
-    }
+  const hasFallbackContexts = Object.keys(fallbackContexts).length > 0
+  if (hasFallbackContexts) {
+    summary.message = 'Sampling not supported by this host. Use the fallbackContexts to translate inline, then call write_translations (mode: "upsert") to write the results.'
   }
 
+  // Compact is a projection of the full result: it may only drop per-key
+  // detail, never the fallback contexts, reasons, or locale metadata that
+  // change what the caller does next.
   if (opts.compact) {
     const byLocale = Object.entries(results).map(([code, r]) => ({
       locale: code,
       translated: r.translated.length,
       failed: r.failed.length,
+      ...(r.reason ? { reason: r.reason } : {}),
     }))
     return {
-      summary: {
-        totalTranslated,
-        totalFailed,
-        byLocale,
-      },
+      summary: { ...summary, byLocale },
+      ...(hasFallbackContexts ? { fallbackContexts } : {}),
     }
   }
 
+  const output: Record<string, unknown> = { results, summary }
+  if (hasFallbackContexts) {
+    output.fallbackContexts = fallbackContexts
+  }
   return output
 }
 

--- a/packages/cli/tests/tools/translate-key.test.ts
+++ b/packages/cli/tests/tools/translate-key.test.ts
@@ -118,13 +118,33 @@ describe('translate_missing compact mode', () => {
       expect.objectContaining({ code: 'es', language: 'es-ES', file: 'es-ES.json' }),
     ])
 
-    // per-locale counts carry the reason
+    // per-locale entries keep all non-key metadata
     expect(result.summary.byLocale).toEqual([
-      expect.objectContaining({ locale: 'es', reason: 'sampling-unavailable' }),
+      expect.objectContaining({ locale: 'es', reason: 'sampling-unavailable', samplingUsed: false }),
     ])
+    expect(result.summary.layer).toBe('root')
+    expect(result.summary.dryRun).toBe(false)
 
     // compact drops only per-key detail
     expect(result.results).toBeUndefined()
+  })
+
+  it('reports dryRun in compact output', async () => {
+    const result = await translateMissing({
+      projectDir: appAdminDir,
+      layer: 'root',
+      referenceLocale: 'de-DE',
+      targetLocales: ['es-ES'],
+      keys: ['admin.users.list'],
+      compact: true,
+      dryRun: true,
+    })
+
+    expect(result.summary.dryRun).toBe(true)
+    expect(result.summary.byLocale).toEqual([
+      expect.objectContaining({ locale: 'es', translated: 1, reason: 'dry-run' }),
+    ])
+    expect(result.fallbackContexts).toBeUndefined()
   })
 
   it('omits fallback contexts from compact output when nothing is missing', async () => {

--- a/packages/cli/tests/tools/translate-key.test.ts
+++ b/packages/cli/tests/tools/translate-key.test.ts
@@ -95,6 +95,57 @@ describe('placeholder validation', () => {
   })
 })
 
+describe('translate_missing compact mode', () => {
+  it('keeps fallback contexts, message, reasons, and locale metadata in compact output', async () => {
+    const result = await translateMissing({
+      projectDir: appAdminDir,
+      layer: 'root',
+      referenceLocale: 'de-DE',
+      targetLocales: ['es-ES'],
+      keys: ['admin.users.list'],
+      compact: true,
+      // no samplingFn — the no-backend fallback path
+    })
+
+    // fallback contexts survive compaction, with the write-back guidance
+    expect(result.fallbackContexts).toHaveProperty('es')
+    expect(result.summary.message).toContain('write_translations')
+    expect(result.summary.samplingSupported).toBe(false)
+
+    // locale metadata as full triples
+    expect(result.summary.referenceLocale).toMatchObject({ code: 'de', language: 'de-DE', file: 'de-DE.json' })
+    expect(result.summary.targetLocales).toEqual([
+      expect.objectContaining({ code: 'es', language: 'es-ES', file: 'es-ES.json' }),
+    ])
+
+    // per-locale counts carry the reason
+    expect(result.summary.byLocale).toEqual([
+      expect.objectContaining({ locale: 'es', reason: 'sampling-unavailable' }),
+    ])
+
+    // compact drops only per-key detail
+    expect(result.results).toBeUndefined()
+  })
+
+  it('omits fallback contexts from compact output when nothing is missing', async () => {
+    const result = await translateMissing({
+      projectDir: appAdminDir,
+      layer: 'root',
+      referenceLocale: 'de-DE',
+      targetLocales: ['es-ES'],
+      keys: ['admin.dashboard.title'],
+      compact: true,
+    })
+
+    expect(result.fallbackContexts).toBeUndefined()
+    expect(result.summary.message).toBeUndefined()
+    expect(result.summary.totalTranslated).toBe(0)
+    expect(result.summary.byLocale).toEqual([
+      expect.objectContaining({ locale: 'es', reason: 'no-missing-keys' }),
+    ])
+  })
+})
+
 describe('translate_missing metadata', () => {
   it('returns locale metadata and per-locale reason', async () => {
     const result = await translateMissing({


### PR DESCRIPTION
Implements #204 (first slice of spec #198).

`translate_missing({compact: true})` in a host without a translation backend previously returned `{totalTranslated: 0, totalFailed: N, byLocale}` and nothing else — the advertised inline-translation fallback was built and then discarded by the compact projection. This was the single worst finding of the original field report.

Compact output now carries:
- `fallbackContexts` + the `write_translations` guidance message (when present)
- `samplingSupported`, `layer`, `dryRun`
- `referenceLocale` / `targetLocales` as `{code, language, file}` triples
- per-locale `reason` in `byLocale`

Non-compact output is byte-identical to before (same fields, same order). Tested through the public `translateMissing` operation against the fixture project — fallback path and no-missing-keys path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact translation output to retain locale details, dry-run and sampling status, fallback context, and per-locale reasons.
  * Ensured fallback messages appear consistently across compact and full output formats.
  * Removed fallback information when no translations are missing.

* **Tests**
  * Added coverage for compact-mode summaries, metadata, fallback handling, and omission of per-key results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->