### PR TITLE
feat(mcp): align with MCP 2026-07-28 direction — SDK 1.30, stateless resources

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ export {
 export * from './core/types.js'
 
 // Config
-export { detectI18nConfig, getCachedConfig } from './config/detector.js'
+export { detectI18nConfig, getCachedConfig, clearConfigCache } from './config/detector.js'
 export type { I18nConfig, LocaleDefinition, LocaleDir, ProjectConfig } from './config/types.js'
 
 // IO

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.23.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "the-i18n-cli": "workspace:*",
     "zod": "^4.3.6"
   },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -139,8 +139,8 @@ export function createServer(): McpServer {
       description:
         'Discover the complete i18n setup. Returns project config (locales, default locale, layers, '
         + 'fallback chain, glossary, translation style) plus per-layer directory listings with file '
-        + 'counts and top-level key namespaces. Call this first — it warms the config cache that all '
-        + 'other tools depend on.',
+        + 'counts and top-level key namespaces. Call this first to understand the project before '
+        + 'reading or writing translations.',
       inputSchema: {
         projectDir: z
           .string()
@@ -751,11 +751,14 @@ export function createServer(): McpServer {
 
   // ─── Resources ────────────────────────────────────────────────
 
+  // Resources resolve their own config (cached after first detection) — no
+  // prior discover call required. Cross-call ordering dependencies are
+  // incompatible with the stateless request/response model of MCP 2026-07-28.
   server.registerResource(
     'locale-file',
     new ResourceTemplate('i18n:///{layer}/{locale}', {
       list: async () => {
-        const config = getCachedConfig()
+        const config = getCachedConfig() ?? await detectI18nConfig(DEFAULT_PROJECT_DIR).catch(() => null)
         if (!config) {
           return { resources: [] }
         }
@@ -786,10 +789,7 @@ export function createServer(): McpServer {
       mimeType: 'application/json',
     },
     async (uri, { layer, locale }) => {
-      const config = getCachedConfig()
-      if (!config) {
-        throw new Error('No i18n config detected yet. Call discover first.')
-      }
+      const config = getCachedConfig() ?? await detectI18nConfig(DEFAULT_PROJECT_DIR)
       const localeDef = findLocaleImpl(config, locale as string)
       if (!localeDef) {
         throw new Error(`Locale not found: ${locale}`)

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { createServer } from '../src/server.js'
+import { clearConfigCache } from 'the-i18n-cli'
 
 /**
  * Transport-level tests: a linked client/server pair over the SDK's in-memory
@@ -37,6 +37,10 @@ beforeAll(async () => {
   }))
   await writeFile(join(localesDir, 'en.json'), '{}\n')
 
+  // The server captures its default project dir from the environment at
+  // module load — set it before importing so resources can self-resolve.
+  process.env.I18N_PROJECT_DIR = projectDir
+  const { createServer } = await import('../src/server.js')
   const server = createServer()
   client = new Client({ name: 'test-client', version: '0.0.0' })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -71,6 +75,13 @@ describe('the-i18n-mcp server over in-memory transport', () => {
       'translate_missing',
       'write_translations',
     ])
+  })
+
+  it('reads a locale resource with a cold cache — no prior discover call', async () => {
+    clearConfigCache()
+    const result = await client.readResource({ uri: 'i18n:///root/de' })
+    const content = result.contents[0] as { text: string }
+    expect(JSON.parse(content.text)).toMatchObject({ greeting: 'Hallo {name}' })
   })
 
   it('discover returns the project configuration', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 0.30.1
       '@google/genai':
         specifier: ^2.0.0
-        version: 2.8.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
+        version: 2.8.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))
       citty:
         specifier: ^0.2.2
         version: 0.2.2
@@ -79,8 +79,8 @@ importers:
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.23.0
-        version: 1.27.1(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.3.6)
       the-i18n-cli:
         specifier: workspace:*
         version: link:../cli
@@ -892,8 +892,8 @@ packages:
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -5721,14 +5721,14 @@ snapshots:
   '@fallow-cli/win32-x64-msvc@2.93.0':
     optional: true
 
-  '@google/genai@2.8.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
+  '@google/genai@2.8.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.6.4
       ws: 8.19.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5892,7 +5892,7 @@ snapshots:
       json5: 2.2.3
       rollup: 4.59.0
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0


### PR DESCRIPTION
First concrete slice of MCP 2026-07-28 alignment (from the [spec changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog) and [Claude's announcement](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude)).

**Reality check**: the latest TS SDK (1.30.0) speaks protocol **2025-11-25** — the 2026-07-28 draft's wire-level changes (stateless `_meta` negotiation, `server/discover`, `resultType`, `ttlMs`/`cacheScope`, MRTR, tasks extension) require a future SDK release. What we can do now:

- **SDK bump** ^1.23 → ^1.30 (zero code changes needed; all transport tests pass)
- **Kill our one stateless-model violation**: resources required a prior `discover` call to warm the config cache — exactly the cross-call ordering state SEP-2567/2575 forbid. They now self-resolve config on demand; proven by a cold-cache resource-read test.
- Where we're already aligned: sampling removal is in flight (#208), diagnostics go to stderr (the spec's suggested Logging migration), `includeContext: 'none'`, deterministic tool registration order.

The SDK-blocked remainder is tracked in a follow-up issue with the full checklist.

CLI 567 · MCP 7 · lint clean · both typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)