### PR TITLE
feat(cli)!: honest translate result contract — mode, failed/skipped reasons, wouldTranslate

### DIFF
--- a/.fallow-baselines/dupes.json
+++ b/.fallow-baselines/dupes.json
@@ -2,16 +2,16 @@
   "clone_groups": [
     "packages/cli/src/adapters/react/index.ts:45-60|packages/cli/src/adapters/vue/index.ts:48-63",
     "packages/cli/src/adapters/react/index.ts:76-111|packages/cli/src/adapters/vue/index.ts:80-112",
-    "packages/cli/src/core/operations.ts:236-245|packages/cli/src/core/operations.ts:249-258",
-    "packages/cli/src/core/operations.ts:661-676|packages/cli/src/core/operations.ts:708-729",
-    "packages/cli/src/core/operations.ts:1285-1291|packages/cli/src/core/operations.ts:807-814",
-    "packages/cli/src/core/operations.ts:815-834|packages/cli/src/core/operations.ts:913-935",
-    "packages/cli/src/core/operations.ts:1302-1311|packages/cli/src/core/operations.ts:816-828",
-    "packages/cli/src/core/operations.ts:1027-1036|packages/cli/src/core/operations.ts:942-951",
-    "packages/cli/src/core/operations.ts:1096-1106|packages/cli/src/core/operations.ts:1176-1186",
-    "packages/cli/src/core/operations.ts:1833-1846|packages/cli/src/core/operations.ts:2021-2028",
-    "packages/cli/src/core/operations.ts:1856-1869|packages/cli/src/core/operations.ts:2046-2058",
-    "packages/cli/src/core/operations.ts:2202-2208|packages/cli/src/core/operations.ts:2209-2215",
+    "packages/cli/src/core/operations.ts:240-249|packages/cli/src/core/operations.ts:253-262",
+    "packages/cli/src/core/operations.ts:665-680|packages/cli/src/core/operations.ts:712-733",
+    "packages/cli/src/core/operations.ts:1289-1295|packages/cli/src/core/operations.ts:811-818",
+    "packages/cli/src/core/operations.ts:819-838|packages/cli/src/core/operations.ts:917-939",
+    "packages/cli/src/core/operations.ts:1306-1315|packages/cli/src/core/operations.ts:820-832",
+    "packages/cli/src/core/operations.ts:1031-1040|packages/cli/src/core/operations.ts:946-955",
+    "packages/cli/src/core/operations.ts:1100-1110|packages/cli/src/core/operations.ts:1180-1190",
+    "packages/cli/src/core/operations.ts:1858-1871|packages/cli/src/core/operations.ts:2046-2053",
+    "packages/cli/src/core/operations.ts:1881-1894|packages/cli/src/core/operations.ts:2071-2083",
+    "packages/cli/src/core/operations.ts:2227-2233|packages/cli/src/core/operations.ts:2234-2240",
     "packages/cli/src/io/key-operations.ts:23-29|packages/cli/src/io/key-operations.ts:42-49",
     "packages/cli/src/io/locale-data.ts:229-243|packages/cli/src/io/locale-data.ts:252-266",
     "packages/cli/tests/adapters/generic-adapter.test.ts:52-65|packages/cli/tests/adapters/laravel-adapter.test.ts:53-66|packages/cli/tests/adapters/react-adapter.test.ts:51-64|packages/cli/tests/adapters/vue-adapter.test.ts:48-61",
@@ -73,7 +73,7 @@
     "packages/cli/tests/tools/remove-and-rename.test.ts:151-158|packages/cli/tests/tools/remove-and-rename.test.ts:74-81",
     "packages/cli/tests/tools/remove-and-rename.test.ts:126-131|packages/cli/tests/tools/remove-and-rename.test.ts:244-249",
     "packages/cli/tests/tools/remove-and-rename.test.ts:147-157|packages/cli/tests/tools/remove-and-rename.test.ts:175-186",
-    "packages/cli/tests/tools/translate-key.test.ts:113-122|packages/cli/tests/tools/translate-key.test.ts:178-184",
-    "packages/cli/tests/tools/translate-seam.test.ts:31-36|packages/mcp/tests/server.test.ts:27-32"
+    "packages/cli/tests/tools/translate-key.test.ts:117-126|packages/cli/tests/tools/translate-key.test.ts:183-189",
+    "packages/cli/tests/tools/translate-seam.test.ts:31-36|packages/mcp/tests/server.test.ts:26-31"
   ]
 }

--- a/.fallow-baselines/health.json
+++ b/.fallow-baselines/health.json
@@ -32,6 +32,11 @@
         "count": 1
       }
     },
+    "packages/cli/src/commands/translate-key.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
     "packages/cli/src/commands/translate.ts": {
       "crap_high": {
         "count": 1
@@ -57,6 +62,9 @@
       },
       "crap_critical": {
         "count": 4
+      },
+      "crap_high": {
+        "count": 1
       },
       "crap_moderate": {
         "count": 2

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,8 @@ runs:
         output=$(the-i18n-cli translate "${args[@]}")
         echo "$output"
 
-        count=$(echo "$output" | jq -r '.summary.totalTranslated // 0')
+        # Dry runs report their counts as totalWouldTranslate
+        count=$(echo "$output" | jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)')
         failed=$(echo "$output" | jq -r '.summary.totalFailed // 0')
         echo "translated_count=$count" >> "$GITHUB_OUTPUT"
         echo "failed_count=$failed" >> "$GITHUB_OUTPUT"

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -116,8 +116,9 @@
       mkdir -p .i18n-reports
       the-i18n-cli translate $args | tee .i18n-reports/translate-output.json
 
-      # Tolerant parse: older CLI versions (< 1.5.4) mixed logs into stdout
-      TRANSLATED=$(jq -r '.summary.totalTranslated // 0' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
+      # Tolerant parse: older CLI versions (< 1.5.4) mixed logs into stdout.
+      # Dry runs report their counts as totalWouldTranslate.
+      TRANSLATED=$(jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       FAILED=$(jq -r '.summary.totalFailed // 0' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       echo "Translated: $TRANSLATED, failed: $FAILED"
       if [ "$FAILED" != "?" ] && [ "$FAILED" -gt 0 ] && [ "$TRANSLATED" = "0" ]; then

--- a/packages/cli/src/commands/translate-key.ts
+++ b/packages/cli/src/commands/translate-key.ts
@@ -14,9 +14,9 @@ export default createCommand({
     sourceValue: { type: 'string', description: 'Optional source value to write before translating' },
     targets: { type: 'string', description: 'Comma-separated target locales, or "all"/omitted for all except source' },
     overwrite: { type: 'boolean', description: 'Overwrite existing target translations (default true)', default: true },
-    dryRun: { type: 'boolean', description: 'Preview without writing or sampling', default: false },
+    dryRun: { type: 'boolean', description: 'Preview without writing or translating', default: false },
     includePreview: { type: 'boolean', description: 'Include translated values in output', default: false },
-    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback context.', valueHint: 'openai|anthropic|google' },
+    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
     model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
     apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
   },
@@ -35,7 +35,7 @@ export default createCommand({
       })
     }
 
-    return translateKey({
+    const result = await translateKey({
       layer: args.layer,
       key: args.key,
       sourceLocale: args.sourceLocale,
@@ -47,5 +47,13 @@ export default createCommand({
       projectDir: args.projectDir,
       translateFn,
     })
+
+    // CLI-owned guidance: agent mode here just means no provider was given
+    if (result.mode === 'agent' && result.skipped.some(s => s.reason === 'no-provider')) {
+      result.message = 'No provider configured — nothing was translated. Pass --provider and --model '
+        + '(API key via --apiKey or the OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env vars) '
+        + 'to translate automatically.'
+    }
+    return result
   },
 })

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -13,7 +13,7 @@ export default createCommand({
     targets: { type: 'string', description: 'Comma-separated target locales (default: all except ref)' },
     keys: { type: 'string', description: 'Comma-separated keys to translate (default: all missing)' },
     batchSize: { type: 'string', description: 'Batch size (default: 50)' },
-    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Without this, only returns fallback contexts.', valueHint: 'openai|anthropic|google' },
+    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
     model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
     apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
     dryRun: { type: 'boolean', description: 'Preview what would be translated', default: false },
@@ -40,7 +40,7 @@ export default createCommand({
       })
     }
 
-    return translateMissing({
+    const result = await translateMissing({
       layer: args.layer,
       referenceLocale: args.ref,
       targetLocales: splitList(args.targets),
@@ -50,5 +50,14 @@ export default createCommand({
       projectDir: args.projectDir,
       translateFn,
     })
+
+    // CLI-owned guidance: agent mode here just means no provider was given
+    const summary = result.summary as Record<string, unknown> | undefined
+    if (summary?.mode === 'agent') {
+      summary.message = 'No provider configured — nothing was translated. Pass --provider and --model '
+        + '(API key via --apiKey or the OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env vars) '
+        + 'to translate automatically.'
+    }
+    return result
   },
 })

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -34,6 +34,10 @@ import type {
   SearchMatch,
   TranslateFn,
   ProgressFn,
+  TranslateMode,
+  TranslateFailReason,
+  TranslateSkipReason,
+  TranslateKeyLocaleIssue,
   TranslateMissingLocaleResult,
   AddTranslationsResult,
   WriteTranslationsResult,
@@ -285,7 +289,7 @@ export async function applyTranslations(
   return result
 }
 
-// ─── Sampling prompt helpers ────────────────────────────────────
+// ─── Translation prompt helpers ─────────────────────────────────
 
 export function extractPlaceholders(value: string, format?: LocaleFileFormat): string[] {
   const placeholders = new Set<string>()
@@ -1308,7 +1312,7 @@ export async function translateMissing(opts: {
       })
     : config.locales.filter(l => l.code !== refLocale.code)
 
-  const samplingSupported = !!opts.translateFn
+  const mode: TranslateMode = isDryRun ? 'dry-run' : opts.translateFn ? 'provider' : 'agent'
   const reportProgress = opts.progressFn ?? (async () => {})
 
   /** Check whether a key is missing in a given locale data object */
@@ -1335,9 +1339,9 @@ export async function translateMissing(opts: {
       } catch {}
       preScanCounts.push(countMissingKeys(scanData))
     }
-    // In dry-run or no-sampling mode, only 2 steps per locale (start + complete),
-    // no batch steps. Full batching only when sampling is available and not dry-run.
-    const willBatch = !isDryRun && samplingSupported
+    // In dry-run or agent mode, only 2 steps per locale (start + complete),
+    // no batch steps. Full batching only in provider mode.
+    const willBatch = mode === 'provider'
     const total = willBatch
       ? computeProgressTotal(preScanCounts, maxBatch)
       : preScanCounts.filter(c => c > 0).length * 2
@@ -1369,7 +1373,7 @@ export async function translateMissing(opts: {
     }
 
     if (missingKeys.length === 0) {
-      return { result: { translated: [], failed: [], samplingUsed: false, reason: 'no-missing-keys' } }
+      return { result: { mode, missing: 0, translated: [], failed: [], skipped: [] } }
     }
 
     await reportProgress(`Starting ${target.code}: ${missingKeys.length} missing keys`)
@@ -1382,19 +1386,20 @@ export async function translateMissing(opts: {
         keysAndValues[key] = value
       }
     }
+    const missing = Object.keys(keysAndValues).length
 
     if (isDryRun) {
       await reportProgress(`Complete ${target.code} (dry run)`)
-      return { result: { translated: Object.keys(keysAndValues), failed: [], samplingUsed: samplingSupported, reason: 'dry-run' } }
+      return { result: { mode: 'dry-run', missing, translated: [], wouldTranslate: Object.keys(keysAndValues), failed: [], skipped: [] } }
     }
 
-    if (samplingSupported && opts.translateFn) {
+    if (opts.translateFn) {
       const translated: string[] = []
-      const failed: string[] = []
+      const failed: Array<{ key: string, reason: TranslateFailReason }> = []
       const keyEntries = Object.entries(keysAndValues)
       const allTranslations: Record<string, string> = {}
       const totalBatches = Math.ceil(keyEntries.length / maxBatch)
-      let samplingModel: string | undefined
+      let model: string | undefined
 
       for (let i = 0; i < keyEntries.length; i += maxBatch) {
         const batchNum = Math.floor(i / maxBatch) + 1
@@ -1415,16 +1420,16 @@ export async function translateMissing(opts: {
             await new Promise(r => setTimeout(r, delayMs))
           }
           try {
-            const samplingResult = await opts.translateFn({
+            const response = await opts.translateFn({
               systemPrompt,
               userMessage,
               maxTokens: computeMaxTokens(Object.keys(batch).length),
             })
 
-            samplingModel = samplingResult.model
-            log.info(`Sampling model: ${samplingResult.model}`)
+            model = response.model
+            log.info(`Translation model: ${response.model}`)
 
-            const parsed = extractJsonFromResponse(samplingResult.text)
+            const parsed = extractJsonFromResponse(response.text)
             const batchKeys = new Set(Object.keys(batch))
             batchTranslations = {} as Record<string, string>
             for (const [key, value] of Object.entries(parsed)) {
@@ -1436,24 +1441,23 @@ export async function translateMissing(opts: {
           } catch (_error) {
             const errMsg = _error instanceof Error ? _error.message : String(_error)
             if (attempt === 0) {
-              log.warn(`Sampling failed for batch ${batchNum} in ${target.code}: ${errMsg}. Retrying (attempt 2)`)
+              log.warn(`Translate request failed for batch ${batchNum} in ${target.code}: ${errMsg}. Retrying (attempt 2)`)
             } else {
-              log.warn(`Sampling retry failed for batch ${batchNum} in ${target.code}: ${errMsg}`)
+              log.warn(`Translate retry failed for batch ${batchNum} in ${target.code}: ${errMsg}`)
             }
           }
         }
 
-        const validTranslations = batchTranslations !== null
-          ? Object.entries(batchTranslations).filter(([, v]) => typeof v === 'string')
-          : []
-
-        if (validTranslations.length > 0) {
-          for (const [key, value] of validTranslations) {
+        // Account for every batch key: translated, omitted by the model,
+        // or lost to a failed batch — totals must always reconcile.
+        for (const key of Object.keys(batch)) {
+          const value = batchTranslations?.[key]
+          if (typeof value === 'string') {
             allTranslations[key] = value
             translated.push(key)
+          } else {
+            failed.push({ key, reason: batchTranslations === null ? 'provider-error' : 'omitted-by-model' })
           }
-        } else {
-          failed.push(...Object.keys(batch))
         }
 
         await reportProgress(`${target.code}: batch ${batchNum}/${totalBatches}`)
@@ -1467,7 +1471,7 @@ export async function translateMissing(opts: {
         const invalidKeys = new Set(placeholderValidation.errors.map(error => error.key))
         for (const key of invalidKeys) {
           delete allTranslations[key]
-          if (!failed.includes(key)) failed.push(key)
+          failed.push({ key, reason: 'placeholder-mismatch' })
         }
         for (const key of [...translated]) {
           if (invalidKeys.has(key)) translated.splice(translated.indexOf(key), 1)
@@ -1483,14 +1487,19 @@ export async function translateMissing(opts: {
           })
         } catch (error) {
           log.warn(`Failed to write translations for ${target.code}: ${toErrorMessage(error)}`)
-          return { result: { translated: [], failed: [...Object.keys(keysAndValues)], samplingUsed: true, reason: 'translated-with-sampling', batches: totalBatches, model: samplingModel, writeError: toErrorMessage(error) } }
+          // Only the keys that were about to be written failed on write;
+          // earlier failures keep their own reasons.
+          for (const key of translated) {
+            failed.push({ key, reason: 'write-error' })
+          }
+          return { result: { mode: 'provider', missing, translated: [], failed, skipped: [], batches: totalBatches, model, writeError: toErrorMessage(error) } }
         }
       }
 
       await reportProgress(`Complete ${target.code}`)
-      return { result: { translated, failed, samplingUsed: true, reason: 'translated-with-sampling', batches: totalBatches, model: samplingModel, ...(placeholderValidation ? { placeholderValidation } : {}) } }
+      return { result: { mode: 'provider', missing, translated, failed, skipped: [], batches: totalBatches, model, ...(placeholderValidation ? { placeholderValidation } : {}) } }
     } else {
-      // Fallback: return context for agent to translate inline
+      // Agent mode: return context for the host agent to translate inline
       const fallbackContext = buildFallbackContext(
         config.projectConfig,
         refLocale!.language || refLocale!.code,
@@ -1498,7 +1507,16 @@ export async function translateMissing(opts: {
         keysAndValues,
       )
       await reportProgress(`Complete ${target.code}`)
-      return { result: { translated: [], failed: Object.keys(keysAndValues), samplingUsed: false, reason: 'sampling-unavailable' }, fallbackContext }
+      return {
+        result: {
+          mode: 'agent',
+          missing,
+          translated: [],
+          failed: [],
+          skipped: Object.keys(keysAndValues).map(key => ({ key, reason: 'no-provider' as const })),
+        },
+        fallbackContext,
+      }
     }
   }
 
@@ -1517,11 +1535,15 @@ export async function translateMissing(opts: {
 
   const totalTranslated = Object.values(results).reduce((sum, r) => sum + r.translated.length, 0)
   const totalFailed = Object.values(results).reduce((sum, r) => sum + r.failed.length, 0)
+  const totalSkipped = Object.values(results).reduce((sum, r) => sum + r.skipped.length, 0)
+  const totalWouldTranslate = Object.values(results).reduce((sum, r) => sum + (r.wouldTranslate?.length ?? 0), 0)
 
   const summary: Record<string, unknown> = {
-    samplingSupported,
+    mode,
     totalTranslated,
     totalFailed,
+    totalSkipped,
+    ...(isDryRun ? { totalWouldTranslate } : {}),
     layer,
     referenceLocale: localeRefInfo(refLocale),
     targetLocales: targets.map(localeRefInfo),
@@ -1529,9 +1551,6 @@ export async function translateMissing(opts: {
   }
 
   const hasFallbackContexts = Object.keys(fallbackContexts).length > 0
-  if (hasFallbackContexts) {
-    summary.message = 'Sampling not supported by this host. Use the fallbackContexts to translate inline, then call write_translations (mode: "upsert") to write the results.'
-  }
 
   // Compact is a projection of the full result: it may only drop per-key
   // detail, never the fallback contexts, reasons, or locale metadata that
@@ -1539,13 +1558,15 @@ export async function translateMissing(opts: {
   if (opts.compact) {
     const byLocale = Object.entries(results).map(([code, r]) => {
       // Reduce per-key arrays to counts; drop per-key placeholder detail;
-      // keep every other per-locale field (samplingUsed, reason, batches,
-      // model, writeError, …).
-      const { translated, failed, placeholderValidation: _placeholderValidation, ...rest } = r
+      // keep every other per-locale field (mode, missing, batches, model,
+      // writeError, …).
+      const { translated, failed, skipped, wouldTranslate, placeholderValidation: _placeholderValidation, ...rest } = r
       return {
         locale: code,
         translated: translated.length,
         failed: failed.length,
+        skipped: skipped.length,
+        ...(wouldTranslate ? { wouldTranslate: wouldTranslate.length } : {}),
         ...rest,
       }
     })
@@ -1618,22 +1639,22 @@ export async function translateKey(opts: {
   }
 
   const existingTargets: Array<{ locale: LocaleDefinition, existingValue: unknown }> = []
-  const failed: Array<string | { locale: string, error: string }> = []
+  const failed: TranslateKeyLocaleIssue[] = []
   for (const locale of targetLocales) {
     try {
       const data = await readLocaleData(config, opts.layer, locale)
       existingTargets.push({ locale, existingValue: getNestedValue(data, opts.key) })
     } catch (error) {
-      failed.push({ locale: locale.code, error: toErrorMessage(error) })
+      failed.push({ locale: locale.code, reason: 'read-error', detail: toErrorMessage(error) })
     }
   }
 
   const targetsToTranslate = existingTargets.filter(({ existingValue }) => {
     return overwrite || existingValue === undefined || existingValue === '' || existingValue === null
   })
-  const skipped = existingTargets
+  const skipped: Array<{ locale: string, reason: TranslateSkipReason }> = existingTargets
     .filter(({ existingValue }) => !overwrite && existingValue !== undefined && existingValue !== '' && existingValue !== null)
-    .map(({ locale }) => locale.code)
+    .map(({ locale }) => ({ locale: locale.code, reason: 'already-translated' as const }))
 
   const basePlaceholderValidation = validatePlaceholders(opts.key, sourceValue, [{ locale: sourceLocale.code, value: sourceValue }], config.localeFileFormat)
 
@@ -1642,13 +1663,13 @@ export async function translateKey(opts: {
       key: opts.key,
       sourceLocale: localeRefInfo(sourceLocale),
       updatedSource,
-      translated: targetsToTranslate.map(({ locale }) => locale.code),
+      mode: 'dry-run',
+      translated: [],
+      wouldTranslate: targetsToTranslate.map(({ locale }) => locale.code),
       skipped,
       failed,
       filesWritten: 0,
       dryRun: true,
-      samplingUsed: !!opts.translateFn,
-      reason: 'dry-run',
       placeholderValidation: basePlaceholderValidation,
       ...(opts.includePreview ? { preview } : {}),
     }
@@ -1659,29 +1680,32 @@ export async function translateKey(opts: {
       key: opts.key,
       sourceLocale: localeRefInfo(sourceLocale),
       updatedSource,
+      mode: opts.translateFn ? 'provider' : 'agent',
       translated: [],
       skipped,
       failed,
       filesWritten,
       dryRun: false,
-      samplingUsed: false,
       placeholderValidation: basePlaceholderValidation,
       ...(opts.includePreview ? { preview } : {}),
     }
   }
 
   if (!opts.translateFn) {
+    // Agent mode: nothing was attempted — targets are skipped, not failed.
     return {
       key: opts.key,
       sourceLocale: localeRefInfo(sourceLocale),
       updatedSource,
+      mode: 'agent',
       translated: [],
-      skipped,
-      failed: [...failed, ...targetsToTranslate.map(({ locale }) => locale.code)],
+      skipped: [
+        ...skipped,
+        ...targetsToTranslate.map(({ locale }) => ({ locale: locale.code, reason: 'no-provider' as const })),
+      ],
+      failed,
       filesWritten,
       dryRun: false,
-      samplingUsed: false,
-      reason: 'sampling-unavailable',
       placeholderValidation: basePlaceholderValidation,
       fallbackContext: buildFallbackContext(
         config.projectConfig,
@@ -1695,10 +1719,11 @@ export async function translateKey(opts: {
 
   const translated: string[] = []
   const placeholderValidations: PlaceholderValidationResult[] = [basePlaceholderValidation]
-  let samplingModel: string | undefined
+  let model: string | undefined
 
   for (const { locale } of targetsToTranslate) {
     let targetValue: string | undefined
+    let requestFailed = false
     const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, locale.language || locale.code, config.localeFileFormat)
     const userMessage = buildTranslationUserMessage(
       sourceLocale.language || sourceLocale.code,
@@ -1708,30 +1733,31 @@ export async function translateKey(opts: {
     )
 
     try {
-      const samplingResult = await opts.translateFn({
+      const response = await opts.translateFn({
         systemPrompt,
         userMessage,
         maxTokens: computeMaxTokens(1),
       })
-      samplingModel = samplingResult.model
-      const parsed = extractJsonFromResponse(samplingResult.text)
+      model = response.model
+      const parsed = extractJsonFromResponse(response.text)
       const parsedValue = parsed[opts.key]
       if (typeof parsedValue === 'string') {
         targetValue = parsedValue
       }
     } catch (error) {
-      log.warn(`Sampling failed for ${locale.code}: ${toErrorMessage(error)}`)
+      requestFailed = true
+      log.warn(`Translate request failed for ${locale.code}: ${toErrorMessage(error)}`)
     }
 
     if (!targetValue) {
-      failed.push(locale.code)
+      failed.push({ locale: locale.code, reason: requestFailed ? 'provider-error' : 'omitted-by-model' })
       continue
     }
 
     const validation = validatePlaceholders(opts.key, sourceValue, [{ locale: locale.code, value: targetValue }], config.localeFileFormat)
     placeholderValidations.push(validation)
     if (!validation.ok) {
-      failed.push(locale.code)
+      failed.push({ locale: locale.code, reason: 'placeholder-mismatch' })
       continue
     }
 
@@ -1743,7 +1769,7 @@ export async function translateKey(opts: {
       filesWritten += written.size
       translated.push(locale.code)
     } catch (error) {
-      failed.push({ locale: locale.code, error: toErrorMessage(error) })
+      failed.push({ locale: locale.code, reason: 'write-error', detail: toErrorMessage(error) })
     }
   }
 
@@ -1751,14 +1777,13 @@ export async function translateKey(opts: {
     key: opts.key,
     sourceLocale: localeRefInfo(sourceLocale),
     updatedSource,
+    mode: 'provider',
     translated,
     skipped,
     failed,
     filesWritten,
     dryRun: false,
-    samplingUsed: true,
-    reason: 'translated-with-sampling',
-    model: samplingModel,
+    model,
     placeholderValidation: mergePlaceholderValidation(placeholderValidations) ?? basePlaceholderValidation,
     ...(opts.includePreview ? { preview } : {}),
   }

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -206,11 +206,29 @@ export interface RenameTranslationKeyResult {
 
 // ─── translate_missing ───────────────────────────────────────────
 
+/** How a translate run was (or would be) executed. */
+export type TranslateMode = 'provider' | 'agent' | 'dry-run'
+
+/** Why a key could not be translated. */
+export type TranslateFailReason =
+  | 'provider-error'
+  | 'omitted-by-model'
+  | 'placeholder-mismatch'
+  | 'write-error'
+
+/** Why a key or locale was intentionally not attempted. */
+export type TranslateSkipReason = 'no-provider' | 'already-translated'
+
 export interface TranslateMissingLocaleResult {
+  mode: TranslateMode
+  /** Number of missing keys found for this locale. Always equals
+   *  translated + wouldTranslate + failed + skipped. */
+  missing: number
   translated: string[]
-  failed: string[]
-  samplingUsed: boolean
-  reason?: 'no-missing-keys' | 'dry-run' | 'translated-with-sampling' | 'sampling-unavailable'
+  /** Dry-run only: keys that would be translated. */
+  wouldTranslate?: string[]
+  failed: Array<{ key: string, reason: TranslateFailReason }>
+  skipped: Array<{ key: string, reason: TranslateSkipReason }>
   batches?: number
   model?: string
   writeError?: string
@@ -221,39 +239,46 @@ export interface TranslateMissingResult {
   results: Record<string, TranslateMissingLocaleResult>
   fallbackContexts?: Record<string, Record<string, unknown>>
   summary: {
-    samplingSupported: boolean
+    mode: TranslateMode
     totalTranslated: number
     totalFailed: number
+    totalSkipped: number
+    totalWouldTranslate?: number
     layer: string
     referenceLocale: string | LocaleRefInfo
     targetLocales: Array<string | LocaleRefInfo>
     dryRun: boolean
+    /** Surface-owned guidance (set by the CLI command or MCP tool, not the core). */
     message?: string
   }
 }
 
 // ─── translate_key ───────────────────────────────────────────────
 
-export interface TranslateKeyFailure {
+export interface TranslateKeyLocaleIssue {
   locale: string
-  error: string
+  reason: TranslateFailReason | 'read-error'
+  detail?: string
 }
 
 export interface TranslateKeyResult {
   key: string
   sourceLocale: LocaleRefInfo
   updatedSource: boolean
+  mode: TranslateMode
   translated: string[]
-  skipped: string[]
-  failed: Array<string | TranslateKeyFailure>
+  /** Dry-run only: locales that would be translated. */
+  wouldTranslate?: string[]
+  skipped: Array<{ locale: string, reason: TranslateSkipReason }>
+  failed: TranslateKeyLocaleIssue[]
   filesWritten: number
   dryRun: boolean
-  samplingUsed: boolean
-  reason?: 'dry-run' | 'translated-with-sampling' | 'sampling-unavailable'
   model?: string
   placeholderValidation: PlaceholderValidationResult
   preview?: Record<string, string>
   fallbackContext?: Record<string, unknown>
+  /** Surface-owned guidance (set by the CLI command or MCP tool, not the core). */
+  message?: string
 }
 
 // ─── find_orphan_keys ────────────────────────────────────────────

--- a/packages/cli/tests/tools/translate-key.test.ts
+++ b/packages/cli/tests/tools/translate-key.test.ts
@@ -30,9 +30,11 @@ describe('translate_key', () => {
     })
 
     expect(result.dryRun).toBe(true)
+    expect(result.mode).toBe('dry-run')
     expect(result.sourceLocale).toMatchObject({ code: 'en', language: 'en-US', file: 'en-US.json' })
     expect(result.updatedSource).toBe(true)
-    expect(result.translated).toEqual(expect.arrayContaining(['de', 'fr', 'es']))
+    expect(result.translated).toEqual([])
+    expect(result.wouldTranslate).toEqual(expect.arrayContaining(['de', 'fr', 'es']))
     expect(result.placeholderValidation).toEqual({
       ok: true,
       placeholders: ['{count}'],
@@ -52,7 +54,7 @@ describe('translate_key', () => {
       dryRun: true,
     })
 
-    expect(result.translated).toEqual(['de', 'fr'])
+    expect(result.wouldTranslate).toEqual(['de', 'fr'])
   })
 
   it('skips existing targets when overwrite is false', async () => {
@@ -66,8 +68,11 @@ describe('translate_key', () => {
       dryRun: true,
     })
 
-    expect(result.translated).toEqual([])
-    expect(result.skipped).toEqual(['de', 'fr'])
+    expect(result.wouldTranslate).toEqual([])
+    expect(result.skipped).toEqual([
+      { locale: 'de', reason: 'already-translated' },
+      { locale: 'fr', reason: 'already-translated' },
+    ])
   })
 })
 
@@ -107,10 +112,9 @@ describe('translate_missing compact mode', () => {
       // no translateFn — the no-backend fallback path
     })
 
-    // fallback contexts survive compaction, with the write-back guidance
+    // fallback contexts survive compaction (guidance messages are surface-owned)
     expect(result.fallbackContexts).toHaveProperty('es')
-    expect(result.summary.message).toContain('write_translations')
-    expect(result.summary.samplingSupported).toBe(false)
+    expect(result.summary.mode).toBe('agent')
 
     // locale metadata as full triples
     expect(result.summary.referenceLocale).toMatchObject({ code: 'de', language: 'de-DE', file: 'de-DE.json' })
@@ -118,9 +122,9 @@ describe('translate_missing compact mode', () => {
       expect.objectContaining({ code: 'es', language: 'es-ES', file: 'es-ES.json' }),
     ])
 
-    // per-locale entries keep all non-key metadata
+    // per-locale entries keep all non-key metadata; per-key arrays become counts
     expect(result.summary.byLocale).toEqual([
-      expect.objectContaining({ locale: 'es', reason: 'sampling-unavailable', samplingUsed: false }),
+      expect.objectContaining({ locale: 'es', mode: 'agent', missing: 1, skipped: 1, translated: 0, failed: 0 }),
     ])
     expect(result.summary.layer).toBe('root')
     expect(result.summary.dryRun).toBe(false)
@@ -141,8 +145,9 @@ describe('translate_missing compact mode', () => {
     })
 
     expect(result.summary.dryRun).toBe(true)
+    expect(result.summary.totalWouldTranslate).toBe(1)
     expect(result.summary.byLocale).toEqual([
-      expect.objectContaining({ locale: 'es', translated: 1, reason: 'dry-run' }),
+      expect.objectContaining({ locale: 'es', wouldTranslate: 1, translated: 0, mode: 'dry-run' }),
     ])
     expect(result.fallbackContexts).toBeUndefined()
   })
@@ -161,7 +166,7 @@ describe('translate_missing compact mode', () => {
     expect(result.summary.message).toBeUndefined()
     expect(result.summary.totalTranslated).toBe(0)
     expect(result.summary.byLocale).toEqual([
-      expect.objectContaining({ locale: 'es', reason: 'no-missing-keys' }),
+      expect.objectContaining({ locale: 'es', missing: 0, translated: 0, failed: 0, skipped: 0 }),
     ])
   })
 })
@@ -182,10 +187,11 @@ describe('translate_missing metadata', () => {
       expect.objectContaining({ code: 'es', language: 'es-ES', file: 'es-ES.json' }),
     ])
     expect(result.results.es).toMatchObject({
-      translated: ['admin.users.list'],
+      wouldTranslate: ['admin.users.list'],
+      translated: [],
       failed: [],
-      samplingUsed: false,
-      reason: 'dry-run',
+      mode: 'dry-run',
+      missing: 1,
     })
   })
 })

--- a/packages/cli/tests/tools/translate-seam.test.ts
+++ b/packages/cli/tests/tools/translate-seam.test.ts
@@ -78,11 +78,13 @@ describe('translateMissing through the translate seam', () => {
 
     expect(result.summary.totalTranslated).toBe(8) // 4 keys × en + fr
     expect(result.summary.totalFailed).toBe(0)
+    expect(result.summary.mode).toBe('provider')
     expect(result.results.en).toMatchObject({
-      samplingUsed: true,
-      reason: 'translated-with-sampling',
+      mode: 'provider',
+      missing: 4,
       model: 'fake-model',
       failed: [],
+      skipped: [],
     })
     expect(result.results.en.translated).toHaveLength(4)
 
@@ -116,7 +118,7 @@ describe('translateMissing through the translate seam', () => {
         k === 'greeting' ? 'Hello {nom}' : `[t] ${v}`),
     })
 
-    expect(result.results.en.failed).toEqual(['greeting'])
+    expect(result.results.en.failed).toEqual([{ key: 'greeting', reason: 'placeholder-mismatch' }])
     expect(result.results.en.translated).toHaveLength(3)
     expect(result.results.en.placeholderValidation?.ok).toBe(false)
 
@@ -171,10 +173,9 @@ describe('translateMissing through the translate seam', () => {
     expect(await readLocale('en')).toEqual({})
   })
 
-  it('pins current accounting for keys omitted by the backend', async () => {
-    // The backend drops one key from its response. Today the omitted key is
-    // neither translated nor failed — #207 will move it to failed with
-    // reason 'omitted-by-model'. This test pins the current behavior.
+  it('accounts for keys omitted by the backend as failed', async () => {
+    // The backend drops one key from its response — it must land in failed
+    // with an explicit reason so totals always reconcile.
     const result = await translateMissing({
       projectDir,
       layer: 'root',
@@ -190,7 +191,8 @@ describe('translateMissing through the translate seam', () => {
     })
 
     expect(result.results.en.translated).toHaveLength(3)
-    expect(result.results.en.failed).toEqual([])
+    expect(result.results.en.failed).toEqual([{ key: 'greeting', reason: 'omitted-by-model' }])
+    expect(result.results.en.missing).toBe(4) // translated + failed reconcile
     expect((await readLocale('en')).greeting).toBeUndefined()
   })
 
@@ -217,11 +219,16 @@ describe('translateMissing through the translate seam', () => {
       // no translateFn
     })
 
-    expect(result.summary.samplingSupported).toBe(false)
+    expect(result.summary.mode).toBe('agent')
+    expect(result.summary.totalSkipped).toBe(4)
     expect(result.fallbackContexts?.en).toMatchObject({
       keysToTranslate: expect.objectContaining({ greeting: 'Hallo {name}' }),
     })
-    expect(result.results.en.reason).toBe('sampling-unavailable')
+    expect(result.results.en.mode).toBe('agent')
+    expect(result.results.en.skipped).toEqual(
+      expect.arrayContaining([{ key: 'greeting', reason: 'no-provider' }]),
+    )
+    expect(result.results.en.failed).toEqual([])
     expect(await readLocale('en')).toEqual({})
   })
 })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -531,6 +531,13 @@ export function createServer(): McpServer {
           onProgressTotal: (total) => { progressTotal = total },
         })
 
+        // MCP-owned guidance for agent mode
+        if (result.fallbackContexts && result.summary) {
+          (result.summary as Record<string, unknown>).message
+            = 'No translation backend available. Use the fallbackContexts to translate inline, '
+            + 'then call write_translations (mode: "upsert") to write the results.'
+        }
+
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('translating missing keys', error)
@@ -604,6 +611,12 @@ export function createServer(): McpServer {
           projectDir,
           translateFn,
         })
+
+        // MCP-owned guidance for agent mode
+        if (result.fallbackContext) {
+          result.message = 'No translation backend available. Use the fallbackContext to translate inline, '
+            + 'then call write_translations (mode: "upsert") to write the results.'
+        }
 
         return jsonContent(result)
       } catch (error) {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -9,8 +9,7 @@ import { clearConfigCache } from 'the-i18n-cli'
 /**
  * Transport-level tests: a linked client/server pair over the SDK's in-memory
  * transport, against a real temp project resolved by the CLI's generic
- * adapter. The client declares no sampling capability — the same situation as
- * Claude Code and most MCP hosts.
+ * adapter. The client provides no translation backend — the agent-mode default.
  */
 
 let projectDir: string
@@ -97,10 +96,11 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     ])
   })
 
-  it('translate_missing without sampling capability returns fallback contexts', async () => {
+  it('translate_missing without a translation backend returns fallback contexts', async () => {
     const { json } = await callTool('translate_missing', { layer: 'root', projectDir })
 
-    expect(json?.summary.samplingSupported).toBe(false)
+    expect(json?.summary.mode).toBe('agent')
+    expect(json?.summary.totalSkipped).toBe(2)
     expect(json?.summary.message).toContain('write_translations')
     expect(json?.fallbackContexts?.en?.keysToTranslate).toMatchObject({
       'greeting': 'Hallo {name}',
@@ -114,7 +114,7 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.fallbackContexts?.en).toBeDefined()
     expect(json?.summary.message).toContain('write_translations')
     expect(json?.summary.byLocale).toEqual([
-      expect.objectContaining({ locale: 'en', reason: 'sampling-unavailable' }),
+      expect.objectContaining({ locale: 'en', mode: 'agent', missing: 2, skipped: 2 }),
     ])
     expect(json?.results).toBeUndefined()
   })


### PR DESCRIPTION
Implements #207 (fourth slice of spec #198) — the largest behavioral slice, protected end to end by the #205 seam tests (updated to pin the new contract).

## The new contract

Per-locale: `{ mode, missing, translated, wouldTranslate?, failed: [{key, reason}], skipped: [{key, reason}], batches?, model?, writeError? }` with the invariant **`missing = translated + wouldTranslate + failed + skipped`** — the silent key-loss class (LLM omits a key → neither bucket) is structurally gone (`omitted-by-model`).

| old | new |
|---|---|
| `samplingUsed`/`samplingSupported`/`reason` | `mode: 'provider' \| 'agent' \| 'dry-run'` |
| no-provider keys in `failed` | `skipped` with `no-provider` |
| dry-run claims `translated` | `wouldTranslate` + `totalWouldTranslate` |
| `failed: Array<string \| {locale, error}>` (translate_key) | uniform `{locale, reason, detail?}` |
| write error fails *all* keys as 'translated-with-sampling' | only about-to-be-written keys fail with `write-error`; prior failures keep their reasons |
| core emits 'call write_translations' to CLI users | guidance is surface-owned: CLI explains `--provider`/env keys, MCP names `write_translations` |

Compact projection updated accordingly (counts for all four buckets + full metadata).

**Breaking** (tool output shapes) — next release is already the 2.x/4.x era, and both packages version together.

CLI 561 · MCP 7 · lint 0 errors · both typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer translation command guidance for dry runs and automatic translation provider requirements.
  - Dry-run results now show which translations would be created without counting them as completed.
  - Translation results distinguish completed, skipped, and failed items with clearer reasons and summary counts.
  - Added guidance for agent-mode translations when no provider is configured, including model and API key setup.
  - MCP responses now explain how to apply fallback translations and save them.

- **Bug Fixes**
  - Improved reporting for provider, model, placeholder, and write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->