### PR TITLE
feat(mcp)!: env-configured provider mode, MCP sampling removed

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,7 +4,7 @@ import { toErrorMessage } from 'the-i18n-cli'
 import { createServer } from './server.js'
 
 try {
-  const server = createServer()
+  const server = await createServer()
   const transport = new StdioServerTransport()
   await server.connect(transport)
 } catch (error) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -27,33 +27,78 @@ import {
   listNamespaces,
   findLocaleImpl,
   toErrorMessage,
+  createTranslateFn,
 } from 'the-i18n-cli'
 
-import type { TranslateFn, ProgressFn, ProjectConfig } from 'the-i18n-cli'
+import type { TranslateFn, ProgressFn, ProjectConfig, LlmProvider } from 'the-i18n-cli'
 
 const DEFAULT_PROJECT_DIR = process.env.I18N_PROJECT_DIR ?? process.cwd()
 
-// ─── Shared helpers ───────────────────────────────────────────────
+// ─── Translation backend (resolved once at startup) ───────────────
 
-// TranslateFn implemented via the deprecated MCP sampling request.
-// Removed entirely by the provider-mode work (#208).
-function createMcpTranslateFn(server: McpServer, samplingSupported: boolean): TranslateFn | undefined {
-  if (!samplingSupported) return undefined
-  return async (opts) => {
-    const SAMPLING_TIMEOUT_MS = 120_000
-    const result = await server.server.createMessage({
-      messages: [{ role: 'user', content: { type: 'text', text: opts.userMessage } }],
-      systemPrompt: opts.systemPrompt,
-      maxTokens: opts.maxTokens,
-      temperature: 0,
-      includeContext: 'none',
-    }, { timeout: SAMPLING_TIMEOUT_MS })
-    return {
-      text: result.content.type === 'text' ? result.content.text : '',
-      model: result.model,
-    }
+const PROVIDER_KEY_ENVS: Record<LlmProvider, string> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GEMINI_API_KEY',
+}
+
+interface TranslationBackend {
+  mode: 'provider' | 'agent'
+  provider?: LlmProvider
+  model?: string
+  translateFn?: TranslateFn
+}
+
+function isKnownProvider(value: string): value is LlmProvider {
+  return value in PROVIDER_KEY_ENVS
+}
+
+/**
+ * Resolve the translation backend from environment configuration.
+ *
+ * Fully configured (`I18N_PROVIDER`, `I18N_MODEL`, and the provider's API key
+ * env) → provider mode: translate tools call the LLM provider directly.
+ * Nothing configured → agent mode: translate tools return fallback contexts
+ * for the host agent to translate inline and persist via write_translations.
+ * Partial configuration → a startup warning on stderr plus agent mode, so a
+ * misconfigured server never surprises callers per-request.
+ */
+async function resolveTranslationBackend(): Promise<TranslationBackend> {
+  const provider = process.env.I18N_PROVIDER
+  const model = process.env.I18N_MODEL
+
+  if (!provider && !model) return { mode: 'agent' }
+
+  const warn = (message: string) => process.stderr.write(`[the-i18n-mcp] ${message}\n`)
+
+  if (!provider) {
+    warn('Partial provider config: I18N_MODEL is set but I18N_PROVIDER is missing. Running in agent mode.')
+    return { mode: 'agent' }
+  }
+  if (!isKnownProvider(provider)) {
+    warn(`Partial provider config: I18N_PROVIDER="${provider}" is not one of openai | anthropic | google. Running in agent mode.`)
+    return { mode: 'agent' }
+  }
+  if (!model) {
+    warn(`Partial provider config: I18N_PROVIDER=${provider} is set but I18N_MODEL is missing. Running in agent mode.`)
+    return { mode: 'agent' }
+  }
+  const keyEnv = PROVIDER_KEY_ENVS[provider]
+  if (!process.env[keyEnv]) {
+    warn(`Partial provider config: I18N_PROVIDER=${provider} is set but ${keyEnv} is missing. Running in agent mode.`)
+    return { mode: 'agent' }
+  }
+
+  try {
+    const translateFn = await createTranslateFn({ provider, model })
+    return { mode: 'provider', provider, model, translateFn }
+  } catch (error) {
+    warn(`Provider setup failed: ${toErrorMessage(error)}. Running in agent mode.`)
+    return { mode: 'agent' }
   }
 }
+
+// ─── Shared helpers ───────────────────────────────────────────────
 
 function buildProjectConfigSection(pc: ProjectConfig | undefined): string {
   if (!pc) return ''
@@ -117,10 +162,26 @@ function jsonContent(data: unknown) {
   }
 }
 
+export interface CreateServerOptions {
+  /**
+   * Test-only seam: inject a TranslateFn directly, bypassing environment
+   * resolution. Production callers must leave this unset and configure the
+   * backend via I18N_PROVIDER / I18N_MODEL / the provider's API key env.
+   */
+  translateFn?: TranslateFn
+}
+
 /**
  * Create and configure the MCP server with all tools.
+ *
+ * The translation backend is resolved once here, at startup — see
+ * resolveTranslationBackend for the environment contract.
  */
-export function createServer(): McpServer {
+export async function createServer(options: CreateServerOptions = {}): Promise<McpServer> {
+  const backend: TranslationBackend = options.translateFn
+    ? { mode: 'provider', translateFn: options.translateFn }
+    : await resolveTranslationBackend()
+
   const server = new McpServer({
     name: 'the-i18n-mcp',
     version,
@@ -135,8 +196,9 @@ export function createServer(): McpServer {
       description:
         'Discover the complete i18n setup. Returns project config (locales, default locale, layers, '
         + 'fallback chain, glossary, translation style) plus per-layer directory listings with file '
-        + 'counts and top-level key namespaces. Call this first to understand the project before '
-        + 'reading or writing translations.',
+        + 'counts and top-level key namespaces, and the active translation mode ("provider" when the '
+        + 'server has an env-configured LLM provider, "agent" otherwise). Call this first to '
+        + 'understand the project before reading or writing translations.',
       inputSchema: {
         projectDir: z
           .string()
@@ -153,6 +215,11 @@ export function createServer(): McpServer {
         return jsonContent({
           ...config,
           layers: dirs,
+          // Active translation mode — lets operators verify env configuration
+          // without triggering a translation. Never includes the API key.
+          translationMode: backend.mode,
+          ...(backend.provider ? { translationProvider: backend.provider } : {}),
+          ...(backend.model ? { translationModel: backend.model } : {}),
         })
       } catch (error) {
         return toolErrorResponse('discovering i18n setup', error)
@@ -447,7 +514,7 @@ export function createServer(): McpServer {
     {
       title: 'Translate Missing',
       description:
-        'Find keys missing in target locales and translate them. Uses the host LLM via MCP sampling if available, otherwise returns context for the agent to translate inline. Uses project config (glossary, translation prompt, locale notes, examples) if available. Translates all locales concurrently by default — pass all targetLocales at once.',
+        'Find keys missing in target locales and translate them. Two modes: in provider mode (server env-configured with I18N_PROVIDER, I18N_MODEL, and an API key) the server calls the LLM provider directly and writes the results; in agent mode (no provider configured) it returns per-locale fallbackContexts — translate those inline and persist via write_translations. Check the discover output for the active mode. Uses project config (glossary, translation prompt, locale notes, examples) if available. Translates all locales concurrently by default — pass all targetLocales at once.',
       annotations: {
         title: 'Translate Missing Translations',
         readOnlyHint: false,
@@ -471,7 +538,7 @@ export function createServer(): McpServer {
         batchSize: z
           .number()
           .optional()
-          .describe('Max keys per LLM sampling request. Default: 50. Lower values reduce per-batch risk but increase round trips.'),
+          .describe('Max keys per provider request (provider mode only). Default: 50. Lower values reduce per-batch risk but increase round trips.'),
         dryRun: z
           .boolean()
           .optional()
@@ -488,10 +555,6 @@ export function createServer(): McpServer {
     },
     async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, compact, projectDir }, extra) => {
       try {
-        // Check sampling support from MCP client capabilities
-        const clientCapabilities = server.server.getClientCapabilities()
-        const samplingSupported = !!clientCapabilities?.sampling
-
         // Build progressFn from MCP progress notifications.
         // progressTotal is set by the onProgressTotal callback below, which runs
         // during the pre-scan phase of translateMissing — before any progress
@@ -514,9 +577,6 @@ export function createServer(): McpServer {
           })
         }
 
-        // Build translateFn from MCP server sampling
-        const translateFn = createMcpTranslateFn(server, samplingSupported)
-
         const result = await translateMissing({
           layer,
           referenceLocale,
@@ -526,7 +586,7 @@ export function createServer(): McpServer {
           dryRun,
           compact,
           projectDir,
-          translateFn,
+          translateFn: backend.translateFn,
           progressFn,
           onProgressTotal: (total) => { progressTotal = total },
         })
@@ -534,8 +594,9 @@ export function createServer(): McpServer {
         // MCP-owned guidance for agent mode
         if (result.fallbackContexts && result.summary) {
           (result.summary as Record<string, unknown>).message
-            = 'No translation backend available. Use the fallbackContexts to translate inline, '
-            + 'then call write_translations (mode: "upsert") to write the results.'
+            = 'Agent mode — no provider configured on the server. Use the fallbackContexts to translate '
+            + 'inline, then call write_translations (mode: "upsert") to write the results. To enable '
+            + 'provider mode, set I18N_PROVIDER, I18N_MODEL, and the provider API key env on the server process.'
         }
 
         return jsonContent(result)
@@ -552,7 +613,7 @@ export function createServer(): McpServer {
     {
       title: 'Translate Key',
       description:
-        'Add/update one source translation key and translate it into target locales. Unlike translate_missing, this can overwrite existing stale target translations.',
+        'Add/update one source translation key and translate it into target locales. Unlike translate_missing, this can overwrite existing stale target translations. Same two modes as translate_missing: provider mode (server env-configured) translates directly; agent mode returns a fallbackContext — translate it inline and persist via write_translations.',
       annotations: {
         title: 'Translate Single Key',
         readOnlyHint: false,
@@ -582,7 +643,7 @@ export function createServer(): McpServer {
         dryRun: z
           .boolean()
           .optional()
-          .describe('When true, previews source/target locales without writing files or calling sampling.'),
+          .describe('When true, previews source/target locales without writing files or calling the translation backend.'),
         includePreview: z
           .boolean()
           .optional()
@@ -595,10 +656,6 @@ export function createServer(): McpServer {
     },
     async ({ layer, key, sourceLocale, sourceValue, targetLocales, overwrite, dryRun, includePreview, projectDir }) => {
       try {
-        const clientCapabilities = server.server.getClientCapabilities()
-        const samplingSupported = !!clientCapabilities?.sampling
-        const translateFn = createMcpTranslateFn(server, samplingSupported)
-
         const result = await translateKey({
           layer,
           key,
@@ -609,13 +666,14 @@ export function createServer(): McpServer {
           dryRun,
           includePreview,
           projectDir,
-          translateFn,
+          translateFn: backend.translateFn,
         })
 
         // MCP-owned guidance for agent mode
         if (result.fallbackContext) {
-          result.message = 'No translation backend available. Use the fallbackContext to translate inline, '
-            + 'then call write_translations (mode: "upsert") to write the results.'
+          result.message = 'Agent mode — no provider configured on the server. Use the fallbackContext to '
+            + 'translate inline, then call write_translations (mode: "upsert") to write the results. To enable '
+            + 'provider mode, set I18N_PROVIDER, I18N_MODEL, and the provider API key env on the server process.'
         }
 
         return jsonContent(result)
@@ -856,7 +914,9 @@ Follow these steps:
    - Follow the glossary and style examples if provided above.
    - Preserve all {placeholders} and @:linked.references.
 4. If you only provided translations for some locales, call \`translate_missing\` to fill in the rest.
-   - Pass \`keys\` explicitly (the exact dot-path keys you just added) to skip the missing-key scan and go straight to sampling.
+   - Pass \`keys\` explicitly (the exact dot-path keys you just added) to skip the missing-key scan.
+   - In provider mode (server env-configured with a provider), it translates and writes directly.
+   - In agent mode, it returns fallbackContexts — translate them inline, then persist via \`write_translations\`.
 5. Summarize what was added.`
 
       return {
@@ -904,8 +964,9 @@ Follow these steps:
    - **Nuxt**: Add the locale entry to \`i18n.locales\` in \`nuxt.config.ts\` (code, language, file).
    - **Laravel**: Add the locale code to the \`available_locales\` array in \`config/app.php\`.
 2. Call \`scaffold_locale\` with the new locale code to create empty locale files in all layers.
-3. Call \`translate_missing\` for each layer to auto-translate all keys from the default locale. Concurrency is handled internally — each layer call is independent and can run in parallel.
-   - If auto-translation is unavailable, use \`get_translations\` to read the default locale, translate the keys yourself, then call \`write_translations\` with mode: 'update'.
+3. Call \`translate_missing\` for each layer to translate all keys from the default locale. Concurrency is handled internally — each layer call is independent and can run in parallel.
+   - In provider mode (server env-configured with a provider), it translates and writes directly.
+   - In agent mode, it returns fallbackContexts — translate them inline, then call \`write_translations\` with mode: 'update'.
 4. Call \`get_missing_translations\` to verify the new locale has zero missing keys in every layer.
 5. Report a summary: locale code added, files created, keys translated per layer.`
 

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,31 +1,28 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { join } from 'node:path'
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { clearConfigCache } from 'the-i18n-cli'
+import type { TranslateFn } from 'the-i18n-cli'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 /**
  * Transport-level tests: a linked client/server pair over the SDK's in-memory
  * transport, against a real temp project resolved by the CLI's generic
- * adapter. The client provides no translation backend — the agent-mode default.
+ * adapter. Covers both translation modes: agent (no backend configured) and
+ * provider (a TranslateFn injected through the test-only createServer seam).
  */
 
 let projectDir: string
 let client: Client
 
-async function callTool(name: string, args: Record<string, unknown>) {
-  const result = await client.callTool({ name, arguments: args })
-  const text = (result.content as Array<{ type: string, text: string }>)[0]?.text ?? ''
-  return { result, json: result.isError ? undefined : JSON.parse(text) as Record<string, any>, text }
-}
-
-beforeAll(async () => {
-  projectDir = await mkdtemp(join(tmpdir(), 'i18n-mcp-test-'))
-  const localesDir = join(projectDir, 'i18n', 'locales')
+async function makeProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'i18n-mcp-test-'))
+  const localesDir = join(dir, 'i18n', 'locales')
   await mkdir(localesDir, { recursive: true })
-  await writeFile(join(projectDir, '.i18n-mcp.json'), JSON.stringify({
+  await writeFile(join(dir, '.i18n-mcp.json'), JSON.stringify({
     localeDirs: [{ path: 'i18n/locales', layer: 'root' }],
     defaultLocale: 'de',
     locales: ['de', 'en'],
@@ -35,18 +32,51 @@ beforeAll(async () => {
     actions: { save: 'Speichern' },
   }))
   await writeFile(join(localesDir, 'en.json'), '{}\n')
+  return dir
+}
+
+async function connectClient(server: McpServer): Promise<Client> {
+  const c = new Client({ name: 'test-client', version: '0.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([
+    server.connect(serverTransport),
+    c.connect(clientTransport),
+  ])
+  return c
+}
+
+async function callToolOn(c: Client, name: string, args: Record<string, unknown>) {
+  const result = await c.callTool({ name, arguments: args })
+  const text = (result.content as Array<{ type: string, text: string }>)[0]?.text ?? ''
+  return { result, json: result.isError ? undefined : JSON.parse(text) as Record<string, any>, text }
+}
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  return callToolOn(client, name, args)
+}
+
+/** A well-behaved fake backend: translates every key in the request batch. */
+const fakeTranslateFn: TranslateFn = async ({ userMessage }) => {
+  const line = userMessage.split('\n').find(l => l.trimStart().startsWith('{"'))
+  if (!line) throw new Error(`No batch JSON found in user message:\n${userMessage}`)
+  const batch = JSON.parse(line.slice(line.indexOf('{'), line.lastIndexOf('}') + 1)) as Record<string, string>
+  const out = Object.fromEntries(Object.entries(batch).map(([k, v]) => [k, `[t] ${v}`]))
+  return { text: JSON.stringify(out), model: 'fake-model' }
+}
+
+beforeAll(async () => {
+  projectDir = await makeProject()
+
+  // Guard against provider config leaking in from the host environment —
+  // this file's default client must run in agent mode.
+  delete process.env.I18N_PROVIDER
+  delete process.env.I18N_MODEL
 
   // The server captures its default project dir from the environment at
   // module load — set it before importing so resources can self-resolve.
   process.env.I18N_PROJECT_DIR = projectDir
   const { createServer } = await import('../src/server.js')
-  const server = createServer()
-  client = new Client({ name: 'test-client', version: '0.0.0' })
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
-  await Promise.all([
-    server.connect(serverTransport),
-    client.connect(clientTransport),
-  ])
+  client = await connectClient(await createServer())
 })
 
 afterAll(async () => {
@@ -76,6 +106,14 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     ])
   })
 
+  it('exposes no sampling wording in the translate tool descriptions', async () => {
+    const { tools } = await client.listTools()
+    for (const tool of tools) {
+      expect(tool.description?.toLowerCase()).not.toContain('sampling')
+      expect(tool.description?.toLowerCase()).not.toContain('host llm')
+    }
+  })
+
   it('reads a locale resource with a cold cache — no prior discover call', async () => {
     clearConfigCache()
     const result = await client.readResource({ uri: 'i18n:///root/de' })
@@ -83,7 +121,7 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(JSON.parse(content.text)).toMatchObject({ greeting: 'Hallo {name}' })
   })
 
-  it('discover returns the project configuration', async () => {
+  it('discover returns the project configuration and the agent translation mode', async () => {
     const { json } = await callTool('discover', { projectDir })
 
     expect(json?.defaultLocale).toBe('de')
@@ -94,6 +132,9 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.layers).toEqual([
       expect.objectContaining({ layer: 'root' }),
     ])
+    expect(json?.translationMode).toBe('agent')
+    expect(json?.translationProvider).toBeUndefined()
+    expect(json?.translationModel).toBeUndefined()
   })
 
   it('translate_missing without a translation backend returns fallback contexts', async () => {
@@ -140,5 +181,115 @@ describe('the-i18n-mcp server over in-memory transport', () => {
 
     expect(result.isError).toBe(true)
     expect(text).toContain('no-such-layer')
+  })
+})
+
+describe('provider mode via injected TranslateFn', () => {
+  let providerProjectDir: string
+  let providerClient: Client
+
+  beforeAll(async () => {
+    providerProjectDir = await makeProject()
+    const { createServer } = await import('../src/server.js')
+    providerClient = await connectClient(await createServer({ translateFn: fakeTranslateFn }))
+  })
+
+  afterAll(async () => {
+    await providerClient.close()
+    await rm(providerProjectDir, { recursive: true, force: true })
+  })
+
+  it('discover reports provider translation mode', async () => {
+    const { json } = await callToolOn(providerClient, 'discover', { projectDir: providerProjectDir })
+
+    expect(json?.translationMode).toBe('provider')
+  })
+
+  it('translate_missing translates through the backend and writes the target locale file', async () => {
+    const { json } = await callToolOn(providerClient, 'translate_missing', {
+      layer: 'root',
+      projectDir: providerProjectDir,
+    })
+
+    expect(json?.summary.mode).toBe('provider')
+    expect(json?.summary.totalTranslated).toBe(2)
+    expect(json?.summary.totalFailed).toBe(0)
+    expect(json?.fallbackContexts).toBeUndefined()
+    expect(json?.results.en).toMatchObject({
+      mode: 'provider',
+      model: 'fake-model',
+      failed: [],
+      skipped: [],
+    })
+
+    const en = JSON.parse(
+      await readFile(join(providerProjectDir, 'i18n', 'locales', 'en.json'), 'utf-8'),
+    ) as Record<string, unknown>
+    expect(en).toMatchObject({
+      greeting: '[t] Hallo {name}',
+      actions: { save: '[t] Speichern' },
+    })
+  })
+})
+
+describe('partial provider env config', () => {
+  let partialProjectDir: string
+  let partialClient: Client
+  let stderrOutput: string
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeAll(async () => {
+    partialProjectDir = await makeProject()
+
+    // Provider named, but no model and no API key — must warn at startup and
+    // serve agent mode.
+    for (const name of ['I18N_PROVIDER', 'I18N_MODEL', 'OPENAI_API_KEY']) {
+      savedEnv[name] = process.env[name]
+    }
+    process.env.I18N_PROVIDER = 'openai'
+    delete process.env.I18N_MODEL
+    delete process.env.OPENAI_API_KEY
+
+    stderrOutput = ''
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrOutput += String(chunk)
+      return true
+    })
+    try {
+      const { createServer } = await import('../src/server.js')
+      partialClient = await connectClient(await createServer())
+    } finally {
+      stderrSpy.mockRestore()
+    }
+  })
+
+  afterAll(async () => {
+    for (const [name, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+    await partialClient.close()
+    await rm(partialProjectDir, { recursive: true, force: true })
+  })
+
+  it('logs a startup warning to stderr', () => {
+    expect(stderrOutput).toContain('Partial provider config')
+    expect(stderrOutput).toContain('agent mode')
+  })
+
+  it('discover reports agent mode', async () => {
+    const { json } = await callToolOn(partialClient, 'discover', { projectDir: partialProjectDir })
+
+    expect(json?.translationMode).toBe('agent')
+  })
+
+  it('translate_missing falls back to agent mode with fallback contexts', async () => {
+    const { json } = await callToolOn(partialClient, 'translate_missing', {
+      layer: 'root',
+      projectDir: partialProjectDir,
+    })
+
+    expect(json?.summary.mode).toBe('agent')
+    expect(json?.fallbackContexts?.en).toBeDefined()
   })
 })


### PR DESCRIPTION
## What

Replaces the deprecated MCP sampling path with env-configured direct provider calls. Implements #208 (headline slice of the #198 spec).

The MCP server now resolves its translation backend **once at startup** from environment configuration:

| Env | Values |
| --- | --- |
| `I18N_PROVIDER` | `openai` \| `anthropic` \| `google` |
| `I18N_MODEL` | provider model name |
| API key | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` |

These are the exact names the CLI and CI templates already use.

- **Fully configured** → provider mode: `translate_missing` / `translate_key` call the provider directly through the CLI's `createTranslateFn` and write results. Progress notifications keep working.
- **Nothing configured** → agent mode: fallbackContexts + `write_translations`, as before.
- **Partial config** (provider without model/key, model without provider, unknown provider, or provider SDK setup failure) → one startup warning on stderr, then agent mode — never a per-call surprise.

## Changes

- `packages/mcp/src/server.ts`
  - `resolveTranslationBackend()` — startup-time env resolution as described above
  - `createServer` is now **async** and takes an options object with a documented **test-only** `translateFn` injection seam
  - `discover` output gains `translationMode: 'provider' | 'agent'`, plus `translationProvider` / `translationModel` when configured (the key is never echoed)
  - MCP sampling deleted: `createMcpTranslateFn`, `server.server.createMessage`, both `getClientCapabilities()?.sampling` checks — zero sampling references remain in the package source
  - Tool descriptions (`translate_missing`, `translate_key`, `discover`, `batchSize`, `dryRun`) and both prompts (`add-feature-translations`, `add-language`) now describe the two real modes instead of "host LLM via MCP sampling" / "go straight to sampling"
  - Agent-mode guidance messages name the mode and tell operators how to enable provider mode
- `packages/mcp/src/index.ts` — awaits the now-async `createServer`
- `packages/mcp/tests/server.test.ts` — in-memory transport coverage extended to 13 tests across three suites:
  - agent mode (existing suite, plus: no sampling wording in any tool description, `discover` reports `translationMode: 'agent'`)
  - provider mode via injected `TranslateFn`: `discover` reports `'provider'`, `translate_missing` returns `mode: 'provider'` results and writes the target locale file
  - partial env config (`I18N_PROVIDER` set, no key/model): startup stderr warning, `discover` reports agent mode, `translate_missing` returns fallbackContexts

READMEs and `schema.json` are intentionally untouched — the docs ticket owns those.

## BREAKING CHANGE

MCP sampling support is removed. Hosts that offered sampling no longer get translation through it — configure provider mode via `I18N_PROVIDER`, `I18N_MODEL`, and the provider API key env on the server process, or use agent mode.

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ (cli 561, mcp 13)
- `pnpm -r --filter='./packages/*' typecheck` ✓
- `pnpm lint` ✓ (0 errors, 4 pre-existing warnings)
- `npx fallow audit --base origin/main` ✓ (no issues in changed files)

Closes #208
Refs #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)