### PR TITLE
feat(cli): provider error classification, truncation detection, CI exit codes

### DIFF
--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -16,8 +16,37 @@ export function createCommand(opts: {
     async run({ args }) {
       const result = await opts.run(args)
       outputResult(result, args)
+      if (isTotalFailure(result)) {
+        process.exitCode = 1
+      }
     },
   }) as any
+}
+
+/**
+ * True when a run completed but achieved nothing: failures present and zero
+ * successes. Covers translate-missing-style results (summary.totalFailed /
+ * summary.totalTranslated) and translate-key-style results (top-level
+ * failed[] / translated[]). Results without those fields are never a
+ * total failure, so unrelated commands are unaffected.
+ */
+export function isTotalFailure(result: unknown): boolean {
+  if (result === null || typeof result !== 'object') return false
+  const r = result as Record<string, unknown>
+
+  const summary = r.summary
+  if (summary !== null && typeof summary === 'object') {
+    const s = summary as Record<string, unknown>
+    if (typeof s.totalFailed === 'number' && typeof s.totalTranslated === 'number') {
+      return s.totalFailed > 0 && s.totalTranslated === 0
+    }
+  }
+
+  if (Array.isArray(r.failed) && Array.isArray(r.translated)) {
+    return r.failed.length > 0 && r.translated.length === 0
+  }
+
+  return false
 }
 
 export const sharedArgs = {

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -1424,6 +1424,13 @@ export async function translateMissing(opts: {
     targetDataCache.set(target.code, targetData)
   }
 
+  // Set when any locale hits an auth error: the run is doomed, so sibling
+  // locales must stop issuing provider requests and must not write output
+  // after the abort. Locales that fully completed before the abort keep
+  // their writes — translateMissing is idempotent (re-runs only fill the
+  // still-missing keys), so completed work is never wasted or wrong.
+  const runState = { aborted: false }
+
   async function translateOneLocale(
     target: LocaleDefinition,
     targetData: Record<string, unknown>,
@@ -1465,6 +1472,7 @@ export async function translateMissing(opts: {
       let model: string | undefined
 
       for (let i = 0; i < keyEntries.length; i += maxBatch) {
+        if (runState.aborted) break
         const batchNum = Math.floor(i / maxBatch) + 1
         const batch = Object.fromEntries(keyEntries.slice(i, i + maxBatch))
         let batchTranslations: Record<string, string> | null = null
@@ -1483,6 +1491,7 @@ export async function translateMissing(opts: {
             const delayMs = 2000 * 2 ** attempt
             await new Promise(r => setTimeout(r, delayMs))
           }
+          if (runState.aborted) break
           try {
             const response = await opts.translateFn({
               systemPrompt,
@@ -1517,6 +1526,7 @@ export async function translateMissing(opts: {
             if (_error instanceof TranslateProviderError && _error.kind === 'auth') {
               // Auth failures affect every request — abort the whole run
               // instead of failing key by key through retries.
+              runState.aborted = true
               throw new ToolError(
                 `Provider authentication failed: ${_error.message}. Verify your API key (config apiKey or the provider's environment variable).`,
                 'PROVIDER_AUTH_ERROR',
@@ -1569,6 +1579,12 @@ export async function translateMissing(opts: {
         for (const key of [...translated]) {
           if (reasonByKey.has(key)) translated.splice(translated.indexOf(key), 1)
         }
+      }
+
+      if (runState.aborted) {
+        // Run is doomed — don't write partial output for an in-flight locale.
+        // The returned result is discarded by the rejecting Promise.all.
+        return { result: { mode: 'provider', missing, translated: [], failed, skipped: [] } }
       }
 
       if (Object.keys(allTranslations).length > 0) {
@@ -1826,35 +1842,47 @@ export async function translateKey(opts: {
       config.localeFileFormat,
     )
 
-    try {
-      const response = await opts.translateFn({
-        systemPrompt,
-        userMessage,
-        maxTokens: computeMaxTokens(1),
-      })
-      model = response.model
-      if (response.truncated) {
-        responseTruncated = true
-        log.warn(`Translate response truncated for ${locale.code}: provider hit the token limit.`)
-      } else if (response.text.trim() === '') {
-        throw new TranslateProviderError('Provider returned an empty response', 'provider')
-      } else {
-        const parsed = extractJsonFromResponse(response.text)
-        const parsedValue = parsed[opts.key]
-        if (typeof parsedValue === 'string') {
-          targetValue = parsedValue
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (attempt > 0) {
+        const delayMs = 2000 * 2 ** attempt
+        await new Promise(r => setTimeout(r, delayMs))
+      }
+      try {
+        const response = await opts.translateFn({
+          systemPrompt,
+          userMessage,
+          maxTokens: computeMaxTokens(1),
+        })
+        model = response.model
+        if (response.truncated) {
+          responseTruncated = true
+          log.warn(`Translate response truncated for ${locale.code}: provider hit the token limit.`)
+        } else if (response.text.trim() === '') {
+          throw new TranslateProviderError('Provider returned an empty response', 'provider')
+        } else {
+          const parsed = extractJsonFromResponse(response.text)
+          const parsedValue = parsed[opts.key]
+          if (typeof parsedValue === 'string') {
+            targetValue = parsedValue
+          }
+        }
+        requestFailed = false
+        break
+      } catch (error) {
+        if (error instanceof TranslateProviderError && error.kind === 'auth') {
+          // Auth failures affect every request — abort the whole run.
+          throw new ToolError(
+            `Provider authentication failed: ${error.message}. Verify your API key (config apiKey or the provider's environment variable).`,
+            'PROVIDER_AUTH_ERROR',
+          )
+        }
+        requestFailed = true
+        if (attempt === 0) {
+          log.warn(`Translate request failed for ${locale.code}: ${toErrorMessage(error)}. Retrying (attempt 2)`)
+        } else {
+          log.warn(`Translate retry failed for ${locale.code}: ${toErrorMessage(error)}`)
         }
       }
-    } catch (error) {
-      if (error instanceof TranslateProviderError && error.kind === 'auth') {
-        // Auth failures affect every request — abort the whole run.
-        throw new ToolError(
-          `Provider authentication failed: ${error.message}. Verify your API key (config apiKey or the provider's environment variable).`,
-          'PROVIDER_AUTH_ERROR',
-        )
-      }
-      requestFailed = true
-      log.warn(`Translate request failed for ${locale.code}: ${toErrorMessage(error)}`)
     }
 
     if (!targetValue) {

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -26,6 +26,7 @@ import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from '../sca
 import { getPatternSet } from '../scanner/patterns.js'
 import { log } from '../utils/logger.js'
 import { ToolError, toErrorMessage } from '../utils/errors.js'
+import { TranslateProviderError } from '../llm/providers.js'
 import { scaffoldLocale } from '../tools/scaffold-locale.js'
 
 import type {
@@ -1467,6 +1468,7 @@ export async function translateMissing(opts: {
         const batchNum = Math.floor(i / maxBatch) + 1
         const batch = Object.fromEntries(keyEntries.slice(i, i + maxBatch))
         let batchTranslations: Record<string, string> | null = null
+        let batchTruncated = false
 
         const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, target.language || target.code, config.localeFileFormat)
         const userMessage = buildTranslationUserMessage(
@@ -1491,6 +1493,17 @@ export async function translateMissing(opts: {
             model = response.model
             log.info(`Translation model: ${response.model}`)
 
+            if (response.truncated) {
+              // The batch response was cut off at the token limit — retrying
+              // with the same budget would truncate again, so fail fast.
+              batchTruncated = true
+              log.warn(`Translate response truncated for batch ${batchNum} in ${target.code}: provider hit the token limit. Reduce batchSize.`)
+              break
+            }
+            if (response.text.trim() === '') {
+              throw new TranslateProviderError('Provider returned an empty response', 'provider')
+            }
+
             const parsed = extractJsonFromResponse(response.text)
             const batchKeys = new Set(Object.keys(batch))
             batchTranslations = {} as Record<string, string>
@@ -1501,6 +1514,14 @@ export async function translateMissing(opts: {
             }
             break
           } catch (_error) {
+            if (_error instanceof TranslateProviderError && _error.kind === 'auth') {
+              // Auth failures affect every request — abort the whole run
+              // instead of failing key by key through retries.
+              throw new ToolError(
+                `Provider authentication failed: ${_error.message}. Verify your API key (config apiKey or the provider's environment variable).`,
+                'PROVIDER_AUTH_ERROR',
+              )
+            }
             const errMsg = _error instanceof Error ? _error.message : String(_error)
             if (attempt === 0) {
               log.warn(`Translate request failed for batch ${batchNum} in ${target.code}: ${errMsg}. Retrying (attempt 2)`)
@@ -1518,7 +1539,12 @@ export async function translateMissing(opts: {
             allTranslations[key] = value
             translated.push(key)
           } else {
-            failed.push({ key, reason: batchTranslations === null ? 'provider-error' : 'omitted-by-model' })
+            failed.push({
+              key,
+              reason: batchTruncated
+                ? 'truncated'
+                : batchTranslations === null ? 'provider-error' : 'omitted-by-model',
+            })
           }
         }
 
@@ -1791,6 +1817,7 @@ export async function translateKey(opts: {
   for (const { locale } of targetsToTranslate) {
     let targetValue: string | undefined
     let requestFailed = false
+    let responseTruncated = false
     const systemPrompt = buildTranslationSystemPrompt(config.projectConfig, locale.language || locale.code, config.localeFileFormat)
     const userMessage = buildTranslationUserMessage(
       sourceLocale.language || sourceLocale.code,
@@ -1806,18 +1833,35 @@ export async function translateKey(opts: {
         maxTokens: computeMaxTokens(1),
       })
       model = response.model
-      const parsed = extractJsonFromResponse(response.text)
-      const parsedValue = parsed[opts.key]
-      if (typeof parsedValue === 'string') {
-        targetValue = parsedValue
+      if (response.truncated) {
+        responseTruncated = true
+        log.warn(`Translate response truncated for ${locale.code}: provider hit the token limit.`)
+      } else if (response.text.trim() === '') {
+        throw new TranslateProviderError('Provider returned an empty response', 'provider')
+      } else {
+        const parsed = extractJsonFromResponse(response.text)
+        const parsedValue = parsed[opts.key]
+        if (typeof parsedValue === 'string') {
+          targetValue = parsedValue
+        }
       }
     } catch (error) {
+      if (error instanceof TranslateProviderError && error.kind === 'auth') {
+        // Auth failures affect every request — abort the whole run.
+        throw new ToolError(
+          `Provider authentication failed: ${error.message}. Verify your API key (config apiKey or the provider's environment variable).`,
+          'PROVIDER_AUTH_ERROR',
+        )
+      }
       requestFailed = true
       log.warn(`Translate request failed for ${locale.code}: ${toErrorMessage(error)}`)
     }
 
     if (!targetValue) {
-      failed.push({ locale: locale.code, reason: requestFailed ? 'provider-error' : 'omitted-by-model' })
+      failed.push({
+        locale: locale.code,
+        reason: responseTruncated ? 'truncated' : requestFailed ? 'provider-error' : 'omitted-by-model',
+      })
       continue
     }
 

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -222,6 +222,7 @@ export type TranslateFailReason =
   | 'placeholder-mismatch'
   | 'plural-mismatch'
   | 'write-error'
+  | 'truncated'
 
 /** Why a key or locale was intentionally not attempted. */
 export type TranslateSkipReason = 'no-provider' | 'already-translated'
@@ -403,6 +404,9 @@ export interface TranslateRequest {
 export interface TranslateResponse {
   text: string
   model: string
+  /** True when the provider stopped early (finish/stop reason = token limit).
+   *  The response text is incomplete and must not be parsed as a full batch. */
+  truncated?: boolean
 }
 
 export type TranslateFn = (opts: TranslateRequest) => Promise<TranslateResponse>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,5 +39,5 @@ export { readLocaleData } from './io/locale-data.js'
 export { ToolError, toErrorMessage } from './utils/errors.js'
 
 // LLM providers
-export { createTranslateFn } from './llm/providers.js'
-export type { LlmProvider, LlmProviderConfig } from './llm/providers.js'
+export { createTranslateFn, TranslateProviderError, classifyProviderError } from './llm/providers.js'
+export type { LlmProvider, LlmProviderConfig, TranslateProviderErrorKind } from './llm/providers.js'

--- a/packages/cli/src/llm/providers.ts
+++ b/packages/cli/src/llm/providers.ts
@@ -2,6 +2,56 @@ import type { TranslateFn, TranslateRequest, TranslateResponse } from '../core/t
 
 export type LlmProvider = 'openai' | 'anthropic' | 'google'
 
+// ─── Error classification ───────────────────────────────────────
+
+/** How a provider failure should be handled by the caller. */
+export type TranslateProviderErrorKind = 'auth' | 'rate-limit' | 'provider'
+
+/**
+ * A classified provider failure. `auth` errors are not retryable (the caller
+ * should abort the run), `rate-limit` errors should be retried with backoff,
+ * and `provider` covers everything else (server errors, network, …).
+ */
+export class TranslateProviderError extends Error {
+  public readonly kind: TranslateProviderErrorKind
+  public readonly status?: number
+
+  constructor(message: string, kind: TranslateProviderErrorKind, status?: number) {
+    super(message)
+    this.name = 'TranslateProviderError'
+    this.kind = kind
+    this.status = status
+  }
+}
+
+/** Defensively extract an HTTP status code from an unknown SDK error shape. */
+function extractStatus(error: unknown): number | undefined {
+  if (error === null || typeof error !== 'object') return undefined
+  const e = error as { status?: unknown, response?: unknown }
+  if (typeof e.status === 'number') return e.status
+  if (e.response !== null && typeof e.response === 'object') {
+    const status = (e.response as { status?: unknown }).status
+    if (typeof status === 'number') return status
+  }
+  return undefined
+}
+
+/**
+ * Classify an SDK error into a TranslateProviderError:
+ * 401/403 → auth, 429 → rate-limit, anything else → provider.
+ * Already-classified errors pass through unchanged.
+ */
+export function classifyProviderError(error: unknown): TranslateProviderError {
+  if (error instanceof TranslateProviderError) return error
+  const status = extractStatus(error)
+  const message = error instanceof Error ? error.message : String(error)
+  const kind: TranslateProviderErrorKind
+    = status === 401 || status === 403 ? 'auth'
+      : status === 429 ? 'rate-limit'
+        : 'provider'
+  return new TranslateProviderError(message, kind, status)
+}
+
 export interface LlmProviderConfig {
   provider: LlmProvider
   model: string
@@ -44,19 +94,27 @@ async function createOpenAiTranslateFn(config: LlmProviderConfig): Promise<Trans
   const client = new OpenAI({ apiKey, baseURL: config.baseUrl })
 
   return async (opts: TranslateRequest): Promise<TranslateResponse> => {
-    const response = await client.chat.completions.create({
-      model: config.model,
-      messages: [
-        { role: 'system', content: opts.systemPrompt },
-        { role: 'user', content: opts.userMessage },
-      ],
-      max_tokens: opts.maxTokens,
-      temperature: 0,
-      response_format: { type: 'json_object' },
-    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK types not available
+    let response: any
+    try {
+      response = await client.chat.completions.create({
+        model: config.model,
+        messages: [
+          { role: 'system', content: opts.systemPrompt },
+          { role: 'user', content: opts.userMessage },
+        ],
+        max_tokens: opts.maxTokens,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      })
+    } catch (error) {
+      throw classifyProviderError(error)
+    }
 
-    const text = response.choices[0]?.message?.content ?? ''
-    return { text, model: response.model || config.model }
+    const choice = response.choices?.[0]
+    const text = choice?.message?.content ?? ''
+    const truncated = choice?.finish_reason === 'length'
+    return { text, model: response.model || config.model, ...(truncated ? { truncated: true } : {}) }
   }
 }
 
@@ -75,19 +133,26 @@ async function createGoogleTranslateFn(config: LlmProviderConfig): Promise<Trans
   const client = new GoogleGenAI({ apiKey })
 
   return async (opts: TranslateRequest): Promise<TranslateResponse> => {
-    const response = await client.models.generateContent({
-      model: config.model,
-      contents: opts.userMessage,
-      config: {
-        systemInstruction: opts.systemPrompt,
-        maxOutputTokens: opts.maxTokens,
-        temperature: 0,
-        responseMimeType: 'application/json',
-      },
-    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK types not available
+    let response: any
+    try {
+      response = await client.models.generateContent({
+        model: config.model,
+        contents: opts.userMessage,
+        config: {
+          systemInstruction: opts.systemPrompt,
+          maxOutputTokens: opts.maxTokens,
+          temperature: 0,
+          responseMimeType: 'application/json',
+        },
+      })
+    } catch (error) {
+      throw classifyProviderError(error)
+    }
 
     const text = response.text ?? ''
-    return { text, model: response.modelVersion || config.model }
+    const truncated = response.candidates?.[0]?.finishReason === 'MAX_TOKENS'
+    return { text, model: response.modelVersion || config.model, ...(truncated ? { truncated: true } : {}) }
   }
 }
 
@@ -106,18 +171,25 @@ async function createAnthropicTranslateFn(config: LlmProviderConfig): Promise<Tr
   const client = new Anthropic({ apiKey, baseURL: config.baseUrl })
 
   return async (opts: TranslateRequest): Promise<TranslateResponse> => {
-    const response = await client.messages.create({
-      model: config.model,
-      system: opts.systemPrompt,
-      messages: [{ role: 'user', content: opts.userMessage }],
-      max_tokens: opts.maxTokens,
-      temperature: 0,
-    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK types not available
+    let response: any
+    try {
+      response = await client.messages.create({
+        model: config.model,
+        system: opts.systemPrompt,
+        messages: [{ role: 'user', content: opts.userMessage }],
+        max_tokens: opts.maxTokens,
+        temperature: 0,
+      })
+    } catch (error) {
+      throw classifyProviderError(error)
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK types not available
-    const textBlock = response.content.find((block: any) => block.type === 'text')
+    const textBlock = response.content?.find((block: any) => block.type === 'text')
     const text = textBlock?.text ?? ''
-    return { text, model: response.model || config.model }
+    const truncated = response.stop_reason === 'max_tokens'
+    return { text, model: response.model || config.model, ...(truncated ? { truncated: true } : {}) }
   }
 }
 

--- a/packages/cli/tests/cli/exit-code.test.ts
+++ b/packages/cli/tests/cli/exit-code.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { isTotalFailure } from '../../src/commands/_shared.js'
+
+/**
+ * Unit tests for the CI exit-code decision: a completed run exits non-zero
+ * only when it achieved nothing (failures present, zero successes).
+ */
+
+describe('isTotalFailure', () => {
+  it('flags a translate-missing result where everything failed', () => {
+    expect(isTotalFailure({
+      results: {},
+      summary: { totalTranslated: 0, totalFailed: 4, totalSkipped: 0 },
+    })).toBe(true)
+  })
+
+  it('accepts partial success (some translated, some failed)', () => {
+    expect(isTotalFailure({
+      summary: { totalTranslated: 3, totalFailed: 1, totalSkipped: 0 },
+    })).toBe(false)
+  })
+
+  it('accepts full success and no-op runs', () => {
+    expect(isTotalFailure({ summary: { totalTranslated: 8, totalFailed: 0, totalSkipped: 0 } })).toBe(false)
+    expect(isTotalFailure({ summary: { totalTranslated: 0, totalFailed: 0, totalSkipped: 0 } })).toBe(false)
+  })
+
+  it('flags a translate-key result where everything failed', () => {
+    expect(isTotalFailure({
+      key: 'a.b',
+      translated: [],
+      failed: [{ locale: 'en', reason: 'provider-error' }],
+    })).toBe(true)
+  })
+
+  it('accepts a translate-key result with any success', () => {
+    expect(isTotalFailure({
+      key: 'a.b',
+      translated: ['fr'],
+      failed: [{ locale: 'en', reason: 'provider-error' }],
+    })).toBe(false)
+    expect(isTotalFailure({ key: 'a.b', translated: [], failed: [] })).toBe(false)
+  })
+
+  it('ignores results without translate summary fields (unrelated commands)', () => {
+    expect(isTotalFailure({ summary: { totalMissingKeys: 12 } })).toBe(false)
+    expect(isTotalFailure({ matches: [], totalMatches: 0 })).toBe(false)
+    expect(isTotalFailure({ summary: 'text' })).toBe(false)
+    expect(isTotalFailure(null)).toBe(false)
+    expect(isTotalFailure(undefined)).toBe(false)
+    expect(isTotalFailure('string')).toBe(false)
+    expect(isTotalFailure([])).toBe(false)
+  })
+
+  it('requires both counters to be numbers before deciding', () => {
+    expect(isTotalFailure({ summary: { totalFailed: 4 } })).toBe(false)
+    expect(isTotalFailure({ summary: { totalFailed: '4', totalTranslated: '0' } })).toBe(false)
+  })
+})

--- a/packages/cli/tests/llm/providers.test.ts
+++ b/packages/cli/tests/llm/providers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { TranslateProviderError, classifyProviderError } from '../../src/llm/providers.js'
+
+/**
+ * Unit tests for the provider error classification mapping. No SDKs are
+ * imported — classifyProviderError only inspects plain error shapes.
+ */
+
+function errWithStatus(status: number): Error {
+  const error = new Error(`HTTP ${status}`)
+  ;(error as Error & { status: number }).status = status
+  return error
+}
+
+describe('classifyProviderError', () => {
+  it('classifies 401 as auth', () => {
+    const classified = classifyProviderError(errWithStatus(401))
+    expect(classified).toBeInstanceOf(TranslateProviderError)
+    expect(classified.kind).toBe('auth')
+    expect(classified.status).toBe(401)
+    expect(classified.message).toBe('HTTP 401')
+  })
+
+  it('classifies 403 as auth', () => {
+    expect(classifyProviderError(errWithStatus(403)).kind).toBe('auth')
+  })
+
+  it('classifies 429 as rate-limit', () => {
+    expect(classifyProviderError(errWithStatus(429)).kind).toBe('rate-limit')
+  })
+
+  it('classifies other status codes as provider', () => {
+    expect(classifyProviderError(errWithStatus(500)).kind).toBe('provider')
+    expect(classifyProviderError(errWithStatus(400)).kind).toBe('provider')
+  })
+
+  it('classifies errors without a status as provider', () => {
+    const classified = classifyProviderError(new Error('socket hang up'))
+    expect(classified.kind).toBe('provider')
+    expect(classified.status).toBeUndefined()
+    expect(classified.message).toBe('socket hang up')
+  })
+
+  it('reads a nested response.status defensively', () => {
+    const error = new Error('unauthorized') as Error & { response: { status: number } }
+    error.response = { status: 401 }
+    expect(classifyProviderError(error).kind).toBe('auth')
+  })
+
+  it('prefers a top-level status over response.status', () => {
+    const error = new Error('rate limited') as Error & { status: number, response: { status: number } }
+    error.status = 429
+    error.response = { status: 500 }
+    expect(classifyProviderError(error).kind).toBe('rate-limit')
+  })
+
+  it('handles non-Error and malformed shapes without throwing', () => {
+    expect(classifyProviderError('boom').kind).toBe('provider')
+    expect(classifyProviderError('boom').message).toBe('boom')
+    expect(classifyProviderError(null).kind).toBe('provider')
+    expect(classifyProviderError({ status: 'not-a-number', response: 42 }).kind).toBe('provider')
+  })
+
+  it('passes an already-classified error through unchanged', () => {
+    const original = new TranslateProviderError('key invalid', 'auth')
+    expect(classifyProviderError(original)).toBe(original)
+  })
+})

--- a/packages/cli/tests/tools/translate-seam.test.ts
+++ b/packages/cli/tests/tools/translate-seam.test.ts
@@ -3,8 +3,10 @@ import { join } from 'node:path'
 import { mkdtemp, rm, mkdir, writeFile, readFile, chmod } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import type { TranslateFn } from '../../src/core/types.js'
-import { translateMissing } from '../../src/core/operations.js'
+import { translateMissing, translateKey } from '../../src/core/operations.js'
 import { clearConfigCache } from '../../src/config/detector.js'
+import { TranslateProviderError } from '../../src/llm/providers.js'
+import { ToolError } from '../../src/utils/errors.js'
 
 /**
  * Seam tests: drive the real translateMissing pipeline end to end with fake
@@ -277,6 +279,141 @@ describe('translateMissing through the translate seam', () => {
 
       expect(result.results.en.failed).toEqual([])
       expect((await readLocale('en')).mode).toBe('Press {key} for A|B mode')
+    })
+  })
+
+  describe('classified provider failures', () => {
+    it('aborts the whole run on an auth error without retrying', async () => {
+      let calls = 0
+      const error = await translateMissing({
+        projectDir,
+        layer: 'root',
+        targetLocales: ['en'],
+        translateFn: async () => {
+          calls++
+          throw new TranslateProviderError('Incorrect API key provided', 'auth')
+        },
+      }).then(() => null, (e: unknown) => e)
+
+      expect(error).toBeInstanceOf(ToolError)
+      expect((error as ToolError).code).toBe('PROVIDER_AUTH_ERROR')
+      expect((error as ToolError).message).toContain('Incorrect API key provided')
+      expect(calls).toBe(1) // no retry — auth failures are not transient
+      expect(await readLocale('en')).toEqual({})
+    })
+
+    it('propagates the auth abort across concurrent locales without writing files', async () => {
+      const error = await translateMissing({
+        projectDir,
+        layer: 'root', // en + fr run in a Promise.all
+        translateFn: async () => {
+          throw new TranslateProviderError('Incorrect API key provided', 'auth')
+        },
+      }).then(() => null, (e: unknown) => e)
+
+      expect(error).toBeInstanceOf(ToolError)
+      expect((error as ToolError).code).toBe('PROVIDER_AUTH_ERROR')
+      expect(await readLocale('en')).toEqual({})
+      expect(await readLocale('fr')).toEqual({})
+    })
+
+    it('fails batch keys with reason "truncated" when the response was cut off', async () => {
+      let calls = 0
+      const result = await translateMissing({
+        projectDir,
+        layer: 'root',
+        targetLocales: ['en'],
+        translateFn: async () => {
+          calls++
+          return { text: '{"greeting": "Hel', model: 'fake-model', truncated: true }
+        },
+      })
+
+      expect(calls).toBe(1) // truncation is not retried — same budget truncates again
+      expect(result.results.en.translated).toEqual([])
+      expect(result.results.en.failed).toHaveLength(4)
+      expect(result.results.en.failed).toEqual(
+        expect.arrayContaining([{ key: 'greeting', reason: 'truncated' }]),
+      )
+      expect(result.results.en.failed.every((f: { reason: string }) => f.reason === 'truncated')).toBe(true)
+      expect(await readLocale('en')).toEqual({})
+    })
+
+    // generous timeout: the production retry waits 4s before the second attempt
+    it('retries after a rate-limit error and succeeds', { timeout: 15_000 }, async () => {
+      let calls = 0
+      const good = fakeTranslator((_k, v) => `[t] ${v}`)
+      const result = await translateMissing({
+        projectDir,
+        layer: 'root',
+        targetLocales: ['en'],
+        translateFn: async (req) => {
+          calls++
+          if (calls === 1) throw new TranslateProviderError('Rate limit exceeded', 'rate-limit', 429)
+          return good(req)
+        },
+      })
+
+      expect(calls).toBe(2)
+      expect(result.results.en.translated).toHaveLength(4)
+      expect(result.results.en.failed).toEqual([])
+      expect((await readLocale('en')).greeting).toBe('[t] Hallo {name}')
+    })
+
+    // generous timeout: the production retry waits 4s before the second attempt
+    it('reports an empty response as a provider error, not JSON-parse noise', { timeout: 15_000 }, async () => {
+      let calls = 0
+      const result = await translateMissing({
+        projectDir,
+        layer: 'root',
+        targetLocales: ['en'],
+        translateFn: async () => {
+          calls++
+          return { text: '', model: 'fake-model' }
+        },
+      })
+
+      expect(calls).toBe(2) // empty responses are retried like other provider errors
+      expect(result.results.en.translated).toEqual([])
+      expect(result.results.en.failed).toEqual(
+        expect.arrayContaining([{ key: 'greeting', reason: 'provider-error' }]),
+      )
+      expect(result.results.en.failed).toHaveLength(4)
+      expect(await readLocale('en')).toEqual({})
+    })
+  })
+
+  describe('translateKey classified provider failures', () => {
+    it('aborts on an auth error', async () => {
+      const error = await translateKey({
+        projectDir,
+        layer: 'root',
+        key: 'greeting',
+        sourceLocale: 'de',
+        targetLocales: ['en'],
+        translateFn: async () => {
+          throw new TranslateProviderError('Incorrect API key provided', 'auth')
+        },
+      }).then(() => null, (e: unknown) => e)
+
+      expect(error).toBeInstanceOf(ToolError)
+      expect((error as ToolError).code).toBe('PROVIDER_AUTH_ERROR')
+      expect(await readLocale('en')).toEqual({})
+    })
+
+    it('fails a locale with reason "truncated" when the response was cut off', async () => {
+      const result = await translateKey({
+        projectDir,
+        layer: 'root',
+        key: 'greeting',
+        sourceLocale: 'de',
+        targetLocales: ['en'],
+        translateFn: async () => ({ text: '{"greeting": "Hel', model: 'fake-model', truncated: true }),
+      })
+
+      expect(result.translated).toEqual([])
+      expect(result.failed).toEqual([{ locale: 'en', reason: 'truncated' }])
+      expect(await readLocale('en')).toEqual({})
     })
   })
 

--- a/packages/cli/tests/tools/translate-seam.test.ts
+++ b/packages/cli/tests/tools/translate-seam.test.ts
@@ -317,6 +317,32 @@ describe('translateMissing through the translate seam', () => {
       expect(await readLocale('fr')).toEqual({})
     })
 
+    it('suppresses in-flight sibling writes once the auth abort is observed', async () => {
+      // fr fails auth immediately; en's request is still in flight and
+      // resolves with valid translations afterwards — but the run is doomed,
+      // so en must not write either.
+      const error = await translateMissing({
+        projectDir,
+        layer: 'root', // en + fr run in a Promise.all
+        translateFn: async ({ userMessage }) => {
+          if (userMessage.includes(' to fr')) {
+            throw new TranslateProviderError('Incorrect API key provided', 'auth')
+          }
+          await new Promise(r => setTimeout(r, 150))
+          const batch = parseBatch(userMessage)
+          return {
+            text: JSON.stringify(Object.fromEntries(Object.entries(batch).map(([k, v]) => [k, `[t] ${v}`]))),
+            model: 'fake-model',
+          }
+        },
+      }).then(() => null, (e: unknown) => e)
+
+      expect(error).toBeInstanceOf(ToolError)
+      expect((error as ToolError).code).toBe('PROVIDER_AUTH_ERROR')
+      expect(await readLocale('en')).toEqual({})
+      expect(await readLocale('fr')).toEqual({})
+    })
+
     it('fails batch keys with reason "truncated" when the response was cut off', async () => {
       let calls = 0
       const result = await translateMissing({
@@ -414,6 +440,30 @@ describe('translateMissing through the translate seam', () => {
       expect(result.translated).toEqual([])
       expect(result.failed).toEqual([{ locale: 'en', reason: 'truncated' }])
       expect(await readLocale('en')).toEqual({})
+    })
+
+    // generous timeout: the retry waits 4s before the second attempt
+    it('retries a rate-limited request once and succeeds', { timeout: 15_000 }, async () => {
+      let calls = 0
+      const result = await translateKey({
+        projectDir,
+        layer: 'root',
+        key: 'greeting',
+        sourceLocale: 'de',
+        targetLocales: ['en'],
+        translateFn: async () => {
+          calls++
+          if (calls === 1) {
+            throw new TranslateProviderError('Rate limit exceeded', 'rate-limit', 429)
+          }
+          return { text: JSON.stringify({ greeting: '[t] Hallo {name}' }), model: 'fake-model' }
+        },
+      })
+
+      expect(calls).toBe(2)
+      expect(result.translated).toEqual(['en'])
+      expect(result.failed).toEqual([])
+      expect((await readLocale('en')).greeting).toBe('[t] Hallo {name}')
     })
   })
 


### PR DESCRIPTION
## Summary

Provider failures become actionable (part of #198):

- **Error classification** (`packages/cli/src/llm/providers.ts`): new `TranslateProviderError` with `kind: 'auth' | 'rate-limit' | 'provider'` plus an exported `classifyProviderError`. SDK errors are classified defensively from `error.status` / `error.response?.status`: 401/403 → `auth`, 429 → `rate-limit`, everything else → `provider`. All three adapters (openai/anthropic/google) throw classified errors.
- **Truncation detection**: each adapter inspects the finish/stop reason (OpenAI `finish_reason === 'length'`, Anthropic `stop_reason === 'max_tokens'`, Google `finishReason === 'MAX_TOKENS'`) and sets the new additive `TranslateResponse.truncated` flag.
- **Core behavior** (`core/operations.ts`):
  - Auth errors abort the entire run immediately with `ToolError` code `PROVIDER_AUTH_ERROR` — no retry, no per-key failure spam (rejection propagates through the per-locale `Promise.all`).
  - Rate-limit and unclassified errors keep the existing single backoff retry.
  - Truncated responses fail their batch keys with the new reason `truncated` (distinct from unusable-JSON `provider-error`) and are not retried — the same token budget would truncate again.
  - Empty response text is reported as "Provider returned an empty response" instead of JSON-parse noise.
- **CI exit codes** (`commands/_shared.ts`): after a completed run, exit 1 on total failure — `summary.totalFailed > 0 && summary.totalTranslated === 0`, or for translate-key `failed[]` non-empty with `translated[]` empty. Guarded so results without those fields (all other commands) are unaffected. Partial success still exits 0.

## Tests

- `tests/llm/providers.test.ts` (new): 9 unit tests for the classification mapping — no SDK imports.
- `tests/cli/exit-code.test.ts` (new): 7 unit tests for the exported `isTotalFailure` helper.
- `tests/tools/translate-seam.test.ts`: 7 new seam tests through the real pipeline — auth abort (single call, ToolError code, no files written), auth abort across concurrent locales, truncation (no retry, reason `truncated`, nothing written), rate-limit then success via retry, empty response reported as provider error, and translateKey auth abort + truncation.

`pnpm --filter the-i18n-cli build`, `pnpm -r test` (592 + 13 passing), `pnpm -r --filter='./packages/*' typecheck`, `pnpm lint`, and `npx fallow audit --base origin/main` all green.

## Acceptance criteria (#209)

- [x] Classified auth error: run aborts fast, single clear error, non-zero exit
- [x] Truncation surfaces as its own failure reason, distinct from invalid JSON
- [x] Rate-limit errors retry with backoff; auth errors don't retry pointlessly
- [x] `translate` exit codes: 0 on success/partial success, non-zero on total failure

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of translation provider failures, including authentication, rate-limit, empty, and truncated responses.
  * Prevented incomplete translations from being parsed or written.
  * Commands now return a failure exit code when all operations fail.
  * Authentication failures stop processing immediately, while rate-limit failures continue to retry appropriately.

* **Improvements**
  * Standardized provider error reporting across supported translation services.
  * Added clearer failure details for truncated translation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->