### PR TITLE
feat(cli): protectedLocales — human-maintained locales excluded from auto-translation

### DIFF
--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -41,6 +41,7 @@ const projectConfigSchema = z.object({
   localeDirs: z.array(localeDirEntrySchema).optional(),
   defaultLocale: z.string().optional(),
   locales: z.array(z.string()).optional(),
+  protectedLocales: z.array(nonEmptyString).optional(),
   reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
   localeFileFormat: z.enum(['json', 'php-array']).optional(),
   // Deprecated with the removal of MCP sampling: accepted so existing config

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -73,6 +73,14 @@ export interface ProjectConfig {
   defaultLocale?: string
   /** Explicit list of locale codes. If set, overrides framework auto-detection (all adapters). Auto-discovered when absent. */
   locales?: string[]
+  /**
+   * Human-maintained locales excluded from automatic translation.
+   * Entries may be any locale ref (code, language tag, or file name);
+   * entries that do not match a known locale are ignored with a warning.
+   * Explicitly naming a protected locale in targetLocales overrides the
+   * protection (with a warning).
+   */
+  protectedLocales?: string[]
   /** Override the auto-detected locale file format. E.g., "json" or "php-array". Useful when both formats exist or auto-detection picks wrong. */
   localeFileFormat?: LocaleFileFormat
 }

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -169,6 +169,127 @@ export function findLocaleImpl(config: I18nConfig, localeRef: string) {
   )
 }
 
+/**
+ * Resolve the config's `protectedLocales` entries (any locale ref: code,
+ * language tag, or file name) against the known locales. Entries that do not
+ * match a known locale are ignored with a warning. Returns the resolved
+ * definitions, deduplicated by canonical code.
+ */
+export function resolveProtectedLocales(config: I18nConfig): LocaleDefinition[] {
+  const refs = config.projectConfig?.protectedLocales ?? []
+  const resolved = new Map<string, LocaleDefinition>()
+  for (const ref of refs) {
+    const locale = findLocaleImpl(config, ref)
+    if (!locale) {
+      log.warn(
+        `protectedLocales entry "${ref}" does not match any known locale — ignoring. `
+        + `Available: ${config.locales.map(l => l.code).join(', ')}`,
+      )
+      continue
+    }
+    if (!resolved.has(locale.code)) {
+      resolved.set(locale.code, locale)
+    }
+  }
+  return [...resolved.values()]
+}
+
+function warnProtectedOverride(code: string): void {
+  log.warn(`Locale "${code}" is protected (protectedLocales) — translating anyway because it was explicitly requested via targetLocales.`)
+}
+
+/**
+ * Resolve translate_missing target locales. Protected locales are excluded
+ * from the DEFAULT target set (returned separately so the caller can report
+ * them as skipped); naming one explicitly in targetLocales overrides the
+ * protection with a warning.
+ */
+function resolveTranslateTargets(
+  config: I18nConfig,
+  refLocale: LocaleDefinition,
+  requested: string[] | undefined,
+): { targets: LocaleDefinition[], protectedDefaults: LocaleDefinition[] } {
+  const protectedCodes = new Set(resolveProtectedLocales(config).map(l => l.code))
+  if (requested) {
+    const targets = requested.map((code) => {
+      const loc = findLocaleImpl(config, code)
+      if (!loc) {
+        throw new ToolError(`Target locale not found: "${code}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass valid locale codes in targetLocales.`, 'LOCALE_NOT_FOUND')
+      }
+      if (protectedCodes.has(loc.code)) {
+        warnProtectedOverride(loc.code)
+      }
+      return loc
+    })
+    return { targets, protectedDefaults: [] }
+  }
+  const defaults = config.locales.filter(l => l.code !== refLocale.code)
+  return {
+    targets: defaults.filter(l => !protectedCodes.has(l.code)),
+    protectedDefaults: defaults.filter(l => protectedCodes.has(l.code)),
+  }
+}
+
+/**
+ * Build result entries for protected locales withheld from the default
+ * target set of translate_missing — callers see what was NOT translated
+ * and the totals stay meaningful.
+ */
+async function collectProtectedLocaleResults(
+  config: I18nConfig,
+  layer: string,
+  mode: TranslateMode,
+  protectedDefaults: LocaleDefinition[],
+  missingKeysIn: (data: Record<string, unknown>) => string[],
+): Promise<Record<string, TranslateMissingLocaleResult>> {
+  const results: Record<string, TranslateMissingLocaleResult> = {}
+  for (const locale of protectedDefaults) {
+    let data: Record<string, unknown> = {}
+    try {
+      data = await readLocaleData(config, layer, locale)
+    } catch {}
+    const missingKeys = missingKeysIn(data)
+    if (missingKeys.length === 0) continue
+    results[locale.code] = {
+      mode,
+      missing: missingKeys.length,
+      translated: [],
+      failed: [],
+      skipped: missingKeys.map(key => ({ key, reason: 'protected-locale' as const })),
+    }
+  }
+  return results
+}
+
+/**
+ * Build the translate_key target list (deduplicated, source locale removed).
+ * Protected locales are excluded from the default 'all' target set and
+ * returned as skipped entries; naming one explicitly overrides the
+ * protection with a warning.
+ */
+function partitionTranslateKeyTargets(
+  config: I18nConfig,
+  resolved: LocaleDefinition[],
+  sourceCode: string,
+  usesDefaultTargets: boolean,
+): { targetLocales: LocaleDefinition[], protectedSkipped: Array<{ locale: string, reason: TranslateSkipReason }> } {
+  const protectedCodes = new Set(resolveProtectedLocales(config).map(l => l.code))
+  const byCode = new Map<string, LocaleDefinition>()
+  const protectedSkipped: Array<{ locale: string, reason: TranslateSkipReason }> = []
+  for (const locale of resolved) {
+    if (locale.code === sourceCode || byCode.has(locale.code)) continue
+    if (protectedCodes.has(locale.code)) {
+      if (usesDefaultTargets) {
+        protectedSkipped.push({ locale: locale.code, reason: 'protected-locale' })
+        continue
+      }
+      warnProtectedOverride(locale.code)
+    }
+    byCode.set(locale.code, locale)
+  }
+  return { targetLocales: [...byCode.values()], protectedSkipped }
+}
+
 export function findLocaleOrThrow(config: I18nConfig, localeRef: string): LocaleDefinition {
   const locale = findLocaleImpl(config, localeRef)
   if (!locale) {
@@ -1364,15 +1485,7 @@ export async function translateMissing(opts: {
   })
 
   const resolvedTargetLocales = opts.targetLocales ?? opts.locales
-  const targets = resolvedTargetLocales
-    ? resolvedTargetLocales.map((code) => {
-        const loc = findLocaleImpl(config, code)
-        if (!loc) {
-          throw new ToolError(`Target locale not found: "${code}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass valid locale codes in targetLocales.`, 'LOCALE_NOT_FOUND')
-        }
-        return loc
-      })
-    : config.locales.filter(l => l.code !== refLocale.code)
+  const { targets, protectedDefaults } = resolveTranslateTargets(config, refLocale, resolvedTargetLocales)
 
   const mode: TranslateMode = isDryRun ? 'dry-run' : opts.translateFn ? 'provider' : 'agent'
   const reportProgress = opts.progressFn ?? (async () => {})
@@ -1383,12 +1496,12 @@ export async function translateMissing(opts: {
     return v === undefined || v === '' || v === null
   }
 
-  /** Count missing keys for a target locale's data */
-  function countMissingKeys(data: Record<string, unknown>): number {
+  /** The keys missing in a target locale's data (scoped to opts.keys when given). */
+  function missingKeysIn(data: Record<string, unknown>): string[] {
     const isMissing = (k: string) => isKeyMissingIn(data, k)
     return opts.keys
-      ? opts.keys.filter(k => isMissing(k) && allRefKeys.includes(k)).length
-      : allRefKeys.filter(k => isMissing(k)).length
+      ? opts.keys.filter(k => isMissing(k) && allRefKeys.includes(k))
+      : allRefKeys.filter(k => isMissing(k))
   }
 
   // Pre-scan: count missing keys per target to compute progressTotal
@@ -1399,7 +1512,7 @@ export async function translateMissing(opts: {
       try {
         scanData = await readLocaleData(config, layer, target)
       } catch {}
-      preScanCounts.push(countMissingKeys(scanData))
+      preScanCounts.push(missingKeysIn(scanData).length)
     }
     // In dry-run or agent mode, only 2 steps per locale (start + complete),
     // no batch steps. Full batching only in provider mode.
@@ -1427,12 +1540,7 @@ export async function translateMissing(opts: {
     target: LocaleDefinition,
     targetData: Record<string, unknown>,
   ): Promise<{ result: TranslateMissingLocaleResult, fallbackContext?: Record<string, unknown> }> {
-    let missingKeys: string[]
-    if (opts.keys) {
-      missingKeys = opts.keys.filter(k => isKeyMissingIn(targetData, k) && allRefKeys.includes(k))
-    } else {
-      missingKeys = allRefKeys.filter(k => isKeyMissingIn(targetData, k))
-    }
+    const missingKeys = missingKeysIn(targetData)
 
     if (missingKeys.length === 0) {
       return { result: { mode, missing: 0, translated: [], failed: [], skipped: [] } }
@@ -1600,6 +1708,8 @@ export async function translateMissing(opts: {
     }
   }
 
+  Object.assign(results, await collectProtectedLocaleResults(config, layer, mode, protectedDefaults, missingKeysIn))
+
   const totalTranslated = Object.values(results).reduce((sum, r) => sum + r.translated.length, 0)
   const totalFailed = Object.values(results).reduce((sum, r) => sum + r.failed.length, 0)
   const totalSkipped = Object.values(results).reduce((sum, r) => sum + r.skipped.length, 0)
@@ -1671,16 +1781,13 @@ export async function translateKey(opts: {
   const isDryRun = opts.dryRun ?? false
   const overwrite = opts.overwrite ?? true
   const sourceLocale = findLocaleOrThrow(config, opts.sourceLocale)
-  const targetLocalesByCode = new Map<string, LocaleDefinition>()
+  const usesDefaultTargets = opts.targetLocales === undefined || opts.targetLocales === 'all'
   const resolvedTargetLocales = opts.targetLocales === undefined || opts.targetLocales === 'all'
     ? config.locales
     : opts.targetLocales.map(localeRef => findLocaleOrThrow(config, localeRef))
-  for (const locale of resolvedTargetLocales) {
-    if (locale.code !== sourceLocale.code && !targetLocalesByCode.has(locale.code)) {
-      targetLocalesByCode.set(locale.code, locale)
-    }
-  }
-  const targetLocales = [...targetLocalesByCode.values()]
+  const { targetLocales, protectedSkipped } = partitionTranslateKeyTargets(
+    config, resolvedTargetLocales, sourceLocale.code, usesDefaultTargets,
+  )
 
   const sourceData = await readLocaleData(config, opts.layer, sourceLocale)
   const existingSourceValue = getNestedValue(sourceData, opts.key)
@@ -1719,9 +1826,12 @@ export async function translateKey(opts: {
   const targetsToTranslate = existingTargets.filter(({ existingValue }) => {
     return overwrite || existingValue === undefined || existingValue === '' || existingValue === null
   })
-  const skipped: Array<{ locale: string, reason: TranslateSkipReason }> = existingTargets
-    .filter(({ existingValue }) => !overwrite && existingValue !== undefined && existingValue !== '' && existingValue !== null)
-    .map(({ locale }) => ({ locale: locale.code, reason: 'already-translated' as const }))
+  const skipped: Array<{ locale: string, reason: TranslateSkipReason }> = [
+    ...protectedSkipped,
+    ...existingTargets
+      .filter(({ existingValue }) => !overwrite && existingValue !== undefined && existingValue !== '' && existingValue !== null)
+      .map(({ locale }) => ({ locale: locale.code, reason: 'already-translated' as const })),
+  ]
 
   const basePlaceholderValidation = validatePlaceholders(opts.key, sourceValue, [{ locale: sourceLocale.code, value: sourceValue }], config.localeFileFormat)
 

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -224,7 +224,7 @@ export type TranslateFailReason =
   | 'write-error'
 
 /** Why a key or locale was intentionally not attempted. */
-export type TranslateSkipReason = 'no-provider' | 'already-translated'
+export type TranslateSkipReason = 'no-provider' | 'already-translated' | 'protected-locale'
 
 export interface TranslateMissingLocaleResult {
   mode: TranslateMode

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ export {
   scaffoldLocaleFiles,
   listNamespaces,
   findLocaleImpl,
+  resolveProtectedLocales,
 } from './core/operations.js'
 
 // Core types

--- a/packages/cli/tests/config/project-config.test.ts
+++ b/packages/cli/tests/config/project-config.test.ts
@@ -311,6 +311,43 @@ describe('loadProjectConfig', () => {
     }
   })
 
+  it('accepts protectedLocales as an array of locale refs', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({
+        protectedLocales: ['en-US', 'en-GB', 'de-DE-formal.json'],
+      }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config).not.toBeNull()
+      expect(config!.protectedLocales).toEqual(['en-US', 'en-GB', 'de-DE-formal.json'])
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  it('throws when protectedLocales is not an array', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({ protectedLocales: 'en-US' }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/protectedLocales/)
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  it('throws when protectedLocales contains empty or whitespace-only entries', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({ protectedLocales: ['en-US', '  '] }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/protectedLocales/)
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
   it('throws when reportOutput is whitespace-only', async () => {
     await mkdir(tmpDir, { recursive: true })
     const configPath = resolve(tmpDir, '.i18n-mcp.json')

--- a/packages/cli/tests/tools/translate-seam.test.ts
+++ b/packages/cli/tests/tools/translate-seam.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { mkdtemp, rm, mkdir, writeFile, readFile, chmod } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import type { TranslateFn } from '../../src/core/types.js'
-import { translateMissing } from '../../src/core/operations.js'
+import { translateMissing, translateKey } from '../../src/core/operations.js'
 import { clearConfigCache } from '../../src/config/detector.js'
 
 /**
@@ -277,6 +277,108 @@ describe('translateMissing through the translate seam', () => {
 
       expect(result.results.en.failed).toEqual([])
       expect((await readLocale('en')).mode).toBe('Press {key} for A|B mode')
+    })
+  })
+
+  describe('protectedLocales', () => {
+    async function writeConfig(protectedLocales: string[]): Promise<void> {
+      await writeFile(join(projectDir, '.i18n-mcp.json'), JSON.stringify({
+        localeDirs: [{ path: 'i18n/locales', layer: 'root' }],
+        defaultLocale: 'de',
+        locales: ['de', 'en', 'fr'],
+        protectedLocales,
+      }, null, 2))
+      clearConfigCache()
+    }
+
+    /** Run translateMissing with default targets and a well-behaved backend. */
+    async function runDefaultTranslate() {
+      return translateMissing({
+        projectDir,
+        layer: 'root',
+        translateFn: fakeTranslator((_k, v) => `[t] ${v}`),
+      })
+    }
+
+    it('excludes protected locales from default targets and reports their missing keys as skipped', async () => {
+      await writeConfig(['fr'])
+
+      const result = await runDefaultTranslate()
+
+      // Only en was translated — fr was withheld but is still reported.
+      expect(result.summary.totalTranslated).toBe(4)
+      expect(result.summary.totalSkipped).toBe(4)
+      expect(result.summary.targetLocales).toEqual([expect.objectContaining({ code: 'en' })])
+      expect(result.results.fr).toMatchObject({
+        mode: 'provider',
+        missing: 4,
+        translated: [],
+        failed: [],
+      })
+      expect(result.results.fr.skipped).toHaveLength(4)
+      expect(result.results.fr.skipped).toEqual(
+        expect.arrayContaining([{ key: 'greeting', reason: 'protected-locale' }]),
+      )
+
+      // The protected locale's file is untouched; the other target was written.
+      expect(await readLocale('fr')).toEqual({})
+      expect((await readLocale('en')).greeting).toBe('[t] Hallo {name}')
+    })
+
+    it('translates a protected locale when it is explicitly named in targetLocales', async () => {
+      await writeConfig(['fr'])
+
+      const result = await translateMissing({
+        projectDir,
+        layer: 'root',
+        targetLocales: ['fr'],
+        translateFn: fakeTranslator((_k, v) => `[t] ${v}`),
+      })
+
+      expect(result.results.fr.translated).toHaveLength(4)
+      expect(result.results.fr.skipped).toEqual([])
+      expect((await readLocale('fr')).greeting).toBe('[t] Hallo {name}')
+    })
+
+    it('ignores protectedLocales entries that do not match a known locale', async () => {
+      await writeConfig(['xx-nope', 'fr'])
+
+      const result = await runDefaultTranslate()
+
+      // The unknown entry changes nothing; the valid one still protects fr.
+      expect(result.summary.totalTranslated).toBe(4)
+      expect(result.results.en.translated).toHaveLength(4)
+      expect(result.results.fr.skipped).toHaveLength(4)
+      expect(await readLocale('fr')).toEqual({})
+    })
+
+    it('translateKey skips protected locales in the default target set and overrides on explicit request', async () => {
+      await writeConfig(['fr'])
+
+      const defaultRun = await translateKey({
+        projectDir,
+        layer: 'root',
+        key: 'greeting',
+        sourceLocale: 'de',
+        translateFn: fakeTranslator((_k, v) => `[t] ${v}`),
+      })
+
+      expect(defaultRun.translated).toEqual(['en'])
+      expect(defaultRun.skipped).toEqual([{ locale: 'fr', reason: 'protected-locale' }])
+      expect(await readLocale('fr')).toEqual({})
+
+      const explicitRun = await translateKey({
+        projectDir,
+        layer: 'root',
+        key: 'greeting',
+        sourceLocale: 'de',
+        targetLocales: ['fr'],
+        translateFn: fakeTranslator((_k, v) => `[t] ${v}`),
+      })
+
+      expect(explicitRun.translated).toEqual(['fr'])
+      expect(explicitRun.skipped).toEqual([])
+      expect((await readLocale('fr')).greeting).toBe('[t] Hallo {name}')
     })
   })
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -26,6 +26,7 @@ import {
   scaffoldLocaleFiles,
   listNamespaces,
   findLocaleImpl,
+  resolveProtectedLocales,
   toErrorMessage,
   createTranslateFn,
 } from 'the-i18n-cli'
@@ -214,6 +215,10 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
         const dirs = await listLocaleDirs(projectDir)
         return jsonContent({
           ...config,
+          // Resolved canonical codes of human-maintained locales that the
+          // translate tools exclude from default targets (raw refs live in
+          // projectConfig.protectedLocales).
+          protectedLocales: resolveProtectedLocales(config).map(l => l.code),
           layers: dirs,
           // Active translation mode — lets operators verify env configuration
           // without triggering a translation. Never includes the API key.

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -18,7 +18,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 let projectDir: string
 let client: Client
 
-async function makeProject(): Promise<string> {
+async function makeProject(extraConfig: Record<string, unknown> = {}): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'i18n-mcp-test-'))
   const localesDir = join(dir, 'i18n', 'locales')
   await mkdir(localesDir, { recursive: true })
@@ -26,6 +26,7 @@ async function makeProject(): Promise<string> {
     localeDirs: [{ path: 'i18n/locales', layer: 'root' }],
     defaultLocale: 'de',
     locales: ['de', 'en'],
+    ...extraConfig,
   }))
   await writeFile(join(localesDir, 'de.json'), JSON.stringify({
     greeting: 'Hallo {name}',
@@ -135,6 +136,22 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.translationMode).toBe('agent')
     expect(json?.translationProvider).toBeUndefined()
     expect(json?.translationModel).toBeUndefined()
+    expect(json?.protectedLocales).toEqual([])
+  })
+
+  it('discover surfaces protectedLocales resolved to canonical codes', async () => {
+    // Refs may use any accepted form (here a file name and an unknown entry);
+    // discover resolves them to canonical codes and drops unknown entries.
+    const dir = await makeProject({ protectedLocales: ['en.json', 'xx-nope'] })
+    try {
+      const { json } = await callTool('discover', { projectDir: dir })
+
+      expect(json?.protectedLocales).toEqual(['en'])
+      // The raw config refs remain visible under projectConfig.
+      expect(json?.projectConfig?.protectedLocales).toEqual(['en.json', 'xx-nope'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   it('translate_missing without a translation backend returns fallback contexts', async () => {


### PR DESCRIPTION
Closes #211 (parent: #198)

## What

`.i18n-mcp.json` gains `protectedLocales` — a list of human-maintained locales that automatic translation must not touch. Motivated by the #198 validation run where en-US/en-GB/de-DE-formal received machine-translated fills because nothing marked them human-authored.

## Changes

- **Config** — `protectedLocales?: string[]` on `ProjectConfig` plus zod validation (optional array of non-empty strings). Entries may be any locale ref (code, language tag, or file name); `resolveProtectedLocales` resolves them via `findLocaleImpl` and ignores unknown entries with a warning.
- **translateMissing** — protected locales are excluded from DEFAULT targets but still reported: a per-locale result entry `{ mode, missing, translated: [], failed: [], skipped: [{ key, reason: 'protected-locale' }, …] }` for each protected locale with missing keys, so callers see what was withheld and totals stay meaningful. Explicitly naming one in `targetLocales` translates it and warns.
- **translateKey** — same policy: excluded from the default `'all'` set with `skipped: [{ locale, reason: 'protected-locale' }]`; explicit naming overrides with a warning.
- **Result contract** — `'protected-locale'` added to `TranslateSkipReason`.
- **MCP discover** — surfaces a resolved top-level `protectedLocales` (canonical codes) next to the raw refs already visible under `projectConfig`.

Docs/schema.json are out of scope (#212).

## Tests

- Seam tests (real temp project, no mocks): default targets skip the protected locale and leave its file untouched while reporting its missing keys; explicit `targetLocales` overrides and writes; unknown entries are ignored; `translateKey` skip/override policy.
- Config schema tests: accepts locale-ref arrays, rejects non-arrays and empty/whitespace entries.
- MCP transport test: discover resolves `['en.json', 'xx-nope']` to `['en']`.

576 CLI + 14 MCP tests green; typecheck, lint, and `fallow audit --base origin/main` clean (the new target-selection logic lives in extracted helpers so `translateMissing`/`translateKey` complexity did not regress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)