### PR TITLE
feat(cli): translate-missing alias for translate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ PLAN.md
 AGENT_HANDOFF.md
 *-plan.md
 reddit-post-*.md
+
+# Claude Code agent worktrees and local state
+.claude/

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,7 +42,7 @@ the-i18n-cli remove-orphans                  # Find orphan keys (dry-run by defa
 | `search` | Search keys and values |
 | `remove` | Remove keys from all locale files in a layer |
 | `rename` | Rename/move a key across all locale files |
-| `translate` | Find missing translations and translate them via LLM (see Translation Modes) |
+| `translate` | Find missing translations and translate them via LLM (see Translation Modes). Also available as `translate-missing`, matching the MCP tool name |
 | `translate-key` | Translate one source key into target locales; can overwrite stale values |
 | `remove-orphans` | Find and remove keys not referenced in source code (dry-run by default) |
 | `scaffold` | Create empty locale files for new languages |

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -13,6 +13,15 @@ export const commands = {
   'remove': () => import('./remove.js').then(m => m.default as CommandDef),
   'rename': () => import('./rename.js').then(m => m.default as CommandDef),
   'translate': () => import('./translate.js').then(m => m.default as CommandDef),
+  // Alias: same operation as `translate`, named to match the MCP tool
+  // translate_missing so docs can use one name across both surfaces.
+  'translate-missing': () => import('./translate.js').then((m) => {
+    const def = m.default as CommandDef
+    return {
+      ...def,
+      meta: { ...(def.meta as object), name: 'translate-missing', description: 'Alias of "translate" — matches the MCP tool translate_missing.' },
+    } as CommandDef
+  }),
   'translate-key': () => import('./translate-key.js').then(m => m.default as CommandDef),
   'scan': () => import('./scan.js').then(m => m.default as CommandDef),
   'remove-orphans': () => import('./remove-orphans.js').then(m => m.default as CommandDef),

--- a/packages/cli/tests/cli/bin-streams.test.ts
+++ b/packages/cli/tests/cli/bin-streams.test.ts
@@ -38,6 +38,15 @@ describe('bin stream routing', () => {
     expect(stdout).toContain('USAGE')
   })
 
+  it('translate-missing is an alias of translate', async () => {
+    const { stdout, code } = await runBin(['translate-missing', '--help'])
+    expect(code).toBe(0)
+    expect(stdout).toContain('translate-missing')
+    // same command definition: identical args surface
+    expect(stdout).toContain('--provider')
+    expect(stdout).toContain('--batchSize')
+  })
+
   it('--version prints the version on stdout', async () => {
     const { stdout, code } = await runBin(['--version'])
     expect(code).toBe(0)


### PR DESCRIPTION
The CLI command `translate` and the MCP tool `translate_missing` are the same operation with different names — pure historical drift, and a recurring source of confusion when reading docs for one surface while using the other.

Adds `translate-missing` as a registry alias of `translate` (same lazy command definition with its own meta name), so documentation can use one consistent name everywhere. `translate` remains fully supported. Spawn-level test asserts the alias resolves with the identical args surface; README command table notes the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)