### PR TITLE
fix(cli): unify locale-dir claim logic, stop dropping dirs behind alias owners

### DIFF
--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -9,7 +9,7 @@ import { loadProjectConfig } from '../../config/project-config'
 import { applyLocaleOverride } from '../../config/locale-override'
 import { log } from '../../utils/logger'
 import { ConfigError, toErrorMessage } from '../../utils/errors'
-import { resolveLayerOwnership } from './layer-dedup'
+import { claimLocaleDir } from './layer-dedup'
 
 export class NuxtAdapter implements FrameworkAdapter {
   readonly name = 'nuxt'
@@ -145,46 +145,21 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
 
     for (const dir of appConfig.localeDirs) {
       const realPath = await realpath(dir.path).catch(() => dir.path)
-      const existing = seenLocalePaths.get(realPath)
-      if (existing) {
-        const { owner, alias } = resolveLayerOwnership(
-          { layer: existing.layer, layerRootDir: existing.layerRootDir },
-          { layer: dir.layer, layerRootDir: dir.layerRootDir },
-          realPath,
-        )
-        if (owner !== existing.layer) {
-          const ownerIndex = allLocaleDirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
-          if (ownerIndex !== -1) {
-            const prev = allLocaleDirs[ownerIndex]
-            allLocaleDirs[ownerIndex] = { ...dir, layer: owner === dir.layer ? dir.layer : owner }
-            allLocaleDirs.push({ ...prev, aliasOf: owner === dir.layer ? dir.layer : owner })
-            seenLocalePaths.set(realPath, { layer: allLocaleDirs[ownerIndex].layer, layerRootDir: allLocaleDirs[ownerIndex].layerRootDir })
-            log.debug(`Layer '${alias}' is alias of '${owner}' (ancestor-based ownership, same path: ${dir.path})`)
-          }
+
+      let claimDir = dir
+      if (!seenLocalePaths.has(realPath)) {
+        let layerName = dir.layer
+        if (usedLayerNames.has(layerName)) {
+          layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
         }
-        else {
-          if (dir.layer !== existing.layer) {
-            allLocaleDirs.push({
-              ...dir,
-              layer: alias === dir.layer ? dir.layer : alias,
-              aliasOf: owner,
-            })
-            log.debug(`Layer '${alias}' is alias of '${owner}' (same path: ${dir.path})`)
-          }
+        if (layerName !== dir.layer) {
+          layerNameRemap.set(dir.layer, layerName)
         }
-        continue
+        usedLayerNames.add(layerName)
+        claimDir = { ...dir, layer: layerName }
       }
 
-      let layerName = dir.layer
-      if (usedLayerNames.has(layerName)) {
-        layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
-      }
-      if (layerName !== dir.layer) {
-        layerNameRemap.set(dir.layer, layerName)
-      }
-      usedLayerNames.add(layerName)
-      seenLocalePaths.set(realPath, { layer: layerName, layerRootDir: dir.layerRootDir })
-      allLocaleDirs.push({ ...dir, layer: layerName })
+      claimLocaleDir(allLocaleDirs, seenLocalePaths, claimDir, realPath)
     }
 
     for (const locale of appConfig.locales) {
@@ -347,54 +322,18 @@ async function discoverLocaleDirs(
     }
 
     const realDir = await realpath(resolvedDir).catch(() => resolvedDir)
-    const existing = resolvedPaths.get(realDir)
-    if (existing) {
-      const { owner, alias } = resolveLayerOwnership(
-        { layer: existing.layer, layerRootDir: existing.layerRootDir },
-        { layer: layerName, layerRootDir },
-        realDir,
-      )
-      if (owner !== existing.layer) {
-        const ownerIndex = dirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
-        if (ownerIndex !== -1) {
-          const prev = dirs[ownerIndex]
-          dirs[ownerIndex] = {
-            path: resolvedDir,
-            layer: layerName,
-            layerRootDir,
-          }
-          dirs.push({ ...prev, aliasOf: layerName })
-          resolvedPaths.set(realDir, { layer: layerName, layerRootDir })
-          log.debug(`Layer '${alias}' is alias of '${owner}' (ancestor-based ownership)`)
-        }
+
+    if (!resolvedPaths.has(realDir)) {
+      const files = await readdir(resolvedDir)
+      const jsonFiles = files.filter(f => f.endsWith('.json'))
+      if (jsonFiles.length === 0) {
+        log.debug(`No JSON files in locale dir for layer '${layerName}': ${resolvedDir}`)
+        continue
       }
-      else {
-        dirs.push({
-          path: resolvedDir,
-          layer: layerName,
-          layerRootDir,
-          aliasOf: existing.layer,
-        })
-        log.debug(`Layer '${alias}' is alias of '${owner}'`)
-      }
-      continue
+      log.debug(`Found locale dir for layer '${layerName}': ${resolvedDir} (${jsonFiles.length} files)`)
     }
 
-    const files = await readdir(resolvedDir)
-    const jsonFiles = files.filter(f => f.endsWith('.json'))
-    if (jsonFiles.length === 0) {
-      log.debug(`No JSON files in locale dir for layer '${layerName}': ${resolvedDir}`)
-      continue
-    }
-
-    resolvedPaths.set(realDir, { layer: layerName, layerRootDir })
-    dirs.push({
-      path: resolvedDir,
-      layer: layerName,
-      layerRootDir,
-    })
-
-    log.debug(`Found locale dir for layer '${layerName}': ${resolvedDir} (${jsonFiles.length} files)`)
+    claimLocaleDir(dirs, resolvedPaths, { path: resolvedDir, layer: layerName, layerRootDir }, realDir)
   }
 
   if (dirs.length === 0) {

--- a/packages/cli/src/adapters/nuxt/layer-dedup.ts
+++ b/packages/cli/src/adapters/nuxt/layer-dedup.ts
@@ -1,4 +1,6 @@
 import { sep } from 'node:path'
+import type { LocaleDir } from '../../config/types'
+import { log } from '../../utils/logger'
 
 export interface LayerRef {
   layer: string
@@ -46,4 +48,62 @@ export function resolveLayerOwnership(
   }
 
   return { owner: existing.layer, alias: incoming.layer }
+}
+
+/**
+ * Claim a locale directory for a layer, deduplicating by real path.
+ *
+ * Mutates `dirs` and `claims`:
+ * - First claim for `realPath`: the incoming dir is pushed and recorded as owner.
+ * - Same path already claimed and the incoming layer wins ownership
+ *   (see `resolveLayerOwnership`): the incoming dir replaces the previous
+ *   owner in place, and the previous owner is re-pushed demoted to an alias.
+ * - Same path already claimed and the existing layer keeps ownership: the
+ *   incoming dir is pushed as an alias of the owner (unless it *is* the owner).
+ * - If the recorded owner cannot be found as a non-alias entry (it was itself
+ *   demoted to an alias by an earlier takeover on another path), the incoming
+ *   dir is still pushed as an alias — a claim never silently drops a dir.
+ */
+export function claimLocaleDir(
+  dirs: LocaleDir[],
+  claims: Map<string, LayerRef>,
+  incoming: LocaleDir,
+  realPath: string,
+): void {
+  const existing = claims.get(realPath)
+
+  if (!existing) {
+    claims.set(realPath, { layer: incoming.layer, layerRootDir: incoming.layerRootDir })
+    dirs.push({ ...incoming })
+    return
+  }
+
+  const { owner, alias } = resolveLayerOwnership(
+    { layer: existing.layer, layerRootDir: existing.layerRootDir },
+    { layer: incoming.layer, layerRootDir: incoming.layerRootDir },
+    realPath,
+  )
+
+  if (owner !== existing.layer) {
+    const ownerIndex = dirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
+    if (ownerIndex !== -1) {
+      const previousOwner = dirs[ownerIndex]
+      const promoted = { ...incoming }
+      delete promoted.aliasOf
+      dirs[ownerIndex] = promoted
+      dirs.push({ ...previousOwner, aliasOf: owner })
+      claims.set(realPath, { layer: incoming.layer, layerRootDir: incoming.layerRootDir })
+      log.debug(`Layer '${alias}' is alias of '${owner}' (ancestor-based ownership, same path: ${incoming.path})`)
+    }
+    else {
+      // Recorded owner is itself an alias — keep the incoming dir as an alias
+      // instead of dropping it.
+      dirs.push({ ...incoming, aliasOf: existing.layer })
+      log.debug(`Layer '${incoming.layer}' is alias of '${existing.layer}' (owner already aliased, same path: ${incoming.path})`)
+    }
+  }
+  else if (incoming.layer !== existing.layer) {
+    dirs.push({ ...incoming, aliasOf: owner })
+    log.debug(`Layer '${alias}' is alias of '${owner}' (same path: ${incoming.path})`)
+  }
 }

--- a/packages/cli/tests/adapters/layer-dedup.test.ts
+++ b/packages/cli/tests/adapters/layer-dedup.test.ts
@@ -10,7 +10,9 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { resolveLayerOwnership } from '../../src/adapters/nuxt/layer-dedup.js'
+import { claimLocaleDir, resolveLayerOwnership } from '../../src/adapters/nuxt/layer-dedup.js'
+import type { LayerRef } from '../../src/adapters/nuxt/layer-dedup.js'
+import type { LocaleDir } from '../../src/config/types.js'
 
 // Helper: build absolute paths without platform issues
 const base = '/projects'
@@ -122,5 +124,94 @@ describe('resolveLayerOwnership — when both are ancestors (same root), existin
     )
     expect(result.owner).toBe('root')
     expect(result.alias).toBe('root-copy')
+  })
+})
+
+describe('claimLocaleDir — stateful claim of a locale dir path', () => {
+  const shopDir: LocaleDir = { path: sharedLocaleDir, layer: 'app-shop', layerRootDir: appShop }
+  const outlookDir: LocaleDir = { path: sharedLocaleDir, layer: 'app-outlook', layerRootDir: appOutlook }
+
+  function setup(): { dirs: LocaleDir[], claims: Map<string, LayerRef> } {
+    return { dirs: [], claims: new Map<string, LayerRef>() }
+  }
+
+  it('first claim pushes the dir and records the layer as owner', () => {
+    const { dirs, claims } = setup()
+
+    claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
+
+    expect(dirs).toEqual([shopDir])
+    expect(dirs[0]).not.toBe(shopDir) // defensive copy, no shared mutation
+    expect(claims.get(sharedLocaleDir)).toEqual({ layer: 'app-shop', layerRootDir: appShop })
+  })
+
+  it('pushes an alias when the existing layer keeps ownership', () => {
+    const { dirs, claims } = setup()
+
+    claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
+    claimLocaleDir(dirs, claims, outlookDir, sharedLocaleDir)
+
+    expect(dirs).toEqual([
+      shopDir,
+      { ...outlookDir, aliasOf: 'app-shop' },
+    ])
+    // Claims map still points at the owner
+    expect(claims.get(sharedLocaleDir)).toEqual({ layer: 'app-shop', layerRootDir: appShop })
+  })
+
+  it('does not push a duplicate when the same layer claims the same path twice', () => {
+    const { dirs, claims } = setup()
+
+    claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
+    claimLocaleDir(dirs, claims, { ...shopDir }, sharedLocaleDir)
+
+    expect(dirs).toEqual([shopDir])
+  })
+
+  it('takeover reorders: incoming true owner replaces in place, previous owner is demoted to alias', () => {
+    const { dirs, claims } = setup()
+
+    // app-outlook (not an ancestor) claims app-shop's locale dir first
+    claimLocaleDir(dirs, claims, outlookDir, sharedLocaleDir)
+    // app-shop (true ancestor) arrives later and takes over
+    claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
+
+    expect(dirs).toEqual([
+      shopDir,
+      { ...outlookDir, aliasOf: 'app-shop' },
+    ])
+    // Claims map is updated to the new owner
+    expect(claims.get(sharedLocaleDir)).toEqual({ layer: 'app-shop', layerRootDir: appShop })
+  })
+
+  it('takeover clears a stale aliasOf on the promoted dir', () => {
+    const { dirs, claims } = setup()
+
+    claimLocaleDir(dirs, claims, outlookDir, sharedLocaleDir)
+    claimLocaleDir(dirs, claims, { ...shopDir, aliasOf: 'stale-owner' }, sharedLocaleDir)
+
+    expect(dirs[0].layer).toBe('app-shop')
+    expect(dirs[0].aliasOf).toBeUndefined()
+  })
+
+  it('regression: incoming dir is not dropped when the recorded owner is itself an alias', () => {
+    const otherPath = `${appOutlook}/i18n/locales`
+
+    // State where the claims map records app-outlook as owner of the shared
+    // path, but app-outlook only exists in dirs as an alias (it was demoted
+    // by an earlier takeover elsewhere).
+    const dirs: LocaleDir[] = [
+      { path: otherPath, layer: 'app-outlook', layerRootDir: appOutlook, aliasOf: 'somewhere-else' },
+    ]
+    const claims = new Map<string, LayerRef>([
+      [sharedLocaleDir, { layer: 'app-outlook', layerRootDir: appOutlook }],
+    ])
+
+    // Incoming true owner cannot find a non-alias entry for the recorded owner.
+    // Before the fix it vanished silently; now it must be kept as an alias.
+    claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
+
+    expect(dirs).toHaveLength(2)
+    expect(dirs[1]).toEqual({ ...shopDir, aliasOf: 'app-outlook' })
   })
 })


### PR DESCRIPTION
## Summary

The stateful locale-dir "claim" sequence (realpath → claims-map lookup → `resolveLayerOwnership` → takeover-or-alias branch) was implemented twice in `packages/cli/src/adapters/nuxt/index.ts` — once in `loadAndMergeApps` (cross-app dedup) and once in `discoverLocaleDirs` (intra-app layers) — and the two copies had silently diverged:

- **Takeover construction**: spread of the incoming dir in one site vs a fresh object literal in the other.
- **Dead ternaries**: `owner === dir.layer ? dir.layer : owner` (and the alias twin) in the merge site — tautological, since `resolveLayerOwnership` always returns one of the two input layers.
- **Alias-push guard**: `dir.layer !== existing.layer` present only in the merge site.

Both copies also shared a real bug: the takeover branch was wrapped in `if (ownerIndex !== -1)` with **no else** — when the recorded owner of a path was itself already demoted to an alias, `findIndex` missed and the incoming dir **silently vanished from the config**.

## Changes

- New `claimLocaleDir(dirs, claims, incoming, realPath)` in `packages/cli/src/adapters/nuxt/layer-dedup.ts`, beside the pure `resolveLayerOwnership`: single implementation of the claim step. Keeps the spread takeover variant (clearing any stale `aliasOf` on promotion), drops the tautological ternaries, keeps the alias-push guard, and adds the missing else: `dirs.push({ ...incoming, aliasOf: existing.layer })` so a locale dir can never be dropped.
- Both adapter call sites shrink to build-dir → realpath → `claimLocaleDir`. Layer-name dedup (`deriveLayerName`) and the JSON-file existence check stay at their call sites, gated on first claim exactly as before.
- First direct tests for the claim glue in `packages/cli/tests/adapters/layer-dedup.test.ts`: first-claim push, alias push (with guard: no duplicate when the same layer re-claims), takeover reorder with `aliasOf` demotion and claims-map update, stale-`aliasOf` clearing on promotion, and the no-drop regression (incoming claiming a path whose recorded owner is already an alias is pushed as an alias instead of vanishing).

`aliasOf` semantics are preserved exactly — all existing layer-dedup, detector-integration, locale-data, and scaffold-locale tests pass unchanged.

Closes #233 (parent #202, step 1)

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ (cli: 608 tests / 31 files, mcp: 14 tests)
- `pnpm -r --filter='./packages/*' typecheck` ✓
- `pnpm lint` ✓ (0 errors; 4 pre-existing warnings, unchanged from main)
- `npx fallow audit --base origin/main` ✓ (exit 0; only warn-level duplication in intentionally-parallel test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)