### PR TITLE
feat(cli): layer graph — canonical layers, ownership, app-consumption edges

### DIFF
--- a/packages/cli/src/config/layer-graph.ts
+++ b/packages/cli/src/config/layer-graph.ts
@@ -1,0 +1,156 @@
+import type { I18nConfig, LocaleDir } from './types'
+
+/**
+ * Queryable view over the layer topology a resolved {@link I18nConfig}
+ * already carries: which locale dirs are canonical (alias-free), which
+ * layer owns an aliased dir, and which apps consume which layers.
+ *
+ * This is a pure derivation — no filesystem access, no config-shape
+ * changes. Cross-layer tooling (duplicate detection, scope-aware orphan
+ * scanning) builds on these queries instead of name-matching heuristics.
+ *
+ * ## Degenerate-case semantics
+ *
+ * These are load-bearing for consumers (scope-aware scanning must never
+ * wrongly narrow its scan scope):
+ *
+ * - **No app info** (`config.apps` empty or absent, e.g. hand-built
+ *   configs): consumption edges are unknowable. `appsUsingLayer` and
+ *   `layersOfApp` return `[]`, and `sharedLayers` conservatively contains
+ *   *every* canonical layer — with no ownership information, every
+ *   layer's keys must be treated as globally visible.
+ * - **Single-app config** (generic/Laravel/Vue/React adapters, or a Nuxt
+ *   project with one app): the strict definition applies, so
+ *   `sharedLayers` is empty (no layer is consumed by more than one app)
+ *   and `appsUsingLayer` returns that one app for the layers it consumes.
+ *   Per-layer scope then equals the whole project, which is correct.
+ * - **Canonical layer consumed by no app** (in a multi-app config):
+ *   `appsUsingLayer` returns `[]` and the layer is not in `sharedLayers`.
+ *   Callers should treat such layers conservatively (global scope).
+ */
+export interface LayerGraph {
+  /**
+   * Alias-free locale dirs, in `config.localeDirs` order. Aliased entries
+   * (e.g. `app-outlook` pointing at `app-shop`'s dir) are excluded.
+   */
+  canonicalLayers: LocaleDir[]
+  /**
+   * Resolve a layer name to the canonical layer that owns its locale dir.
+   * Follows chained `aliasOf` links (an alias may point at a layer that
+   * was itself demoted to an alias). Identity for canonical names and for
+   * names unknown to `localeDirs` (e.g. layers without locale dirs).
+   */
+  ownerOf: (layer: string) => string
+  /**
+   * Names of apps whose consumed layers include the given layer. The
+   * queried name and each app's layer list are alias-resolved via
+   * {@link ownerOf} first, so querying an alias name yields the owner's
+   * consumers. Returns `[]` when no app info exists.
+   */
+  appsUsingLayer: (layer: string) => string[]
+  /**
+   * Canonical layers consumed by more than one app — e.g. a shared root
+   * layer in a multi-app monorepo, identified purely from consumption
+   * edges (no name matching). When no app info exists, contains every
+   * canonical layer (see degenerate-case semantics above).
+   */
+  sharedLayers: LocaleDir[]
+  /**
+   * Canonical layers the given app consumes (alias entries in the app's
+   * layer list resolve to their owners; layers without locale dirs are
+   * omitted). Returns `[]` for unknown apps or when no app info exists.
+   */
+  layersOfApp: (app: string) => LocaleDir[]
+}
+
+/**
+ * Build the alias resolver: follows chained `aliasOf` links to the owning
+ * canonical layer. Identity for canonical and unknown names; guarded
+ * against (malformed) alias cycles.
+ */
+function buildOwnerResolver(localeDirs: LocaleDir[]): (layer: string) => string {
+  // alias name -> immediate target (owner or another alias)
+  const aliasTargets = new Map<string, string>()
+  for (const dir of localeDirs) {
+    if (dir.aliasOf && dir.aliasOf !== dir.layer) {
+      aliasTargets.set(dir.layer, dir.aliasOf)
+    }
+  }
+
+  return (layer: string): string => {
+    let current = layer
+    const seen = new Set<string>()
+    while (aliasTargets.has(current) && !seen.has(current)) {
+      seen.add(current)
+      current = aliasTargets.get(current)!
+    }
+    return current
+  }
+}
+
+interface ConsumptionEdges {
+  /** canonical layer name -> names of apps consuming it */
+  consumers: Map<string, Set<string>>
+  /** app name -> canonical layer names it consumes (locale-dir-backed only) */
+  consumed: Map<string, Set<string>>
+}
+
+/**
+ * Build app → layer consumption edges, alias-resolving every layer name in
+ * each app's layer list. `consumers` keeps edges for layers without locale
+ * dirs too (so `appsUsingLayer` can answer for them); `consumed` is
+ * restricted to canonical, locale-dir-backed layers.
+ */
+function buildConsumptionEdges(
+  apps: I18nConfig['apps'],
+  ownerOf: (layer: string) => string,
+  canonicalNames: Set<string>,
+): ConsumptionEdges {
+  const consumers = new Map<string, Set<string>>()
+  const consumed = new Map<string, Set<string>>()
+
+  for (const app of apps) {
+    const consumedByApp = consumed.get(app.name) ?? new Set<string>()
+    consumed.set(app.name, consumedByApp)
+    for (const layerName of app.layers) {
+      const owner = ownerOf(layerName)
+      const layerConsumers = consumers.get(owner) ?? new Set<string>()
+      consumers.set(owner, layerConsumers)
+      layerConsumers.add(app.name)
+      if (canonicalNames.has(owner)) {
+        consumedByApp.add(owner)
+      }
+    }
+  }
+
+  return { consumers, consumed }
+}
+
+/**
+ * Build a {@link LayerGraph} from a resolved config's `localeDirs`
+ * (with their `aliasOf` markers) and `apps` (app → consumed-layers edges).
+ */
+export function buildLayerGraph(config: I18nConfig): LayerGraph {
+  const localeDirs = config.localeDirs ?? []
+  const canonicalLayers = localeDirs.filter(d => !d.aliasOf)
+  const canonicalNames = new Set(canonicalLayers.map(d => d.layer))
+  const ownerOf = buildOwnerResolver(localeDirs)
+
+  const apps = config.apps ?? []
+  const { consumers, consumed } = buildConsumptionEdges(apps, ownerOf, canonicalNames)
+
+  const sharedLayers = apps.length > 0
+    ? canonicalLayers.filter(d => (consumers.get(d.layer)?.size ?? 0) > 1)
+    : [...canonicalLayers]
+
+  const appsUsingLayer = (layer: string): string[] =>
+    [...(consumers.get(ownerOf(layer)) ?? [])]
+
+  const layersOfApp = (app: string): LocaleDir[] => {
+    const names = consumed.get(app)
+    if (!names || names.size === 0) return []
+    return canonicalLayers.filter(d => names.has(d.layer))
+  }
+
+  return { canonicalLayers, ownerOf, appsUsingLayer, sharedLayers, layersOfApp }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,8 @@ export * from './core/types.js'
 // Config
 export { detectI18nConfig, getCachedConfig, clearConfigCache } from './config/detector.js'
 export type { I18nConfig, LocaleDefinition, LocaleDir, ProjectConfig } from './config/types.js'
+export { buildLayerGraph } from './config/layer-graph.js'
+export type { LayerGraph } from './config/layer-graph.js'
 
 // IO
 export { readLocaleData } from './io/locale-data.js'

--- a/packages/cli/tests/config/layer-graph.test.ts
+++ b/packages/cli/tests/config/layer-graph.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { buildLayerGraph } from '../../src/config/layer-graph.js'
+import type { I18nConfig } from '../../src/config/types.js'
+import {
+  createMultiAppConfig,
+  createNoAppsConfig,
+  createPlaygroundConfig,
+} from '../fixtures/config.js'
+
+describe('buildLayerGraph — canonical layers', () => {
+  const graph = buildLayerGraph(createMultiAppConfig())
+
+  it('canonicalLayers excludes alias entries', () => {
+    const names = graph.canonicalLayers.map(d => d.layer)
+    expect(names).toEqual(['root', 'app-admin', 'app-shop'])
+    expect(graph.canonicalLayers.every(d => !d.aliasOf)).toBe(true)
+  })
+})
+
+describe('buildLayerGraph — ownerOf alias resolution', () => {
+  const graph = buildLayerGraph(createMultiAppConfig())
+
+  it('is identity for canonical layer names', () => {
+    expect(graph.ownerOf('root')).toBe('root')
+    expect(graph.ownerOf('app-admin')).toBe('app-admin')
+    expect(graph.ownerOf('app-shop')).toBe('app-shop')
+  })
+
+  it('resolves an alias to its owning layer', () => {
+    expect(graph.ownerOf('app-outlook')).toBe('app-shop')
+  })
+
+  it('is identity for names unknown to localeDirs', () => {
+    expect(graph.ownerOf('no-such-layer')).toBe('no-such-layer')
+  })
+
+  it('follows chained aliasOf links', () => {
+    const config = createMultiAppConfig()
+    // app-legacy -> app-outlook -> app-shop (an alias pointing at a layer
+    // that was itself demoted to an alias — claimLocaleDir can produce this)
+    config.localeDirs.push({
+      path: config.localeDirs[3].path,
+      layer: 'app-legacy',
+      layerRootDir: config.localeDirs[3].layerRootDir,
+      aliasOf: 'app-outlook',
+    })
+    expect(buildLayerGraph(config).ownerOf('app-legacy')).toBe('app-shop')
+  })
+
+  it('terminates on a (malformed) alias cycle', () => {
+    const config = createMultiAppConfig()
+    config.localeDirs.push(
+      { path: '/tmp/a', layer: 'cycle-a', layerRootDir: '/tmp/a', aliasOf: 'cycle-b' },
+      { path: '/tmp/b', layer: 'cycle-b', layerRootDir: '/tmp/b', aliasOf: 'cycle-a' },
+    )
+    expect(['cycle-a', 'cycle-b']).toContain(buildLayerGraph(config).ownerOf('cycle-a'))
+  })
+})
+
+describe('buildLayerGraph — appsUsingLayer', () => {
+  const graph = buildLayerGraph(createMultiAppConfig())
+
+  it('returns all apps for the shared root layer', () => {
+    expect(graph.appsUsingLayer('root').sort()).toEqual([
+      'app-admin',
+      'app-outlook',
+      'app-shop',
+    ])
+  })
+
+  it('returns only the owning app for a private layer', () => {
+    expect(graph.appsUsingLayer('app-admin')).toEqual(['app-admin'])
+  })
+
+  it('resolves alias names in app layer lists to owners', () => {
+    // app-outlook consumes 'app-outlook' (alias of app-shop) — the edge
+    // must land on the canonical layer.
+    expect(graph.appsUsingLayer('app-shop').sort()).toEqual(['app-outlook', 'app-shop'])
+  })
+
+  it('resolves an alias query to the owner\'s consumers', () => {
+    expect(graph.appsUsingLayer('app-outlook').sort()).toEqual(['app-outlook', 'app-shop'])
+  })
+
+  it('returns [] for a layer no app consumes', () => {
+    expect(graph.appsUsingLayer('no-such-layer')).toEqual([])
+  })
+})
+
+describe('buildLayerGraph — sharedLayers', () => {
+  const graph = buildLayerGraph(createMultiAppConfig())
+
+  it('identifies the root layer from consumption edges alone', () => {
+    const names = graph.sharedLayers.map(d => d.layer).sort()
+    expect(names).toContain('root')
+    // app-shop is shared too: consumed by app-shop and (via alias) app-outlook
+    expect(names).toEqual(['app-shop', 'root'])
+  })
+
+  it('excludes app-private layers', () => {
+    expect(graph.sharedLayers.map(d => d.layer)).not.toContain('app-admin')
+  })
+})
+
+describe('buildLayerGraph — layersOfApp', () => {
+  const graph = buildLayerGraph(createMultiAppConfig())
+
+  it('returns canonical layers the app consumes', () => {
+    expect(graph.layersOfApp('app-admin').map(d => d.layer).sort()).toEqual([
+      'app-admin',
+      'root',
+    ])
+  })
+
+  it('resolves alias entries in the app layer list', () => {
+    expect(graph.layersOfApp('app-outlook').map(d => d.layer).sort()).toEqual([
+      'app-shop',
+      'root',
+    ])
+    expect(graph.layersOfApp('app-outlook').every(d => !d.aliasOf)).toBe(true)
+  })
+
+  it('returns [] for an unknown app', () => {
+    expect(graph.layersOfApp('no-such-app')).toEqual([])
+  })
+
+  it('omits consumed layers without locale dirs but keeps their consumption edges', () => {
+    const config = createMultiAppConfig()
+    // A Nuxt layer without an i18n/locales dir appears in app.layers but
+    // never in localeDirs.
+    config.apps[0].layers.push('base-no-i18n')
+    const withBase = buildLayerGraph(config)
+    expect(withBase.layersOfApp('app-admin').map(d => d.layer).sort()).toEqual([
+      'app-admin',
+      'root',
+    ])
+    expect(withBase.appsUsingLayer('base-no-i18n')).toEqual(['app-admin'])
+  })
+})
+
+describe('buildLayerGraph — degenerate configs', () => {
+  it('no-apps config: every canonical layer is trivially shared', () => {
+    const graph = buildLayerGraph(createNoAppsConfig())
+    expect(graph.canonicalLayers.map(d => d.layer)).toEqual(['default'])
+    expect(graph.sharedLayers).toEqual(graph.canonicalLayers)
+  })
+
+  it('no-apps config: consumption queries return empty results', () => {
+    const graph = buildLayerGraph(createNoAppsConfig())
+    expect(graph.appsUsingLayer('default')).toEqual([])
+    expect(graph.layersOfApp('default')).toEqual([])
+  })
+
+  it('tolerates a config where apps is absent entirely', () => {
+    const config = createNoAppsConfig() as Partial<I18nConfig>
+    delete config.apps
+    const graph = buildLayerGraph(config as I18nConfig)
+    expect(graph.sharedLayers.map(d => d.layer)).toEqual(['default'])
+    expect(graph.appsUsingLayer('default')).toEqual([])
+  })
+
+  it('single-app config: no layer is shared, the app consumes its layers', () => {
+    const graph = buildLayerGraph(createPlaygroundConfig())
+    expect(graph.canonicalLayers.map(d => d.layer)).toEqual(['root'])
+    expect(graph.sharedLayers).toEqual([])
+    expect(graph.appsUsingLayer('root')).toEqual(['root'])
+    expect(graph.layersOfApp('root').map(d => d.layer)).toEqual(['root'])
+  })
+})

--- a/packages/cli/tests/fixtures/config.ts
+++ b/packages/cli/tests/fixtures/config.ts
@@ -102,6 +102,75 @@ export function createMonorepoConfig(): I18nConfig {
     apps: [{ name: 'playground', rootDir: playgroundDir, layers: ['playground'] }],
   }
 }
+const appShopDir = resolve(playgroundDir, 'app-shop')
+const appOutlookDir = resolve(playgroundDir, 'app-outlook')
+
+/**
+ * Multi-app fixture: a root layer shared by all apps, app-private layers
+ * (`app-admin`, `app-shop`), and an alias entry — `app-outlook` reuses
+ * `app-shop`'s locale dir (aliasOf: 'app-shop') and consumes it under the
+ * alias name in its app layer list.
+ */
+export function createMultiAppConfig(): I18nConfig {
+  return {
+    rootDir: playgroundDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales: structuredClone(locales),
+    localeDirs: [
+      {
+        path: resolve(playgroundDir, 'i18n/locales'),
+        layer: 'root',
+        layerRootDir: playgroundDir,
+      },
+      {
+        path: resolve(appAdminDir, 'i18n/locales'),
+        layer: 'app-admin',
+        layerRootDir: appAdminDir,
+      },
+      {
+        path: resolve(appShopDir, 'i18n/locales'),
+        layer: 'app-shop',
+        layerRootDir: appShopDir,
+      },
+      {
+        path: resolve(appShopDir, 'i18n/locales'),
+        layer: 'app-outlook',
+        layerRootDir: appOutlookDir,
+        aliasOf: 'app-shop',
+      },
+    ],
+    layerRootDirs: [playgroundDir, appAdminDir, appShopDir, appOutlookDir],
+    apps: [
+      { name: 'app-admin', rootDir: appAdminDir, layers: ['app-admin', 'root'] },
+      { name: 'app-shop', rootDir: appShopDir, layers: ['app-shop', 'root'] },
+      { name: 'app-outlook', rootDir: appOutlookDir, layers: ['app-outlook', 'root'] },
+    ],
+  }
+}
+
+/**
+ * Degenerate fixture without app info (generic/Laravel-style config where
+ * no app → layer consumption edges exist).
+ */
+export function createNoAppsConfig(): I18nConfig {
+  return {
+    rootDir: playgroundDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales: structuredClone(locales),
+    localeDirs: [
+      {
+        path: resolve(playgroundDir, 'lang'),
+        layer: 'default',
+        layerRootDir: playgroundDir,
+      },
+    ],
+    layerRootDirs: [playgroundDir],
+    apps: [],
+  }
+}
+
 export function createAppAdminConfig(): I18nConfig {
   return {
     rootDir: appAdminDir,


### PR DESCRIPTION
## Summary

Implements #234 (parent #202, step 2): `packages/cli/src/config/layer-graph.ts` — a pure derivation over data the resolved `I18nConfig` already carries (`localeDirs` with `aliasOf` markers + `AppInfo.layers`). No config-shape changes, no adapter changes, no filesystem access.

### API

`buildLayerGraph(config: I18nConfig): LayerGraph` with:

- `canonicalLayers` — alias-free `LocaleDir`s in config order
- `ownerOf(layer)` — resolves alias names (incl. chained `aliasOf`, which `claimLocaleDir` can produce) to the owning canonical layer; identity for canonical/unknown names; cycle-guarded
- `appsUsingLayer(layer)` — app names consuming the layer; both the query and each app's layer list are alias-resolved first
- `sharedLayers` — canonical layers consumed by >1 app, identified purely from consumption edges (no name matching)
- `layersOfApp(app)` — canonical, locale-dir-backed layers the app consumes

### Degenerate-case semantics (documented on `LayerGraph`, load-bearing for #235/#236)

- **No app info** (empty/absent `apps`): consumption queries return `[]`; `sharedLayers` conservatively contains *every* canonical layer, so downstream tooling never wrongly narrows scan scope
- **Single-app configs**: strict `>1 app` definition — `sharedLayers` is empty; per-layer scope equals the whole project, which is correct
- **Layers without locale dirs** (Nuxt layers without i18n): omitted from `layersOfApp`, but their consumption edges are kept so `appsUsingLayer` can still answer

### Tests

21 new unit tests (`packages/cli/tests/config/layer-graph.test.ts`) against a new `createMultiAppConfig()` fixture (shared root + app-private layers + `app-outlook` alias of `app-shop`) and `createNoAppsConfig()` in `tests/fixtures/config.ts`: canonical filtering, chained-alias resolution, cycle termination, consumption edges via alias names, sharedLayers identifying root from edges alone, and all degenerate cases.

Validation: cli build, 629+14 tests green, typecheck, lint (only pre-existing warnings), `fallow audit --base origin/main` clean.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)