### PR TITLE
fix(cli)!: preserve locale file formatting, deliberate deletes, PHP escaping, React flat layouts

### DIFF
--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -237,17 +237,22 @@ async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
     if (isLocaleSubdir(fullPath)) localeCodes.add(entry)
   }
 
-  if (localeCodes.size === 0) {
-    // Flat JSON layout: locales/en.json
-    for (const entry of entries) {
-      if (entry.endsWith('.json')) {
-        localeCodes.add(entry.replace(/\.json$/, ''))
-      }
-    }
+  if (localeCodes.size > 0) {
+    return [...localeCodes].sort().map(code => ({
+      code,
+      language: code,
+    }))
   }
 
-  return [...localeCodes].sort().map(code => ({
-    code,
-    language: code,
-  }))
+  // Flat JSON layout: locales/en.json — `file` is required here, otherwise
+  // resolveLocaleEntries cannot resolve flat entries and every read/write
+  // becomes a silent no-op (#194).
+  return entries
+    .filter(entry => entry.endsWith('.json'))
+    .sort()
+    .map(file => ({
+      code: file.replace(/\.json$/, ''),
+      language: file.replace(/\.json$/, ''),
+      file,
+    }))
 }

--- a/packages/cli/src/io/json-writer.ts
+++ b/packages/cli/src/io/json-writer.ts
@@ -1,6 +1,6 @@
 import { FileIOError } from '../utils/errors'
 import { toErrorMessage } from '../utils/errors'
-import { sortKeysDeep } from './key-operations'
+import { sortKeysDeep, orderKeysPreserving } from './key-operations'
 import { clearFileCacheEntry, readLocaleFileWithMeta } from './json-reader'
 import { atomicWrite } from './atomic-write'
 
@@ -63,11 +63,26 @@ export async function writeReportFile(
   }
 }
 
+/**
+ * Read, mutate, and write back a single JSON locale file while preserving its
+ * existing formatting:
+ *
+ * - Indentation and trailing newline are detected from the file on disk
+ *   (readLocaleFileWithMeta bypasses the mtime read cache by design — it needs
+ *   the raw content; the subsequent write clears the cache entry, so cached
+ *   readers stay consistent).
+ * - Existing keys keep their on-disk order; keys added by the mutation are
+ *   inserted in sorted position among their siblings.
+ */
 export async function mutateLocaleFile(
   filePath: string,
   mutate: (data: Record<string, unknown>) => void,
 ): Promise<void> {
   const { data, indent, trailingNewline } = await readLocaleFileWithMeta(filePath)
+  // Snapshot the on-disk key order before the mutation runs so existing keys
+  // keep their positions even if the mutation rebuilds objects.
+  const reference = structuredClone(data)
   mutate(data)
-  await writeLocaleFile(filePath, data, { indent, trailingNewline })
+  const ordered = orderKeysPreserving(data, reference)
+  await writeLocaleFile(filePath, ordered, { indent, trailingNewline, sortKeys: false })
 }

--- a/packages/cli/src/io/key-operations.ts
+++ b/packages/cli/src/io/key-operations.ts
@@ -105,6 +105,59 @@ export function getLeafKeys(obj: Record<string, unknown>, prefix = '', depth = 0
 export const sortKeysDeep = (obj: Record<string, unknown>): Record<string, unknown> =>
   sortKeys(obj, { deep: true }) as Record<string, unknown>
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Reorder `data` (deeply) against a `reference` object that carries the
+ * authoritative key order (typically the on-disk state before a mutation):
+ *
+ * - Keys that also exist in `reference` keep the reference's relative order.
+ * - Keys new to `data` are inserted in sorted position among their siblings
+ *   (after the last existing sibling that sorts before them), so additions
+ *   land alphabetically without re-sorting existing keys.
+ * - Without a reference, all keys are sorted (equivalent to sortKeysDeep).
+ *
+ * Returns a new object — does not mutate the input.
+ */
+export function orderKeysPreserving(
+  data: Record<string, unknown>,
+  reference?: Record<string, unknown>,
+): Record<string, unknown> {
+  const orderedKeys = reference ? Object.keys(reference).filter(k => k in data) : []
+  const existing = new Set(orderedKeys)
+  const newKeys = Object.keys(data).filter(k => !existing.has(k)).sort()
+
+  for (const key of newKeys) {
+    let insertAt = 0
+    for (let i = orderedKeys.length - 1; i >= 0; i--) {
+      if (orderedKeys[i] <= key) {
+        insertAt = i + 1
+        break
+      }
+    }
+    orderedKeys.splice(insertAt, 0, key)
+  }
+
+  const result: Record<string, unknown> = {}
+  for (const key of orderedKeys) {
+    result[key] = orderValuePreserving(data[key], reference?.[key])
+  }
+  return result
+}
+
+function orderValuePreserving(value: unknown, refValue: unknown): unknown {
+  if (Array.isArray(value)) {
+    const refArray = Array.isArray(refValue) ? refValue : undefined
+    return value.map((item, i) => orderValuePreserving(item, refArray?.[i]))
+  }
+  if (isPlainObject(value)) {
+    return orderKeysPreserving(value, isPlainObject(refValue) ? refValue : undefined)
+  }
+  return value
+}
+
 /**
  * Rename a key in a nested object. Preserves the value.
  * Returns true if the old key was found and renamed.

--- a/packages/cli/src/io/locale-data.ts
+++ b/packages/cli/src/io/locale-data.ts
@@ -1,7 +1,9 @@
 import { join, extname } from 'node:path'
 import { readdir, mkdir, unlink } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { readLocale, writeLocale } from './locale-io'
+import { readLocale, writeLocale, mutateLocale } from './locale-io'
+import { clearFileCacheEntry } from './json-reader'
+import { clearPhpFileCacheEntry } from './php-reader'
 import type { I18nConfig, LocaleDefinition } from '../config/types'
 import { log } from '../utils/logger'
 import { FileIOError } from '../utils/errors'
@@ -45,7 +47,21 @@ export async function resolveLocaleEntries(
   if (jsonEntries.length > 0) return jsonEntries
 
   // Flat JSON (Nuxt: i18n/en-US.json)
-  if (!locale.file) return []
+  if (!locale.file) {
+    // A flat-layout locale without a `file` cannot be resolved at all — reads
+    // would silently report {} and writes would vanish. If a matching flat
+    // file exists on disk, this is a misconfiguration (e.g. an adapter that
+    // forgot to set `file`): fail loudly instead of silently returning [].
+    const flatCandidate = join(localeDir, `${locale.code}.json`)
+    if (existsSync(flatCandidate)) {
+      log.warn(
+        `Locale '${locale.code}' (layer '${layer}') uses a flat JSON layout but has no 'file' set — `
+        + `${flatCandidate} exists yet cannot be resolved. Reads will return no keys and writes will be no-ops. `
+        + `Set 'file' on the locale definition (e.g. '${locale.code}.json').`,
+      )
+    }
+    return []
+  }
   return [{ path: join(localeDir, locale.file), namespace: null }]
 }
 
@@ -146,32 +162,8 @@ export async function mutateLocaleData(
       await mkdir(localePath, { recursive: true })
     }
 
-    for (const [namespace, nsData] of Object.entries(data)) {
-      if (typeof nsData !== 'object' || nsData === null) {
-        log.warn(`Skipping non-object namespace '${namespace}' for locale '${locale.code}'`)
-        continue
-      }
-      if (JSON.stringify(nsData) !== preSnapshots.get(namespace)) {
-        const filePath = join(localePath, `${namespace}${fileExt}`)
-        await writeLocale(filePath, nsData as Record<string, unknown>)
-        filesWritten.add(filePath)
-      }
-    }
-
-    const expectedFiles = new Set(
-      Object.keys(data)
-        .filter(ns => typeof data[ns] === 'object' && data[ns] !== null)
-        .map(ns => `${ns}${fileExt}`),
-    )
-    try {
-      const existingFiles = await readdir(localePath)
-      for (const file of existingFiles) {
-        if (file.endsWith(fileExt) && !expectedFiles.has(file)) {
-          await unlink(join(localePath, file))
-        }
-      }
-    }
-    catch {}
+    await writeChangedNamespaces(data, preSnapshots, localePath, fileExt, locale.code, filesWritten)
+    await deleteRemovedNamespaceFiles(data, preSnapshots, localePath, fileExt, locale.code)
   }
   else {
     // Flat file write (Nuxt-style single JSON file)
@@ -184,7 +176,7 @@ export async function mutateLocaleData(
 
     if (entries.length === 0) return filesWritten
     const filePath = entries[0].path
-    await writeLocale(filePath, data)
+    await writeLocaleEntryFile(filePath, data)
     filesWritten.add(filePath)
   }
 
@@ -192,6 +184,94 @@ export async function mutateLocaleData(
 }
 
 // ─── Internal helpers ───────────────────────────────────────────
+
+/** Write every namespace whose content changed relative to its pre-mutation snapshot. */
+async function writeChangedNamespaces(
+  data: Record<string, unknown>,
+  preSnapshots: Map<string, string>,
+  localePath: string,
+  fileExt: string,
+  localeCode: string,
+  filesWritten: Set<string>,
+): Promise<void> {
+  for (const [namespace, nsData] of Object.entries(data)) {
+    if (typeof nsData !== 'object' || nsData === null) {
+      log.warn(`Skipping non-object namespace '${namespace}' for locale '${localeCode}'`)
+      continue
+    }
+    if (JSON.stringify(nsData) !== preSnapshots.get(namespace)) {
+      const filePath = join(localePath, `${namespace}${fileExt}`)
+      await writeLocaleEntryFile(filePath, nsData as Record<string, unknown>)
+      filesWritten.add(filePath)
+    }
+  }
+}
+
+/**
+ * Delete only the namespace files this mutation explicitly removed (top-level
+ * keys present before the mutation and absent after) — never a
+ * whole-directory reconciliation. Narrowing deletion to this mutation's own
+ * removals also defuses the concurrency hazard: translateMissing runs one
+ * mutation per locale in a Promise.all, and a directory-wide sweep could race
+ * concurrent mutations on shared/aliased namespace dirs and delete files
+ * another locale's mutation was about to write.
+ */
+async function deleteRemovedNamespaceFiles(
+  data: Record<string, unknown>,
+  preSnapshots: Map<string, string>,
+  localePath: string,
+  fileExt: string,
+  localeCode: string,
+): Promise<void> {
+  for (const namespace of preSnapshots.keys()) {
+    if (namespace in data) continue
+    const filePath = join(localePath, `${namespace}${fileExt}`)
+    if (!existsSync(filePath)) continue
+    log.warn(`Deleting namespace file '${filePath}': namespace '${namespace}' was removed from locale '${localeCode}'`)
+    try {
+      await unlink(filePath)
+    }
+    catch (err) {
+      throw new FileIOError(
+        `Failed to delete removed namespace file: ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+        filePath,
+      )
+    }
+    if (fileExt === '.php') clearPhpFileCacheEntry(filePath)
+    else clearFileCacheEntry(filePath)
+  }
+}
+
+/**
+ * Write mutated locale data to a single file.
+ *
+ * Existing files go through the format-preserving mutate path
+ * (mutateLocaleFile / mutatePhpLocaleFile): indentation, trailing newline and
+ * PHP quote style are detected from the file on disk, existing keys keep
+ * their on-disk order, and new keys are inserted in sorted position among
+ * their siblings. The mutate path re-reads the file with metadata (bypassing
+ * the mtime read cache by design) and the write clears the cache entry, so
+ * cached readers stay consistent.
+ *
+ * New files are written with the writer defaults (sorted keys, standard
+ * indentation).
+ */
+async function writeLocaleEntryFile(
+  filePath: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  if (!existsSync(filePath)) {
+    await writeLocale(filePath, data)
+    return
+  }
+
+  await mutateLocale(filePath, (fileData) => {
+    for (const key of Object.keys(fileData)) {
+      delete fileData[key]
+    }
+    Object.assign(fileData, data)
+  })
+}
 
 function resolveLayerDir(config: I18nConfig, layer: string): string | null {
   const dir = config.localeDirs.find(d => d.layer === layer)

--- a/packages/cli/src/io/php-writer.ts
+++ b/packages/cli/src/io/php-writer.ts
@@ -1,8 +1,8 @@
-import { writeFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { FileIOError } from '../utils/errors'
 import { toErrorMessage } from '../utils/errors'
-import { sortKeysDeep } from './key-operations'
+import { sortKeysDeep, orderKeysPreserving } from './key-operations'
 import { clearPhpFileCacheEntry } from './php-reader'
 import { atomicWrite } from './atomic-write'
 
@@ -96,7 +96,9 @@ function escapePhpString(str: string, quote: string): string {
   if (quote === '\'') {
     return str.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')
   }
-  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  // Double-quoted PHP strings interpolate variables: an unescaped `$` (or
+  // `{$…}`) in a value would become live PHP interpolation on read-back.
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$')
 }
 
 function renderArray(
@@ -165,6 +167,12 @@ export function detectPhpStyle(content: string): { quoteStyle: 'single' | 'doubl
   return { quoteStyle, indent }
 }
 
+/**
+ * Read, mutate, and write back a single PHP locale file while preserving its
+ * existing style (quote style + indentation, via detectPhpStyle) and key
+ * order: existing keys keep their on-disk order; keys added by the mutation
+ * are inserted in sorted position among their siblings.
+ */
 export async function mutatePhpLocaleFile(
   filePath: string,
   mutate: (data: Record<string, unknown>) => void,
@@ -173,6 +181,9 @@ export async function mutatePhpLocaleFile(
   const data = await readPhpLocaleFile(filePath)
   const rawContent = await readFile(filePath, 'utf-8')
   const { quoteStyle, indent } = detectPhpStyle(rawContent)
+  // Snapshot the on-disk key order before the mutation runs.
+  const reference = structuredClone(data)
   mutate(data)
-  await writePhpLocaleFile(filePath, data, { quoteStyle, indent })
+  const ordered = orderKeysPreserving(data, reference)
+  await writePhpLocaleFile(filePath, ordered, { quoteStyle, indent, sortKeys: false })
 }

--- a/packages/cli/tests/adapters/react-adapter.test.ts
+++ b/packages/cli/tests/adapters/react-adapter.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { ReactAdapter } from '../../src/adapters/react/index'
 import { registerAdapter, resetRegistry, detectFramework } from '../../src/adapters/registry'
 import { NuxtAdapter } from '../../src/adapters/nuxt/index'
 import { VueAdapter } from '../../src/adapters/vue/index'
+import { readLocaleData, mutateLocaleData } from '../../src/io/locale-data'
+import { clearFileCache } from '../../src/io/json-reader'
 
 function createReactProject(root: string, opts: {
   type?: 'next' | 'react'
@@ -235,6 +237,76 @@ describe('ReactAdapter.resolve', () => {
     const config = await adapter.resolve(tempDir)
 
     expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
+
+  it('sets file on flat-layout locales so entries can be resolved', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0', 'react-i18next': '^14.0.0' },
+    }))
+    const localeDir = join(tempDir, 'locales')
+    mkdirSync(localeDir, { recursive: true })
+    writeFileSync(join(localeDir, 'en.json'), JSON.stringify({ hello: 'world' }))
+    writeFileSync(join(localeDir, 'de.json'), JSON.stringify({ hello: 'welt' }))
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.map(l => l.file)).toEqual(['de.json', 'en.json'])
+  })
+
+  it('does not set file for namespaced layouts', async () => {
+    createReactProject(tempDir)
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+
+    expect(config.locales.every(l => l.file === undefined)).toBe(true)
+  })
+})
+
+describe('ReactAdapter flat JSON layout end-to-end', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `react-flat-e2e-test-${Date.now()}`)
+    mkdirSync(tempDir, { recursive: true })
+    clearFileCache()
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('reads and writes flat JSON locales through the io layer', async () => {
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0', 'react-i18next': '^14.0.0' },
+    }))
+    const localeDir = join(tempDir, 'locales')
+    mkdirSync(localeDir, { recursive: true })
+    writeFileSync(join(localeDir, 'en.json'), '{\n  "zebra": "Zebra",\n  "apple": "Apple"\n}\n')
+    writeFileSync(join(localeDir, 'de.json'), '{\n  "zebra": "Zebra",\n  "apple": "Apfel"\n}\n')
+
+    const adapter = new ReactAdapter()
+    const config = await adapter.resolve(tempDir)
+    const en = config.locales.find(l => l.code === 'en')!
+
+    // Reads must surface the file contents, not silently return {}
+    const data = await readLocaleData(config, 'root', en)
+    expect(data).toEqual({ zebra: 'Zebra', apple: 'Apple' })
+
+    // Writes must land on disk, preserving indentation and key order
+    const written = await mutateLocaleData(config, 'root', en, (d) => {
+      ;(d as Record<string, unknown>).mango = 'Mango'
+    })
+    expect(written.has(join(localeDir, 'en.json'))).toBe(true)
+
+    const content = readFileSync(join(localeDir, 'en.json'), 'utf-8')
+    expect(content).not.toContain('\t')
+    expect(Object.keys(JSON.parse(content))).toEqual(['zebra', 'apple', 'mango'])
+
+    clearFileCache()
+    const after = await readLocaleData(config, 'root', en)
+    expect(after.mango).toBe('Mango')
   })
 })
 

--- a/packages/cli/tests/io/json-writer.test.ts
+++ b/packages/cli/tests/io/json-writer.test.ts
@@ -134,6 +134,44 @@ describe('mutateLocaleFile', () => {
     expect(content).not.toContain('\t')
   })
 
+  it('preserves existing key order and inserts new keys in sorted position', async () => {
+    const filePath = join(tempDir, 'test.json')
+    await writeFile(filePath, '{\n  "zebra": "z",\n  "apple": "a",\n  "mango": "m"\n}\n')
+
+    await mutateLocaleFile(filePath, (data) => {
+      data.banana = 'b'
+    })
+
+    const content = await readFile(filePath, 'utf-8')
+    expect(Object.keys(JSON.parse(content))).toEqual(['zebra', 'apple', 'banana', 'mango'])
+    expect(content).toContain('  "zebra"')
+    expect(content).not.toContain('\t')
+  })
+
+  it('does not re-sort existing nested keys', async () => {
+    const filePath = join(tempDir, 'test.json')
+    await writeFile(filePath, '{\n  "outer": {\n    "zebra": "z",\n    "apple": "a"\n  }\n}\n')
+
+    await mutateLocaleFile(filePath, (data) => {
+      ;((data.outer as Record<string, unknown>)).banana = 'b'
+    })
+
+    const parsed = JSON.parse(await readFile(filePath, 'utf-8'))
+    expect(Object.keys(parsed.outer)).toEqual(['zebra', 'apple', 'banana'])
+  })
+
+  it('preserves absence of trailing newline', async () => {
+    const filePath = join(tempDir, 'test.json')
+    await writeFile(filePath, '{\n  "a": 1\n}')
+
+    await mutateLocaleFile(filePath, (data) => {
+      data.b = 2
+    })
+
+    const content = await readFile(filePath, 'utf-8')
+    expect(content.endsWith('\n')).toBe(false)
+  })
+
   it('works with nested mutation via setNestedValue', async () => {
     const filePath = join(tempDir, 'test.json')
     await writeFile(filePath, '{\n\t"common": {\n\t\t"actions": {\n\t\t\t"save": "Save"\n\t\t}\n\t}\n}\n')

--- a/packages/cli/tests/io/key-operations.test.ts
+++ b/packages/cli/tests/io/key-operations.test.ts
@@ -6,6 +6,7 @@ import {
   hasNestedKey,
   getLeafKeys,
   sortKeysDeep,
+  orderKeysPreserving,
   renameNestedKey,
 } from '../../src/io/key-operations.js'
 
@@ -175,5 +176,71 @@ describe('renameNestedKey', () => {
     const obj: Record<string, unknown> = { a: { b: { c: 1, d: 2 } } }
     expect(renameNestedKey(obj, 'a.b', 'x.y')).toBe(true)
     expect(obj).toEqual({ x: { y: { c: 1, d: 2 } } })
+  })
+})
+
+describe('orderKeysPreserving', () => {
+  it('keeps existing keys in reference order without re-sorting', () => {
+    const reference = { zebra: 1, apple: 2, mango: 3 }
+    const data = { apple: 2, mango: 3, zebra: 1 }
+    expect(Object.keys(orderKeysPreserving(data, reference))).toEqual(['zebra', 'apple', 'mango'])
+  })
+
+  it('inserts new keys in sorted position among existing siblings', () => {
+    const reference = { apple: 1, mango: 2, zebra: 3 }
+    const data = { apple: 1, mango: 2, zebra: 3, banana: 4, aardvark: 5 }
+    expect(Object.keys(orderKeysPreserving(data, reference)))
+      .toEqual(['aardvark', 'apple', 'banana', 'mango', 'zebra'])
+  })
+
+  it('inserts a new key after the last existing sibling that sorts before it (unsorted reference)', () => {
+    const reference = { zebra: 1, apple: 2, mango: 3 }
+    const data = { zebra: 1, apple: 2, mango: 3, banana: 4 }
+    expect(Object.keys(orderKeysPreserving(data, reference)))
+      .toEqual(['zebra', 'apple', 'banana', 'mango'])
+  })
+
+  it('drops keys removed from data', () => {
+    const reference = { a: 1, b: 2, c: 3 }
+    const data = { a: 1, c: 3 }
+    expect(Object.keys(orderKeysPreserving(data, reference))).toEqual(['a', 'c'])
+  })
+
+  it('recurses into nested objects', () => {
+    const reference = { outer: { zebra: 1, apple: 2 } }
+    const data = { outer: { apple: 2, zebra: 1, banana: 3 } }
+    const result = orderKeysPreserving(data, reference)
+    expect(Object.keys(result.outer as Record<string, unknown>))
+      .toEqual(['zebra', 'apple', 'banana'])
+  })
+
+  it('sorts everything when no reference is given (new file)', () => {
+    const data = { z: { b: 1, a: 2 }, a: 3 }
+    const result = orderKeysPreserving(data)
+    expect(Object.keys(result)).toEqual(['a', 'z'])
+    expect(Object.keys(result.z as Record<string, unknown>)).toEqual(['a', 'b'])
+  })
+
+  it('sorts nested objects whose reference value was not an object', () => {
+    const reference = { key: 'string value' }
+    const data = { key: { b: 1, a: 2 } }
+    const result = orderKeysPreserving(data, reference)
+    expect(Object.keys(result.key as Record<string, unknown>)).toEqual(['a', 'b'])
+  })
+
+  it('leaves arrays untouched but orders object elements inside them', () => {
+    const reference = { list: [{ z: 1, a: 2 }, 'x'] }
+    const data = { list: [{ a: 2, z: 1, m: 3 }, 'x', 'y'] }
+    const result = orderKeysPreserving(data, reference)
+    const list = result.list as unknown[]
+    expect(Object.keys(list[0] as Record<string, unknown>)).toEqual(['z', 'a', 'm'])
+    expect(list[1]).toBe('x')
+    expect(list[2]).toBe('y')
+  })
+
+  it('does not mutate the input', () => {
+    const data = { b: 1, a: 2 }
+    orderKeysPreserving(data, { a: 2 })
+    expect(Object.keys(data)).toEqual(['b', 'a'])
   })
 })

--- a/packages/cli/tests/io/locale-data.test.ts
+++ b/packages/cli/tests/io/locale-data.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, writeFile, rm, mkdir, readFile } from 'node:fs/promises'
+import { writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { resolveLocaleEntries, readLocaleData, mutateLocaleData } from '../../src/io/locale-data.js'
 import { clearFileCache } from '../../src/io/json-reader.js'
 import { clearPhpFileCache } from '../../src/io/php-reader.js'
+import { log } from '../../src/utils/logger.js'
 import type { I18nConfig, LocaleDefinition } from '../../src/config/types.js'
 
 let tempDir: string
@@ -486,5 +488,152 @@ describe('mutateLocaleData', () => {
     const { existsSync } = await import('node:fs')
     expect(existsSync(join(tempDir, 'messages', 'en', 'auth.json'))).toBe(false)
     expect(existsSync(join(tempDir, 'messages', 'en', 'common.json'))).toBe(true)
+  })
+
+  it('logs a warning naming each namespace file it deletes', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+
+    try {
+      await mutateLocaleData(config, 'root', locale, (data) => {
+        delete data.auth
+      })
+
+      const messages = warnSpy.mock.calls.map(args => args.join(' '))
+      expect(messages.some(m => m.includes(join(tempDir, 'messages', 'en', 'auth.json')) && m.includes("'auth'"))).toBe(true)
+    }
+    finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('does not delete namespace files it did not explicitly remove', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+    const strayFile = join(tempDir, 'messages', 'en', 'stray.json')
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      // Simulate a concurrent writer creating a namespace file after this
+      // mutation read the directory: it must survive the write-back.
+      writeFileSync(strayFile, JSON.stringify({ other: 'data' }))
+      ;(data.auth as Record<string, string>).login = 'Sign In'
+    })
+
+    const { existsSync } = await import('node:fs')
+    expect(existsSync(strayFile)).toBe(true)
+    expect(JSON.parse(await readFile(strayFile, 'utf-8'))).toEqual({ other: 'data' })
+  })
+
+  it('preserves 2-space indentation and existing key order on namespaced JSON writes', async () => {
+    const enDir = join(tempDir, 'messages', 'en')
+    await mkdir(enDir, { recursive: true })
+    await writeFile(join(enDir, 'common.json'), '{\n  "zebra": "z",\n  "apple": "a",\n  "mango": "m"\n}\n')
+
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.common as Record<string, string>).banana = 'b'
+    })
+
+    const content = await readFile(join(enDir, 'common.json'), 'utf-8')
+    expect(content).not.toContain('\t')
+    expect(content).toContain('  "zebra"')
+    expect(Object.keys(JSON.parse(content))).toEqual(['zebra', 'apple', 'banana', 'mango'])
+    expect(content.endsWith('\n')).toBe(true)
+  })
+
+  it('preserves indentation and key order on flat JSON writes', async () => {
+    const localesDir = join(tempDir, 'locales')
+    await mkdir(localesDir, { recursive: true })
+    await writeFile(join(localesDir, 'en.json'), '{\n  "zebra": "z",\n  "apple": "a"\n}\n')
+
+    const config = makeNuxtConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data as Record<string, unknown>).mango = 'm'
+    })
+
+    const content = await readFile(join(localesDir, 'en.json'), 'utf-8')
+    expect(content).not.toContain('\t')
+    expect(content).toContain('  "zebra"')
+    expect(Object.keys(JSON.parse(content))).toEqual(['zebra', 'apple', 'mango'])
+  })
+
+  it('preserves PHP quote style and key order on namespaced PHP writes', async () => {
+    const enDir = join(tempDir, 'lang', 'en')
+    await mkdir(enDir, { recursive: true })
+    await writeFile(join(enDir, 'auth.php'), `<?php\n\nreturn [\n  'zebra' => 'z',\n  'apple' => 'a',\n];\n`)
+
+    const config = makeLaravelConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data.auth as Record<string, string>).mango = 'm'
+    })
+
+    const content = await readFile(join(enDir, 'auth.php'), 'utf-8')
+    expect(content).toContain("  'zebra' => 'z',")
+    const order = ['zebra', 'apple', 'mango'].map(k => content.indexOf(`'${k}'`))
+    expect([...order].sort((a, b) => a - b)).toEqual(order)
+  })
+
+  it('writes new namespace files with sorted keys and default formatting', async () => {
+    await setupNextJsLocales()
+    const config = makeNextJsConfig()
+    const locale = config.locales[0]
+
+    await mutateLocaleData(config, 'root', locale, (data) => {
+      ;(data as Record<string, unknown>).profile = { title: 'My Profile', avatar: 'Avatar' }
+    })
+
+    const content = await readFile(join(tempDir, 'messages', 'en', 'profile.json'), 'utf-8')
+    expect(Object.keys(JSON.parse(content))).toEqual(['avatar', 'title'])
+    expect(content).toContain('\t"avatar"')
+  })
+})
+
+describe('resolveLocaleEntries flat-layout misconfiguration', () => {
+  it('warns loudly when a flat JSON file exists but the locale has no file set', async () => {
+    const localesDir = join(tempDir, 'locales')
+    await mkdir(localesDir, { recursive: true })
+    await writeFile(join(localesDir, 'en.json'), JSON.stringify({ hello: 'world' }))
+
+    const config = makeNuxtConfig({
+      locales: [{ code: 'en', language: 'en' }], // no `file`
+    })
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+
+    try {
+      const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+      expect(entries).toEqual([])
+
+      const messages = warnSpy.mock.calls.map(args => args.join(' '))
+      expect(messages.some(m => m.includes("'en'") && m.includes("'root'") && m.includes('file'))).toBe(true)
+    }
+    finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('stays silent when neither a file nor a flat candidate exists (new locale)', async () => {
+    await mkdir(join(tempDir, 'locales'), { recursive: true })
+    const config = makeNuxtConfig({
+      locales: [{ code: 'fr', language: 'fr' }],
+    })
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+
+    try {
+      const entries = await resolveLocaleEntries(config, 'root', config.locales[0])
+      expect(entries).toEqual([])
+      expect(warnSpy).not.toHaveBeenCalled()
+    }
+    finally {
+      warnSpy.mockRestore()
+    }
   })
 })

--- a/packages/cli/tests/io/php-writer.test.ts
+++ b/packages/cli/tests/io/php-writer.test.ts
@@ -161,6 +161,59 @@ return [
   })
 })
 
+describe('PHP string escaping round-trips', () => {
+  it('escapes $ in double-quoted output so literal dollars survive read-back', async () => {
+    const filePath = join(tempDir, 'vars.php')
+    const data = {
+      greeting: 'Hello $name',
+      braces: 'Balance: {$x} left',
+      literal: 'Line one\\nLine two',
+    }
+    await writePhpLocaleFile(filePath, data) // default: double quotes
+
+    const content = await readFile(filePath, 'utf-8')
+    expect(content).toContain('Hello \\$name')
+    expect(content).toContain('{\\$x}')
+
+    clearPhpFileCache()
+    const readBack = await readPhpLocaleFile(filePath)
+    expect(readBack).toEqual(data)
+  })
+
+  it('round-trips $ values with single-quote style (no interpolation, no escape needed)', async () => {
+    const filePath = join(tempDir, 'vars-single.php')
+    const data = { greeting: 'Hello $name', braces: '{$x}' }
+    await writePhpLocaleFile(filePath, data, { quoteStyle: 'single' })
+
+    const content = await readFile(filePath, 'utf-8')
+    expect(content).toContain("'Hello $name'")
+
+    clearPhpFileCache()
+    const readBack = await readPhpLocaleFile(filePath)
+    expect(readBack).toEqual(data)
+  })
+
+  it('round-trips double quotes and backslashes in double-quoted output', async () => {
+    const filePath = join(tempDir, 'quotes.php')
+    const data = { quoted: 'He said "hi"', path: 'C:\\temp' }
+    await writePhpLocaleFile(filePath, data)
+
+    clearPhpFileCache()
+    const readBack = await readPhpLocaleFile(filePath)
+    expect(readBack).toEqual(data)
+  })
+
+  it('escapes $ in keys as well as values', async () => {
+    const filePath = join(tempDir, 'dollar-key.php')
+    const data = { '$special': 'value' }
+    await writePhpLocaleFile(filePath, data)
+
+    clearPhpFileCache()
+    const readBack = await readPhpLocaleFile(filePath)
+    expect(readBack).toEqual(data)
+  })
+})
+
 describe('detectPhpStyle', () => {
   it('detects single-quote style', () => {
     const content = `<?php\n\nreturn [\n    'key' => 'value',\n];\n`
@@ -217,5 +270,23 @@ describe('mutatePhpLocaleFile', () => {
     const content = await readFile(filePath, 'utf-8')
     expect(content).toContain("'added' => 'new value'")
     expect(content).toContain("'existing' => 'value'")
+  })
+
+  it('preserves existing key order, indentation and quote style; inserts new keys sorted', async () => {
+    const filePath = join(tempDir, 'order.php')
+    await writeFile(filePath, `<?php\n\nreturn [\n\t'zebra' => 'z',\n\t'apple' => 'a',\n\t'mango' => 'm',\n];\n`)
+
+    await mutatePhpLocaleFile(filePath, (data) => {
+      data.banana = 'b'
+    })
+
+    const content = await readFile(filePath, 'utf-8')
+    // Tab indentation and single quotes preserved
+    expect(content).toContain("\t'zebra' => 'z',")
+    expect(content).not.toContain('"zebra"')
+    // Existing order preserved, new key inserted after the last sibling that sorts before it
+    const order = ['zebra', 'apple', 'banana', 'mango'].map(k => content.indexOf(`'${k}'`))
+    expect(order.every(i => i >= 0)).toBe(true)
+    expect([...order].sort((a, b) => a - b)).toEqual(order)
   })
 })


### PR DESCRIPTION
Closes #194

Four data-integrity fixes in the locale write path (io layer + adapters), found in the 2026-08-08 full-repo assessment.

## 1. Formatting-preserving writes

`mutateLocaleData` previously wrote every touched file through `writeLocaleFile` defaults (tab indent, full deep re-sort), destroying each file's indentation and key order on first touch (observed live: ~3k-line diffs on space-indented / unsorted consumer files).

- The production mutate path is now wired through the previously test-only preserving paths: `mutateLocaleFile` (json-writer) and `mutatePhpLocaleFile` + `detectPhpStyle` (php-writer), via a new `writeLocaleEntryFile` helper in `locale-data.ts`.
- Preserved per file: detected indentation, trailing newline, PHP quote style.
- Key order: existing keys keep their on-disk order; keys **added** by a mutation are inserted in sorted position among their siblings (new `orderKeysPreserving` in `key-operations.ts`) — the documented alphabetical-insertion behavior for additions, without re-sorting existing keys.
- New files keep the old defaults (sorted keys, standard indent).
- Read-cache interplay: the mutate path re-reads via `readLocaleFileWithMeta` (bypasses the mtime cache by design); writes clear the cache entry through `atomicWrite`, so cached readers stay consistent.

## 2. Deliberate namespace-file deletion

The bare-`catch {}` whole-directory reconciliation is replaced by per-mutation semantics:

- Only namespace files whose top-level key was present before the mutation and absent after are deleted.
- Each deletion emits a `log.warn` naming the file and namespace.
- `unlink` errors surface as `FileIOError` instead of being swallowed.
- The narrowed semantics remove the cross-locale race with `translateMissing`'s per-locale `Promise.all` on shared/aliased namespace dirs (documented in a comment on `deleteRemovedNamespaceFiles`); a test simulates a concurrently created namespace file and asserts it survives.

## 3. PHP double-quote escaping

`escapePhpString` now escapes `$` (alongside `\` and `"`) for double-quoted output, so values containing `$name` / `{$x}` no longer become live PHP variable interpolation on read-back. Single-quoted style keeps its existing rules. Round-trip verified through writer + `php-array-reader` for `$name`, `{$x}`, literal `\n`, quotes, backslashes, and `$` in keys.

## 4. React flat-JSON layouts

- The React adapter now sets `LocaleDefinition.file` for flat layouts (like the Vue adapter), so `resolveLocaleEntries` can resolve them; namespaced layouts are unchanged.
- `resolveLocaleEntries` now warns loudly (naming locale + layer) when a flat layout has no `file` but a matching `<code>.json` exists on disk, instead of silently returning `[]` (which made reads report `{}` and writes vanish). It stays silent for genuinely-new locales with no file on disk.

## Tests

650 passing (636 cli + 14 mcp), 42 new:

- `tests/io/key-operations.test.ts`: 9 unit tests for `orderKeysPreserving` (order preservation, sorted insertion incl. unsorted references, removal, recursion, arrays, no-reference sorting, input immutability).
- `tests/io/json-writer.test.ts`: `mutateLocaleFile` preserves existing (unsorted) order + 2-space indent with sorted insertion of new keys; no nested re-sort; preserves absence of trailing newline.
- `tests/io/php-writer.test.ts`: `$`/`{$x}`/backslash/quote round-trips in double- and single-quote styles; `mutatePhpLocaleFile` preserves order, indent and quote style.
- `tests/io/locale-data.test.ts`: 2-space + unsorted-order preservation through `mutateLocaleData` (flat JSON, namespaced JSON, PHP); new namespace files still get sorted defaults; deletion warning names the file; unrelated (concurrently created) namespace files are NOT deleted; `resolveLocaleEntries` flat-layout misconfiguration warns / stays silent for new locales.
- `tests/adapters/react-adapter.test.ts`: flat layout sets `file`, namespaced does not; end-to-end mkdtemp-style test: `resolve` → `readLocaleData` (returns real data, not `{}`) → `mutateLocaleData` (lands on disk, formatting preserved) → re-read.

**Behavior-pinning changes**: no existing test pinned the old destructive behavior at the `mutateLocaleData` level, so no existing assertions had to be rewritten — all 608 pre-existing tests pass unmodified. The seam tests (2-space files, raw reads) now exercise the preserving path and keep passing.

## Breaking change

Write output formatting changes: existing files keep their detected indentation, trailing newline, PHP quote style and existing key order instead of being normalized to tab indentation and fully re-sorted keys; new keys are inserted alphabetically among siblings. Namespace files are only deleted when a mutation explicitly removed the namespace, with a warning per deleted file.

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ (650 tests)
- `pnpm -r --filter='./packages/*' typecheck` ✓
- `pnpm lint` ✓ (0 errors; 3 pre-existing warnings untouched, 1 pre-existing unused-import warning in php-writer removed)
- `npx fallow audit --base origin/main` ✓ exit 0, no baseline regeneration needed (`mutateLocaleData` was refactored into `writeChangedNamespaces` / `deleteRemovedNamespaceFiles` helpers to stay under the complexity gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)