### PR TITLE
chore: comment sweep — constraints over narration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,14 @@ afterEach(async () => {
 3. Add types for any framework-specific config to `config/types.ts`
 4. Add tests in `tests/adapters/<framework>-adapter.test.ts`
 
+## Comments
+
+- Comments state constraints, invariants, and non-obvious "why"s — things the code cannot say itself.
+- No narration of the next line ("// increment the counter") and no restating what a well-named symbol already says.
+- No development-history references ("removed in #208", "per review", "the old X did Y"). If a historical note guards a live invariant, rewrite it as the invariant.
+- Redundant JSDoc that adds nothing over the signature: enrich it with the non-obvious part or delete it.
+- `// ─── Section ───` divider comments are the established navigation style and welcome.
+
 ## PRs
 
 - Branch from `main`

--- a/packages/cli/src/adapters/laravel/index.ts
+++ b/packages/cli/src/adapters/laravel/index.ts
@@ -53,10 +53,8 @@ export class LaravelAdapter implements FrameworkAdapter {
       )
     }
 
-    // Determine file format: honor override, auto-detect, or default
     const format = resolveFormat(langDir, projectConfig?.localeFileFormat)
 
-    // Discover locale codes based on format
     const localeCodes = await discoverLocaleCodes(langDir, format)
     if (localeCodes.length === 0) {
       throw new ConfigError(

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -203,6 +203,7 @@ async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
 }
 
 function extractDefaultLocale(projectDir: string): string | null {
-  // Not critical — return null if .env doesn't exist or can't be read
+  // Stub: default-locale extraction from Vue project config is not
+  // implemented — callers fall back to the first discovered locale.
   return null
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { defineCommand, runCommand, runMain } from 'citty'
 import { log } from './utils/logger.js'
 import { commands as allCommands } from './commands/index.js'
 
-// Hidden diagnostic commands: detect, list-dirs, empty, scan
+// Diagnostic commands kept out of the public CLI surface
 const hiddenCommands = new Set(['detect', 'list-dirs', 'empty', 'scan'])
 const commands = Object.fromEntries(
   Object.entries(allCommands).filter(([key]) => !hiddenCommands.has(key)),

--- a/packages/cli/src/config/nuxt-loader.ts
+++ b/packages/cli/src/config/nuxt-loader.ts
@@ -2,9 +2,7 @@ import { log } from '../utils/logger'
 
 type NuxtKit = typeof import('@nuxt/kit')
 
-/**
- * Dynamically import a module from a given root directory.
- */
+/** Import `id` resolved against the project's node_modules rather than our own. */
 async function importModuleFrom(id: string, rootDir: string): Promise<unknown> {
   const { createRequire } = await import('node:module')
   const require = createRequire(rootDir + '/')

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -86,7 +86,7 @@ export interface ProjectConfig {
 }
 
 /**
- * The fully resolved i18n configuration for a Nuxt project.
+ * The fully resolved i18n configuration for a project.
  */
 export interface I18nConfig {
   /** Detected framework name (e.g., 'nuxt', 'laravel'). Set by the detector. */

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -2,8 +2,8 @@
  * Core i18n operations — pure async functions with no MCP dependency.
  *
  * This module is a barrel: the implementations live in the cohesive
- * modules below, and every symbol operations.ts historically exported is
- * re-exported here so consumers keep a single stable import path.
+ * modules below and are re-exported here so consumers keep a single
+ * stable import path.
  *
  * Each function accepts plain parameters and returns plain objects.
  * Errors are thrown (ToolError etc.) rather than returned as isError responses.

--- a/packages/cli/src/core/ops-read.ts
+++ b/packages/cli/src/core/ops-read.ts
@@ -17,7 +17,8 @@ import { findLayerOrThrow, findLocaleImpl, localeRefInfo } from './shared.js'
 import { resolveReportFilePath } from './report.js'
 
 /**
- * Detect the i18n configuration from the project.
+ * Detect the i18n configuration from the project, always bypassing the
+ * config cache (clears it first).
  */
 export async function detectConfig(projectDir?: string): Promise<I18nConfig> {
   const dir = projectDir ?? process.cwd()
@@ -104,7 +105,6 @@ export async function getTranslations(opts: {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
 
-  // Validate layer exists
   findLayerOrThrow(config, layer)
 
   const localesToRead = locale === '*'
@@ -171,14 +171,12 @@ export async function getMissingTranslations(opts: {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
 
-  // Determine reference locale
   const refCode = opts.referenceLocale ?? config.defaultLocale
   const refLocale = findLocaleImpl(config, refCode)
   if (!refLocale) {
     throw new ToolError(`Reference locale not found: "${refCode}". Available: ${config.locales.map(l => l.code).join(', ')}. Pass a valid locale code as referenceLocale, or omit it to use the project default.`, 'REFERENCE_LOCALE_NOT_FOUND')
   }
 
-  // Determine target locales
   const resolvedTargets = opts.targetLocales ?? opts.locales
   const targets = resolvedTargets
     ? resolvedTargets.map((code) => {
@@ -190,7 +188,6 @@ export async function getMissingTranslations(opts: {
       })
     : config.locales.filter(l => l.code !== refLocale.code)
 
-  // Determine layers to scan
   const layersToScan = layer
     ? config.localeDirs.filter(d => d.layer === layer)
     : config.localeDirs.filter(d => !d.aliasOf)
@@ -277,7 +274,6 @@ export async function findEmptyTranslations(opts: {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
 
-  // Determine locales to check
   const localesToCheck = locale
     ? (() => {
         const loc = findLocaleImpl(config, locale)
@@ -291,7 +287,6 @@ export async function findEmptyTranslations(opts: {
       })()
     : config.locales
 
-  // Determine layers to scan
   const layersToScan = layer
     ? config.localeDirs.filter(d => d.layer === layer)
     : config.localeDirs.filter(d => !d.aliasOf)
@@ -366,7 +361,6 @@ export async function searchTranslations(opts: {
   const mode = opts.searchIn ?? 'both'
   const queryLower = query.toLowerCase()
 
-  // Determine layers to search
   const layersToSearch = (layer && layer !== '*')
     ? config.localeDirs.filter(d => d.layer === layer)
     : config.localeDirs.filter(d => !d.aliasOf)
@@ -378,7 +372,6 @@ export async function searchTranslations(opts: {
     throw new ToolError('No locale directories found. Run detect_i18n_config to verify the project setup.', 'LAYER_NOT_FOUND')
   }
 
-  // Determine locales to search
   const localesToSearch = locale
     ? (() => {
         const found = findLocaleImpl(config, locale)
@@ -463,7 +456,6 @@ export async function listNamespaces(opts: {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
 
-  // Validate and resolve layers
   if (opts.layer && opts.layer !== '*') {
     findLayerOrThrow(config, opts.layer)
   }
@@ -471,7 +463,6 @@ export async function listNamespaces(opts: {
     ? config.localeDirs.filter(d => d.layer === opts.layer)
     : config.localeDirs.filter(d => !d.aliasOf)
 
-  // Resolve locale: validate explicit, default to configured default locale
   const localeToUse = opts.locale
     ? findLocaleImpl(config, opts.locale) ?? (() => {
         throw new ToolError(`Locale not found: "${opts.locale}". Available: ${config.locales.map(l => l.code).join(', ')}.`, 'LOCALE_NOT_FOUND')
@@ -511,7 +502,6 @@ export async function listNamespaces(opts: {
       node.keyCount++ // leaf count at terminal node
     }
 
-    // Propagate leaf counts upward
     propagateCounts(root)
 
     layers[ld.layer] = { namespaces: root.children ?? {} }

--- a/packages/cli/src/core/ops-translate.ts
+++ b/packages/cli/src/core/ops-translate.ts
@@ -33,15 +33,16 @@ import { findLayerOrThrow, findLocaleImpl, findLocaleOrThrow, localeRefInfo } fr
 // ─── Shared helpers (exported for reuse) ────────────────────────
 
 /**
- * Fixed maxTokens budget for a translate request. Batch size no longer
- * scales the budget — models simply stop when the JSON object is closed.
+ * Fixed maxTokens budget for a translate request. Deliberately independent
+ * of batch size — models simply stop when the JSON object is closed.
  */
 export function computeMaxTokens(_batchKeyCount: number): number {
   return 16384
 }
 
 /**
- * Compute the total number of progress steps for translate_missing.
+ * Total progress steps for translate_missing: per locale with missing keys,
+ * one step per batch plus a start and a complete step (the +2).
  */
 export function computeProgressTotal(missingKeyCounts: number[], maxBatch: number): number {
   return missingKeyCounts.reduce((sum, count) => {
@@ -463,13 +464,11 @@ export async function translateMissing(opts: {
     throw new ToolError(`Invalid batchSize: ${opts.batchSize}. Must be a positive integer.`, 'INVALID_BATCH_SIZE')
   }
 
-  // Validate layer
   const localeDir = findLayerOrThrow(config, layer)
   if (localeDir.aliasOf) {
     throw new ToolError(`Layer "${layer}" is an alias of "${localeDir.aliasOf}". Modify the source layer "${localeDir.aliasOf}" instead.`, 'LAYER_IS_ALIAS')
   }
 
-  // Determine reference locale
   const refCode = opts.referenceLocale ?? config.defaultLocale
   const refLocale = findLocaleImpl(config, refCode)
   if (!refLocale) {
@@ -491,7 +490,6 @@ export async function translateMissing(opts: {
   const mode: TranslateMode = isDryRun ? 'dry-run' : opts.translateFn ? 'provider' : 'agent'
   const reportProgress = opts.progressFn ?? (async () => {})
 
-  /** Check whether a key is missing in a given locale data object */
   function isKeyMissingIn(data: Record<string, unknown>, k: string): boolean {
     const v = getNestedValue(data, k)
     return v === undefined || v === '' || v === null
@@ -556,7 +554,6 @@ export async function translateMissing(opts: {
 
     await reportProgress(`Starting ${target.code}: ${missingKeys.length} missing keys`)
 
-    // Build key-value pairs from reference
     const keysAndValues: Record<string, string> = {}
     for (const key of missingKeys) {
       const value = getNestedValue(refData, key)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,5 @@
 // Public API — re-export everything the MCP package (and other consumers) need
 
-// Error utilities (added for MCP error handling)
-
 // Core operations
 export {
   detectConfig,

--- a/packages/cli/src/io/key-operations.ts
+++ b/packages/cli/src/io/key-operations.ts
@@ -58,7 +58,6 @@ export function removeNestedValue(obj: Record<string, unknown>, path: string): b
 
   delete current[lastKey]
 
-  // Clean up empty parent objects - parent can be cleaned up if childs are empty
   for (let i = parents.length - 1; i >= 0; i--) {
     const { obj: parentObj, key } = parents[i]
     const child = parentObj[key] as Record<string, unknown>
@@ -132,14 +131,12 @@ export function validateTranslationValue(value: unknown): string | null {
     return `Value must be a string, got ${typeof value}`
   }
 
-  // Check for unbalanced placeholder braces
   const openBraces = (value.match(/\{/g) || []).length
   const closeBraces = (value.match(/\}/g) || []).length
   if (openBraces !== closeBraces) {
     return `Unbalanced placeholder braces: ${openBraces} opening vs ${closeBraces} closing in "${value}"`
   }
 
-  // Check for malformed linked references
   if (value.includes('@:') && /@:\s*$/.test(value)) {
     return `Malformed linked reference: "@:" at end of string with no target`
   }

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -46,8 +46,7 @@ export interface ScanResult {
  * Extract all i18n key references from file content.
  * Returns static usages and dynamic (unresolvable) references.
  *
- * When no `patterns` argument is provided, defaults to Vue/Nuxt patterns
- * for backward compatibility.
+ * When `patterns` is omitted, defaults to Vue/Nuxt patterns.
  */
 export function extractKeys(content: string, filePath: string, patterns?: ScanPatternSet): { usages: KeyUsage[]; dynamicKeys: DynamicKeyUsage[] } {
   const pat = patterns ?? VUE_NUXT_PATTERNS
@@ -215,8 +214,7 @@ function buildUnresolvedWarnings(dynamicKeys: DynamicKeyUsage[]): UnresolvedKeyW
 /**
  * Scan source files in a directory for i18n key usage.
  *
- * When `patterns` is omitted, defaults to Vue/Nuxt patterns for backward
- * compatibility.
+ * When `patterns` is omitted, defaults to Vue/Nuxt patterns.
  */
 export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], patterns?: ScanPatternSet): Promise<ScanResult> {
   const pat = patterns ?? VUE_NUXT_PATTERNS
@@ -283,7 +281,6 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
       bareDynamicCandidates.add(`\`${normalized}\``)
     }
 
-    // Concat prefix: 'some.key.' + var  (catches multiline t() calls)
     BARE_CONCAT_PREFIX.lastIndex = 0
     for (const match of content.matchAll(BARE_CONCAT_PREFIX)) {
       bareDynamicCandidates.add(`\`${match[2]}.\${_}\``)

--- a/packages/cli/tests/adapters/layer-dedup.test.ts
+++ b/packages/cli/tests/adapters/layer-dedup.test.ts
@@ -1,12 +1,9 @@
 /**
- * Tests for ancestor-based layer dedup (issue #70).
+ * Tests for ancestor-based layer dedup.
  *
  * When two layers claim the same locale directory path, the layer whose
  * `layerRootDir` is an ancestor of (or equal to) the locale dir path is the
  * true owner. The other layer gets `aliasOf` pointing to the owner.
- *
- * The tests exercise `resolveLayerOwnership` — the pure helper extracted
- * from the dedup logic in `src/adapters/nuxt/index.ts`.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -207,8 +204,8 @@ describe('claimLocaleDir — stateful claim of a locale dir path', () => {
       [sharedLocaleDir, { layer: 'app-outlook', layerRootDir: appOutlook }],
     ])
 
-    // Incoming true owner cannot find a non-alias entry for the recorded owner.
-    // Before the fix it vanished silently; now it must be kept as an alias.
+    // The incoming true owner cannot find a non-alias entry for the recorded
+    // owner — it must still be kept as an alias, never silently dropped.
     claimLocaleDir(dirs, claims, shopDir, sharedLocaleDir)
 
     expect(dirs).toHaveLength(2)

--- a/packages/cli/tests/adapters/react-adapter.test.ts
+++ b/packages/cli/tests/adapters/react-adapter.test.ts
@@ -83,8 +83,7 @@ describe('ReactAdapter.detect', () => {
 
   it('returns 8 for Next.js without i18n dep but with locale files', async () => {
     createReactProject(tempDir, { i18nDep: null })
-    // next (5) + next.config (1) + locale files (2) = 8... wait
-    // Actually without i18n dep: next (5) + hasNextConfig (1) + locale files (2) = 8
+    // next (5) + next.config (1) + locale files (2) = 8
     const adapter = new ReactAdapter()
     expect(await adapter.detect(tempDir)).toBe(8)
   })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -209,9 +209,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     },
     async ({ projectDir }) => {
       try {
-        // Detect config first (warms cache)
+        // detectConfig first: it warms the config cache listLocaleDirs reuses
         const config = await detectConfig(projectDir)
-        // Then get layer directory info
         const dirs = await listLocaleDirs(projectDir)
         return jsonContent({
           ...config,
@@ -560,11 +559,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     },
     async ({ layer, referenceLocale, targetLocales, keys, batchSize, dryRun, compact, projectDir }, extra) => {
       try {
-        // Build progressFn from MCP progress notifications.
-        // progressTotal is set by the onProgressTotal callback below, which runs
-        // during the pre-scan phase of translateMissing — before any progress
-        // notifications are sent. This temporal coupling is safe because the core
-        // operation always pre-scans before emitting progress.
+        // Invariant: translateMissing invokes onProgressTotal during its
+        // pre-scan, before the first progressFn call — progressTotal is
+        // always set by the time a notification is sent.
         const progressToken = extra._meta?.progressToken
         let progressCurrent = 0
         let progressTotal: number | undefined


### PR DESCRIPTION
## Summary

Comment-quality sweep of `packages/cli/src`, `packages/mcp/src`, and test files (lighter touch). Zero executable-code changes — the diff is comments plus a new CONTRIBUTING.md section. Validated by building, running all tests (608 CLI + 14 MCP, all green), typecheck, and lint (0 errors, same 4 pre-existing warnings as main).

Excluded by design (parallel rewrite in flight): `io/locale-data|json-*|php-*|read-cache|atomic-write`, `adapters/react`, `tests/io/**`.

## Files touched (15)

- **Source**: `cli.ts`, `index.ts`, `config/{nuxt-loader,types}.ts`, `core/{operations,ops-read,ops-translate}.ts`, `io/key-operations.ts`, `scanner/code-scanner.ts`, `adapters/{laravel,vue}/index.ts`, `mcp/src/server.ts`
- **Tests**: `adapters/{layer-dedup,react-adapter}.test.ts`
- **Docs**: `CONTRIBUTING.md` — new "Comments" section codifying the standard (constraints and non-obvious whys; no next-line narration; no development-history references; dividers OK)

## Rough tally

- **Removed (~20)**: next-line narration (`// Validate layer`, `// Determine reference locale`, eight `// Determine X` block labels in ops-read, `// Check for unbalanced placeholder braces`, …), comments duplicating an adjacent doc comment, an orphaned "(added for MCP error handling)" note, and a leftover "= 8... wait / Actually…" thinking-out-loud pair in the React adapter test.
- **Tightened/rewritten (~12)**: history-flavored notes rewritten as live invariants — the MCP progress "temporal coupling is safe because…" note now states the invariant (onProgressTotal fires during pre-scan, before the first notification); "batch size no longer scales the budget" → "deliberately independent of batch size"; "for backward compatibility" default-patterns phrasing dropped; `operations.ts` barrel header de-historicized; layer-dedup test's "before the fix it vanished silently" → "must be kept as an alias, never silently dropped" and stale file-path/issue references removed; stale `extractDefaultLocale` comment now honestly labeled a stub; redundant JSDoc enriched instead of deleted (`detectConfig` now documents the cache-clearing, `computeProgressTotal` explains the `+2`, `importModuleFrom` explains project-local resolution).
- **Kept deliberately**: stdout-purity rationale (guard/logger/bin), compact-is-a-projection rule, batch accounting and abort/idempotency notes in translate, alias/ownership semantics in layer-dedup, samplingPreferences shim, test-only injection seam warnings, hoisted `vi.mock` notes, all `// ─── Section ───` dividers, and test comments that explain scenario intent or score arithmetic.

## Judgment calls

- Kept `// Dry run — just report` / `// Actual removal` block labels in the long `removeOrphanKeys` function — borderline narration, but they mark major phases of a 170-line function.
- Fixed a factual staleness while sweeping: `I18nConfig` was documented as "for a Nuxt project" though it serves Laravel/Vue/generic too.
- Left `// TODO: use specific result type` comments untouched — TODOs were out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)