### PR TITLE
feat(cli): layer-scope-aware orphan scanning with misplaced-usage detection

### DIFF
--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -3,17 +3,122 @@
  * referenced in source code, plus code-usage scanning.
  */
 
+import { isAbsolute, relative } from 'node:path'
+
 import { detectI18nConfig } from '../config/detector.js'
+import { buildLayerGraph } from '../config/layer-graph.js'
 import type { I18nConfig, LocaleDir } from '../config/types.js'
 import { writeReportFile } from '../io/json-writer.js'
 import { readLocaleData, mutateLocaleData } from '../io/locale-data.js'
 import { getLeafKeys, removeNestedValue } from '../io/key-operations.js'
 import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from '../scanner/code-scanner.js'
+import type { OrphanScanPlan, OrphanScanResult } from '../scanner/code-scanner.js'
 import { getPatternSet } from '../scanner/patterns.js'
 import { ToolError } from '../utils/errors.js'
 
 import { findLayerOrThrow, findLocaleImpl } from './shared.js'
 import { validateReportPath, resolveReportFilePath } from './report.js'
+
+const MISPLACED_USAGE_NOTE
+  = 'Keys referenced only from apps that do not consume their layer. '
+  + 'Either the key belongs in a broader (shared) layer, or the usage is a bug. '
+  + 'These keys are not counted as orphans and are never removed.'
+
+/** True when `child` equals `parent` or lies inside it. */
+function isWithin(child: string, parent: string): boolean {
+  const rel = relative(parent, child)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+/**
+ * Build the scope-aware scan plan for orphan detection from the layer graph.
+ *
+ * Units are the distinct app root dirs plus canonical layer root dirs (each
+ * scanned exactly once — nested unit dirs are carved out of ancestor scans).
+ * Layer L's scope is its own layer root dir plus the root dirs of all apps
+ * in `appsUsingLayer(L)`.
+ *
+ * Degenerate cases (no app info, or a layer consumed by no app) fall back to
+ * ALL units — the whole-project behavior of the pre-scope-aware scan. Code
+ * outside every unit (e.g. scripts/ in a monorepo scanned from its root) is
+ * claimed by a synthetic project-root unit that counts for every layer, so
+ * scoping never produces orphans the old global scan would not have.
+ */
+export function buildOrphanScanPlan(config: I18nConfig, projectDir: string): OrphanScanPlan {
+  const graph = buildLayerGraph(config)
+  const apps = config.apps ?? []
+
+  const nameByDir = new Map<string, string>()
+  const usedNames = new Set<string>()
+  const claim = (dir: string, name: string): void => {
+    if (nameByDir.has(dir)) return
+    let unique = name
+    let n = 2
+    while (usedNames.has(unique)) unique = `${name}#${n++}`
+    nameByDir.set(dir, unique)
+    usedNames.add(unique)
+  }
+
+  // Apps claim first so a dir shared by an app and its layer reports the app name.
+  for (const app of apps) claim(app.rootDir, app.name)
+  for (const layer of graph.canonicalLayers) claim(layer.layerRootDir, layer.layer)
+
+  let projectUnitName: string | undefined
+  if (![...nameByDir.keys()].some(unitDir => isWithin(projectDir, unitDir))) {
+    claim(projectDir, 'project-root')
+    projectUnitName = nameByDir.get(projectDir)
+  }
+
+  const units = [...nameByDir].map(([dir, name]) => ({ name, dir }))
+  const allNames = units.map(u => u.name)
+
+  const scopeByLayer = new Map<string, string[]>()
+  for (const layer of graph.canonicalLayers) {
+    const consumers = graph.appsUsingLayer(layer.layer)
+    if (apps.length === 0 || consumers.length === 0) {
+      scopeByLayer.set(layer.layer, allNames)
+      continue
+    }
+    const scope = new Set<string>()
+    if (projectUnitName) scope.add(projectUnitName)
+    scope.add(nameByDir.get(layer.layerRootDir)!)
+    for (const appName of consumers) {
+      const app = apps.find(a => a.name === appName)
+      if (app) scope.add(nameByDir.get(app.rootDir)!)
+    }
+    scopeByLayer.set(layer.layer, [...scope])
+  }
+
+  return { units, scopeByLayer }
+}
+
+/** Relativize each layer's scan-scope dirs against the project dir for reporting. */
+function relativeScanScope(result: OrphanScanResult, projectDir: string): Record<string, string[]> {
+  const scanScope: Record<string, string[]> = {}
+  for (const [layerName, dirs] of Object.entries(result.scanScopeByLayer)) {
+    scanScope[layerName] = dirs.map(d => toRelativePath(d, projectDir) || '.')
+  }
+  return scanScope
+}
+
+/**
+ * Shared scan entry for findOrphanKeys/removeOrphanKeys: explicit scanDirs
+ * keep the global combined-scan behavior; otherwise a scope-aware plan is
+ * built from the layer graph.
+ */
+async function runOrphanScan(
+  config: I18nConfig,
+  keysByLayer: Map<string, { keys: string[]; localeDir: LocaleDir }>,
+  opts: { scanDirs?: string[]; excludeDirs?: string[]; dir: string },
+): Promise<OrphanScanResult> {
+  return findOrphanKeysForConfig({
+    keysByLayer,
+    ...(opts.scanDirs ? { scanDirs: opts.scanDirs } : { scanPlan: buildOrphanScanPlan(config, opts.dir) }),
+    excludeDirs: opts.excludeDirs || undefined,
+    resolveIgnorePatterns: layerName => resolveOrphanIgnorePatterns(config, layerName),
+    patterns: getPatternSet(config.localeFileFormat),
+  })
+}
 
 export function resolveOrphanIgnorePatterns(
   config: I18nConfig,
@@ -90,6 +195,13 @@ async function resolveOrphanScanContext(
 export async function findOrphanKeys(opts: {
   layer?: string
   locale?: string
+  /**
+   * Explicit scan roots — manual scope control. When set, all layers are
+   * checked against one combined usage set from these dirs (no per-layer
+   * scoping, no misplaced-usage detection). When absent, a scope-aware plan
+   * from the layer graph is used: each layer is checked against the apps
+   * that consume it.
+   */
   scanDirs?: string[]
   excludeDirs?: string[]
   projectDir?: string
@@ -119,13 +231,7 @@ export async function findOrphanKeys(opts: {
     return emptyOutput
   }
 
-  const orphanResult = await findOrphanKeysForConfig({
-    keysByLayer,
-    scanDirs: scanDirs || [dir],
-    excludeDirs: excludeDirs || undefined,
-    resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
-    patterns: getPatternSet(config.localeFileFormat),
-  })
+  const orphanResult = await runOrphanScan(config, keysByLayer, { scanDirs, excludeDirs, dir })
 
   const byLayer = orphanResult.orphansByLayer
   const allOrphanKeys: Array<{ key: string; layer: string }> = []
@@ -139,19 +245,24 @@ export async function findOrphanKeys(opts: {
     sortedByLayer[keyLayer].push(key)
   }
 
+  const misplacedCount = orphanResult.misplacedUsages.length
   const output: Record<string, unknown> = {
     orphanKeys: sortedByLayer,
     uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
+    misplacedUsages: misplacedCount > 0 ? orphanResult.misplacedUsages : undefined,
+    misplacedUsageNote: misplacedCount > 0 ? MISPLACED_USAGE_NOTE : undefined,
     summary: {
       totalKeys,
       orphanCount: orphanResult.orphanCount,
       uncertainCount: orphanResult.uncertainCount,
+      misplacedCount,
       dynamicMatchedCount: orphanResult.dynamicMatchedCount,
       ignoredCount: orphanResult.ignoredCount,
-      usedCount: totalKeys - orphanResult.orphanCount - orphanResult.uncertainCount,
+      usedCount: totalKeys - orphanResult.orphanCount - orphanResult.uncertainCount - misplacedCount,
       filesScanned: orphanResult.totalFilesScanned,
       layersChecked: layersToCheck.map(d => d.layer),
       dirsScanned: orphanResult.dirsScanned,
+      scanScope: relativeScanScope(orphanResult, dir),
       locale: localeCode,
     },
     dynamicKeyWarning: orphanResult.allDynamicKeys.length > 0
@@ -277,6 +388,7 @@ export async function scanCodeUsage(opts: {
 export async function removeOrphanKeys(opts: {
   layer?: string
   locale?: string
+  /** Explicit scan roots — manual scope control, same semantics as {@link findOrphanKeys}. */
   scanDirs?: string[]
   excludeDirs?: string[]
   dryRun?: boolean
@@ -309,18 +421,16 @@ export async function removeOrphanKeys(opts: {
     return emptyOutput
   }
 
-  const orphanResult = await findOrphanKeysForConfig({
-    keysByLayer,
-    scanDirs: scanDirs || [dir],
-    excludeDirs: excludeDirs || undefined,
-    resolveIgnorePatterns: (layerName) => resolveOrphanIgnorePatterns(config, layerName),
-    patterns: getPatternSet(config.localeFileFormat),
-  })
+  const orphanResult = await runOrphanScan(config, keysByLayer, { scanDirs, excludeDirs, dir })
   const orphansByLayer = orphanResult.orphansByLayer
   const orphanCount = orphanResult.orphanCount
   const totalFilesScanned = orphanResult.totalFilesScanned
   const dynamicMatchedCount = orphanResult.dynamicMatchedCount
   const ignoredCount = orphanResult.ignoredCount
+  const misplacedCount = orphanResult.misplacedUsages.length
+  const misplacedUsages = misplacedCount > 0 ? orphanResult.misplacedUsages : undefined
+  const misplacedUsageNote = misplacedCount > 0 ? MISPLACED_USAGE_NOTE : undefined
+  const scanScope = relativeScanScope(orphanResult, dir)
   const allDynamicKeys = orphanResult.allDynamicKeys.map(dk => ({
     expression: dk.expression,
     file: toRelativePath(dk.file, dir),
@@ -332,11 +442,14 @@ export async function removeOrphanKeys(opts: {
     if (dynamicMatchedCount > 0) messageParts.push(`${dynamicMatchedCount} key(s) were excluded by dynamic pattern matching.`)
     if (ignoredCount > 0) messageParts.push(`${ignoredCount} key(s) were excluded by ignore patterns.`)
     if (orphanResult.uncertainCount > 0) messageParts.push(`${orphanResult.uncertainCount} uncertain key(s) were excluded because they overlap with dynamic translation patterns.`)
-    if (dynamicMatchedCount === 0 && ignoredCount === 0 && orphanResult.uncertainCount === 0) messageParts.push('All translation keys are referenced in code.')
+    if (misplacedCount > 0) messageParts.push(`${misplacedCount} key(s) are referenced only outside their layer's scope (see misplacedUsages).`)
+    if (dynamicMatchedCount === 0 && ignoredCount === 0 && orphanResult.uncertainCount === 0 && misplacedCount === 0) messageParts.push('All translation keys are referenced in code.')
     const zeroOutput: Record<string, unknown> = {
       orphanKeys: {},
       uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
-      summary: { totalKeys, orphanCount: 0, uncertainCount: orphanResult.uncertainCount, dynamicMatchedCount, ignoredCount, filesScanned: totalFilesScanned, message: messageParts.join(' ') },
+      misplacedUsages,
+      misplacedUsageNote,
+      summary: { totalKeys, orphanCount: 0, uncertainCount: orphanResult.uncertainCount, misplacedCount, dynamicMatchedCount, ignoredCount, filesScanned: totalFilesScanned, scanScope, message: messageParts.join(' ') },
     }
     const zeroReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (zeroReportPath) {
@@ -355,16 +468,20 @@ export async function removeOrphanKeys(opts: {
     const output: Record<string, unknown> = {
       orphanKeys: orphansByLayer,
       uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
+      misplacedUsages,
+      misplacedUsageNote,
       summary: {
         dryRun: true,
         totalKeys,
         orphanCount,
         uncertainCount: orphanResult.uncertainCount,
+        misplacedCount,
         dynamicMatchedCount,
         ignoredCount,
-        usedCount: totalKeys - orphanCount - orphanResult.uncertainCount,
+        usedCount: totalKeys - orphanCount - orphanResult.uncertainCount - misplacedCount,
         filesScanned: totalFilesScanned,
-        message: `Found ${orphanCount} orphan key(s) safe to remove.${orphanResult.uncertainCount > 0 ? ` ${orphanResult.uncertainCount} uncertain key(s) excluded (overlap with dynamic translation patterns).` : ''} ${dynamicMatchedCount > 0 ? `${dynamicMatchedCount} key(s) matched dynamic patterns and were excluded. ` : ''}${ignoredCount > 0 ? `${ignoredCount} key(s) matched ignore patterns and were excluded. ` : ''}Call again with dryRun: false to remove them.`,
+        scanScope,
+        message: `Found ${orphanCount} orphan key(s) safe to remove.${orphanResult.uncertainCount > 0 ? ` ${orphanResult.uncertainCount} uncertain key(s) excluded (overlap with dynamic translation patterns).` : ''}${misplacedCount > 0 ? ` ${misplacedCount} key(s) referenced only outside their layer's scope were excluded (see misplacedUsages).` : ''} ${dynamicMatchedCount > 0 ? `${dynamicMatchedCount} key(s) matched dynamic patterns and were excluded. ` : ''}${ignoredCount > 0 ? `${ignoredCount} key(s) matched ignore patterns and were excluded. ` : ''}Call again with dryRun: false to remove them.`,
       },
     }
     if (allDynamicKeys.length > 0) {
@@ -419,16 +536,20 @@ export async function removeOrphanKeys(opts: {
   const removalOutput: Record<string, unknown> = {
     removed: removedByLayer,
     uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
+    misplacedUsages,
+    misplacedUsageNote,
     summary: {
       dryRun: false,
       totalKeys,
       removedCount: orphanCount,
       uncertainCount: orphanResult.uncertainCount,
+      misplacedCount,
       dynamicMatchedCount,
       ignoredCount,
       remainingCount: totalKeys - orphanCount,
       filesWritten: totalFilesWritten,
       filesScanned: totalFilesScanned,
+      scanScope,
     },
   }
 

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -113,7 +113,8 @@ async function runOrphanScan(
 ): Promise<OrphanScanResult> {
   return findOrphanKeysForConfig({
     keysByLayer,
-    ...(opts.scanDirs ? { scanDirs: opts.scanDirs } : { scanPlan: buildOrphanScanPlan(config, opts.dir) }),
+    // an empty scanDirs array means "not provided" (matches excludeDirs)
+    ...(opts.scanDirs?.length ? { scanDirs: opts.scanDirs } : { scanPlan: buildOrphanScanPlan(config, opts.dir) }),
     excludeDirs: opts.excludeDirs || undefined,
     resolveIgnorePatterns: layerName => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { isAbsolute, join, relative, sep } from 'node:path'
 import { glob } from 'tinyglobby'
 import { log } from '../utils/logger.js'
 import type { ScanPatternSet } from './patterns.js'
@@ -331,10 +331,57 @@ export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
   })
 }
 
+/** One scan root with a stable name (app or layer) for scope reporting. */
+export interface ScanUnit {
+  /** Unit name used in scope maps and misplaced-usage reports (app or layer name). */
+  name: string
+  /** Absolute directory scanned for this unit. */
+  dir: string
+}
+
+/**
+ * Scope-aware scan plan: which dirs to scan (each exactly once) and which
+ * units vouch for each layer's keys being "used".
+ */
+export interface OrphanScanPlan {
+  /**
+   * Scan units, deduplicated by directory. When a unit's dir nests inside
+   * another unit's dir, the nested subtree is excluded from the ancestor's
+   * scan so every file is attributed to exactly one unit (same total file
+   * work as one whole-project scan).
+   */
+  units: ScanUnit[]
+  /**
+   * Layer name → names of units whose usage evidence counts for that layer.
+   * Layers missing from the map are checked against ALL units (conservative
+   * global scope — never wrongly narrows).
+   */
+  scopeByLayer: Map<string, string[]>
+}
+
+/** A key referenced only from scan units outside its layer's consuming scope. */
+export interface MisplacedUsage {
+  key: string
+  /** Layer the key is defined in. */
+  layer: string
+  /** Out-of-scope scan units (apps or layers) where the key was found. */
+  usingApps: string[]
+}
+
 export interface OrphanScanOptions {
   keysByLayer: Map<string, { keys: string[]; localeDir: { layer: string } }>
-  /** Root directories to scan for source file usage. Scanned recursively. */
-  scanDirs: string[]
+  /**
+   * Explicit root directories to scan recursively — manual scope control.
+   * When set, every layer is checked against ONE combined usage set from
+   * these dirs (the pre-scope-aware global behavior): `scanPlan` is ignored
+   * and no misplaced-usage detection happens.
+   */
+  scanDirs?: string[]
+  /**
+   * Scope-aware scan plan (see `buildOrphanScanPlan`). Used when `scanDirs`
+   * is absent. One of `scanDirs` / `scanPlan` is required.
+   */
+  scanPlan?: OrphanScanPlan
   excludeDirs?: string[]
   resolveIgnorePatterns: (layerName: string) => string[] | undefined
   patterns?: ScanPatternSet
@@ -359,37 +406,105 @@ export interface OrphanScanResult {
   uncertainByLayer: Record<string, string[]>
   uncertainCount: number
   totalFilesScanned: number
+  /** Accumulated across layers — a key present in several layers counts once per layer. */
   dynamicMatchedCount: number
+  /** Accumulated across layers, like dynamicMatchedCount. */
   ignoredCount: number
   allDynamicKeys: Array<{ expression: string; file: string; line: number; callee: string }>
   dirsScanned: string[]
   unresolvedKeyWarnings: UnresolvedKeyWarning[]
+  /** Keys referenced only from units outside their layer's scope. Not counted as orphans. */
+  misplacedUsages: MisplacedUsage[]
+  /** Layer name → dirs whose scans vouched for that layer's keys being "used". */
+  scanScopeByLayer: Record<string, string[]>
+}
+
+/** Per-unit scan evidence, with lazily built dynamic-key regexes. */
+interface UnitEvidence {
+  unit: ScanUnit
+  result: ScanResult
+  /** Dynamic key expressions incl. bare candidates, in legacy accumulation order. */
+  dynamicRaw: DynamicKeyUsage[]
+  dynRegexes?: RegExp[]
+}
+
+/**
+ * Glob ignores for other units' dirs nested inside this unit's dir, so a
+ * scope-aware scan visits every file exactly once and attributes it to the
+ * innermost unit.
+ */
+function nestedUnitIgnores(unit: ScanUnit, units: ScanUnit[]): string[] {
+  const ignores: string[] = []
+  for (const other of units) {
+    if (other.dir === unit.dir) continue
+    const rel = relative(unit.dir, other.dir)
+    if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue
+    const posixRel = rel.split(sep).join('/')
+    ignores.push(posixRel, `${posixRel}/**`)
+  }
+  return ignores
 }
 
 export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promise<OrphanScanResult> {
-  const { keysByLayer, scanDirs, excludeDirs, resolveIgnorePatterns, patterns } = options
+  const { keysByLayer, scanDirs, scanPlan, excludeDirs, resolveIgnorePatterns, patterns } = options
 
-  // Single recursive scan from each provided root dir.
-  // All layers share the combined results — no per-layer scan planning needed.
-  const combinedUniqueKeys = new Set<string>()
-  const combinedBareStrings = new Set<string>()
-  const allDynamicKeysRaw: Array<{ expression: string; file: string; line: number; callee: string }> = []
+  // Explicit scanDirs = manual scope control: one combined usage set shared
+  // by all layers, no misplaced-usage detection (pre-scope-aware behavior).
+  const globalScope = scanDirs !== undefined || !scanPlan
+  const units: ScanUnit[] = scanDirs !== undefined
+    ? scanDirs.map(d => ({ name: d, dir: d }))
+    : scanPlan!.units
+
+  // Scan each unit dir exactly once. In plan mode, nested unit dirs are
+  // excluded from ancestor scans; explicit scanDirs are scanned as given.
+  const evidences: UnitEvidence[] = []
+  const allDynamicKeysRaw: DynamicKeyUsage[] = []
   let totalFilesScanned = 0
 
-  for (const dir of scanDirs) {
-    const result = await scanSourceFiles(dir, excludeDirs ?? [], patterns)
+  for (const unit of units) {
+    const ignores = globalScope ? [] : nestedUnitIgnores(unit, units)
+    const result = await scanSourceFiles(unit.dir, [...(excludeDirs ?? []), ...ignores], patterns)
     totalFilesScanned += result.filesScanned
-    for (const key of result.uniqueKeys) combinedUniqueKeys.add(key)
-    for (const bare of result.bareStringCandidates) combinedBareStrings.add(bare)
-    allDynamicKeysRaw.push(...result.dynamicKeys)
-    for (const bd of result.bareDynamicCandidates) {
-      allDynamicKeysRaw.push({ expression: bd, file: '', line: 0, callee: '' })
-    }
+    const dynamicRaw: DynamicKeyUsage[] = [
+      ...result.dynamicKeys,
+      ...[...result.bareDynamicCandidates].map(bd => ({ expression: bd, file: '', line: 0, callee: '' })),
+    ]
+    allDynamicKeysRaw.push(...dynamicRaw)
+    evidences.push({ unit, result, dynamicRaw })
   }
 
-  const dynamicKeyRegexes = buildDynamicKeyRegexes(allDynamicKeysRaw)
+  // Unresolved-key warnings and the derived "uncertain" classification stay
+  // global (all units): a key overlapping ANY dynamic translation pattern is
+  // withheld from removal regardless of where that pattern lives.
   const unresolvedWarnings = buildUnresolvedWarnings(allDynamicKeysRaw)
   const uncertainRegexes = buildIgnorePatternRegexes(unresolvedWarnings.map(w => w.suggestedIgnorePattern))
+
+  const evidenceByName = new Map(evidences.map(e => [e.unit.name, e]))
+  const allUnitNames = units.map(u => u.name)
+
+  // Scope unions are memoized — sibling layers typically share a scope.
+  const scopeCache = new Map<string, { unique: Set<string>; bare: Set<string>; dynRegexes: RegExp[] }>()
+  const scopeEvidence = (names: string[]) => {
+    const cacheKey = names.join('\u0000')
+    let cached = scopeCache.get(cacheKey)
+    if (!cached) {
+      const unique = new Set<string>()
+      const bare = new Set<string>()
+      const dynamicRaw: DynamicKeyUsage[] = []
+      for (const name of names) {
+        const evidence = evidenceByName.get(name)
+        if (!evidence) continue
+        for (const key of evidence.result.uniqueKeys) unique.add(key)
+        for (const candidate of evidence.result.bareStringCandidates) bare.add(candidate)
+        dynamicRaw.push(...evidence.dynamicRaw)
+      }
+      cached = { unique, bare, dynRegexes: buildDynamicKeyRegexes(dynamicRaw) }
+      scopeCache.set(cacheKey, cached)
+    }
+    return cached
+  }
+  const unitDynRegexes = (evidence: UnitEvidence): RegExp[] =>
+    evidence.dynRegexes ??= buildDynamicKeyRegexes(evidence.dynamicRaw)
 
   const orphansByLayer: Record<string, string[]> = {}
   let orphanCount = 0
@@ -397,15 +512,27 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
   let uncertainCount = 0
   let dynamicMatchedCount = 0
   let ignoredCount = 0
+  const misplacedUsages: MisplacedUsage[] = []
+  const scanScopeByLayer: Record<string, string[]> = {}
 
   for (const [layerName, { keys }] of keysByLayer) {
+    const scopeNames = (globalScope
+      ? allUnitNames
+      : scanPlan!.scopeByLayer.get(layerName) ?? allUnitNames)
+      .filter(name => evidenceByName.has(name))
+    scanScopeByLayer[layerName] = scopeNames.map(name => evidenceByName.get(name)!.unit.dir)
+
+    const scope = scopeEvidence(scopeNames)
+    const scopeNameSet = new Set(scopeNames)
+    const outOfScope = globalScope ? [] : evidences.filter(e => !scopeNameSet.has(e.unit.name))
+
     const ignorePatterns = resolveIgnorePatterns(layerName)
     const ignoreRegexes = ignorePatterns ? buildIgnorePatternRegexes(ignorePatterns) : []
 
     const orphans = keys.filter((k) => {
-      if (combinedUniqueKeys.has(k)) return false
-      if (combinedBareStrings.has(k)) return false
-      if (dynamicKeyRegexes.some(re => re.test(k))) {
+      if (scope.unique.has(k)) return false
+      if (scope.bare.has(k)) return false
+      if (scope.dynRegexes.some(re => re.test(k))) {
         dynamicMatchedCount++
         return false
       }
@@ -419,6 +546,18 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
     const certain: string[] = []
     const uncertain: string[] = []
     for (const k of orphans) {
+      // Not vouched for in scope — but referenced from non-consuming units?
+      // Then it's a misplaced usage, reported separately (not an orphan).
+      const usingApps = outOfScope
+        .filter(e =>
+          e.result.uniqueKeys.has(k)
+          || e.result.bareStringCandidates.has(k)
+          || unitDynRegexes(e).some(re => re.test(k)))
+        .map(e => e.unit.name)
+      if (usingApps.length > 0) {
+        misplacedUsages.push({ key: k, layer: layerName, usingApps })
+        continue
+      }
       if (uncertainRegexes.length > 0 && uncertainRegexes.some(re => re.test(k))) {
         uncertain.push(k)
       } else {
@@ -436,6 +575,8 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
     }
   }
 
+  misplacedUsages.sort((a, b) => a.layer.localeCompare(b.layer) || a.key.localeCompare(b.key))
+
   return {
     orphansByLayer,
     orphanCount,
@@ -445,7 +586,9 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
     dynamicMatchedCount,
     ignoredCount,
     allDynamicKeys: allDynamicKeysRaw,
-    dirsScanned: scanDirs,
+    dirsScanned: units.map(u => u.dir),
     unresolvedKeyWarnings: unresolvedWarnings,
+    misplacedUsages,
+    scanScopeByLayer,
   }
 }

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -577,6 +577,13 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
 
   misplacedUsages.sort((a, b) => a.layer.localeCompare(b.layer) || a.key.localeCompare(b.key))
 
+  // File glob ordering varies between runs — sort the diagnostic arrays so
+  // report output is byte-deterministic (CI artifact diffing relies on it).
+  const byLocation = (a: { file: string; line: number; expression: string }, b: { file: string; line: number; expression: string }) =>
+    a.file.localeCompare(b.file) || a.line - b.line || a.expression.localeCompare(b.expression)
+  allDynamicKeysRaw.sort(byLocation)
+  unresolvedWarnings.sort((a, b) => byLocation(a, b))
+
   return {
     orphansByLayer,
     orphanCount,

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -368,24 +368,25 @@ export interface MisplacedUsage {
   usingApps: string[]
 }
 
-export interface OrphanScanOptions {
+interface OrphanScanBaseOptions {
   keysByLayer: Map<string, { keys: string[]; localeDir: { layer: string } }>
-  /**
-   * Explicit root directories to scan recursively — manual scope control.
-   * When set, every layer is checked against ONE combined usage set from
-   * these dirs (the pre-scope-aware global behavior): `scanPlan` is ignored
-   * and no misplaced-usage detection happens.
-   */
-  scanDirs?: string[]
-  /**
-   * Scope-aware scan plan (see `buildOrphanScanPlan`). Used when `scanDirs`
-   * is absent. One of `scanDirs` / `scanPlan` is required.
-   */
-  scanPlan?: OrphanScanPlan
   excludeDirs?: string[]
   resolveIgnorePatterns: (layerName: string) => string[] | undefined
   patterns?: ScanPatternSet
 }
+
+/**
+ * Exactly one scan source is required:
+ * - `scanDirs` — explicit root directories, scanned recursively; manual
+ *   scope control. Every layer is checked against ONE combined usage set
+ *   (the pre-scope-aware global behavior) and no misplaced-usage
+ *   detection happens.
+ * - `scanPlan` — scope-aware plan from `buildOrphanScanPlan`.
+ */
+export type OrphanScanOptions = OrphanScanBaseOptions & (
+  | { scanDirs: string[]; scanPlan?: undefined }
+  | { scanDirs?: undefined; scanPlan: OrphanScanPlan }
+)
 
 export interface UnresolvedKeyWarning {
   /** The dynamic expression as detected (e.g., `` `notifications.subscriptions.${_}.message` ``) */
@@ -446,14 +447,14 @@ function nestedUnitIgnores(unit: ScanUnit, units: ScanUnit[]): string[] {
 }
 
 export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promise<OrphanScanResult> {
-  const { keysByLayer, scanDirs, scanPlan, excludeDirs, resolveIgnorePatterns, patterns } = options
+  const { keysByLayer, excludeDirs, resolveIgnorePatterns, patterns } = options
 
   // Explicit scanDirs = manual scope control: one combined usage set shared
   // by all layers, no misplaced-usage detection (pre-scope-aware behavior).
-  const globalScope = scanDirs !== undefined || !scanPlan
-  const units: ScanUnit[] = scanDirs !== undefined
-    ? scanDirs.map(d => ({ name: d, dir: d }))
-    : scanPlan!.units
+  const globalScope = options.scanDirs !== undefined
+  const units: ScanUnit[] = options.scanDirs !== undefined
+    ? options.scanDirs.map(d => ({ name: d, dir: d }))
+    : options.scanPlan.units
 
   // Scan each unit dir exactly once. In plan mode, nested unit dirs are
   // excluded from ancestor scans; explicit scanDirs are scanned as given.
@@ -516,9 +517,9 @@ export async function findOrphanKeysForConfig(options: OrphanScanOptions): Promi
   const scanScopeByLayer: Record<string, string[]> = {}
 
   for (const [layerName, { keys }] of keysByLayer) {
-    const scopeNames = (globalScope
+    const scopeNames = (options.scanDirs !== undefined
       ? allUnitNames
-      : scanPlan!.scopeByLayer.get(layerName) ?? allUnitNames)
+      : options.scanPlan.scopeByLayer.get(layerName) ?? allUnitNames)
       .filter(name => evidenceByName.has(name))
     scanScopeByLayer[layerName] = scopeNames.map(name => evidenceByName.get(name)!.unit.dir)
 

--- a/packages/cli/tests/fixtures/config.ts
+++ b/packages/cli/tests/fixtures/config.ts
@@ -150,6 +150,33 @@ export function createMultiAppConfig(): I18nConfig {
 }
 
 /**
+ * In-memory multi-app config over a temp directory tree: `projectDir` is the
+ * root layer's dir and contains nested `app-admin/` and `app-shop/` app dirs.
+ * Used by the scope-aware orphan-scan tests, which create real source and
+ * locale files under these paths.
+ */
+export function createTempMultiAppConfig(projectDir: string): I18nConfig {
+  const adminDir = resolve(projectDir, 'app-admin')
+  const shopDir = resolve(projectDir, 'app-shop')
+  return {
+    rootDir: projectDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales: [{ code: 'de', language: 'de-DE', file: 'de-DE.json' }],
+    localeDirs: [
+      { path: resolve(projectDir, 'i18n/locales'), layer: 'root', layerRootDir: projectDir },
+      { path: resolve(adminDir, 'i18n/locales'), layer: 'app-admin', layerRootDir: adminDir },
+      { path: resolve(shopDir, 'i18n/locales'), layer: 'app-shop', layerRootDir: shopDir },
+    ],
+    layerRootDirs: [projectDir, adminDir, shopDir],
+    apps: [
+      { name: 'app-admin', rootDir: adminDir, layers: ['app-admin', 'root'] },
+      { name: 'app-shop', rootDir: shopDir, layers: ['app-shop', 'root'] },
+    ],
+  }
+}
+
+/**
  * Degenerate fixture without app info (generic/Laravel-style config where
  * no app → layer consumption edges exist).
  */

--- a/packages/cli/tests/scanner/orphan-scan-scope.test.ts
+++ b/packages/cli/tests/scanner/orphan-scan-scope.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Scope-aware orphan scanning (#236).
+ *
+ * Covers the scan plan built from the layer graph (per-app usage sets,
+ * degenerate fallbacks, project-root remainder unit) and the scoped checking
+ * in findOrphanKeysForConfig: per-layer scope, misplaced-usage detection,
+ * explicit-scanDirs global behavior, and once-per-file nested scanning.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdir, writeFile, rm, mkdtemp } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { findOrphanKeysForConfig } from '../../src/scanner/code-scanner.js'
+import type { OrphanScanOptions } from '../../src/scanner/code-scanner.js'
+import { buildOrphanScanPlan } from '../../src/core/ops-orphans.js'
+import type { I18nConfig } from '../../src/config/types.js'
+import { createMultiAppConfig, createNoAppsConfig, createTempMultiAppConfig } from '../fixtures/config.js'
+
+// ─── Scan plan from the layer graph ─────────────────────────────
+
+describe('buildOrphanScanPlan', () => {
+  it('multi-app config: one unit per distinct app/layer dir, scoped per consuming apps', () => {
+    const config = createMultiAppConfig()
+    const plan = buildOrphanScanPlan(config, config.rootDir)
+
+    const unitNames = plan.units.map(u => u.name).sort()
+    expect(unitNames).toEqual(['app-admin', 'app-outlook', 'app-shop', 'root'])
+
+    // root is consumed by every app; its own layer dir also vouches.
+    expect(plan.scopeByLayer.get('root')?.sort()).toEqual(['app-admin', 'app-outlook', 'app-shop', 'root'])
+    // App-private layer: its own app only.
+    expect(plan.scopeByLayer.get('app-admin')).toEqual(['app-admin'])
+    // Alias consumption resolves to the owner: app-outlook vouches for app-shop keys.
+    expect(plan.scopeByLayer.get('app-shop')?.sort()).toEqual(['app-outlook', 'app-shop'])
+  })
+
+  it('no app info: every layer falls back to ALL units (degenerate semantics)', () => {
+    const config = createNoAppsConfig()
+    const plan = buildOrphanScanPlan(config, config.rootDir)
+
+    expect(plan.units.map(u => u.name)).toEqual(['default'])
+    expect(plan.scopeByLayer.get('default')).toEqual(['default'])
+  })
+
+  it('project dir outside every unit: adds a project-root unit that counts for every layer', () => {
+    const config = createMultiAppConfig()
+    const outsideRoot = resolve(config.rootDir, '../..')
+    const plan = buildOrphanScanPlan(config, outsideRoot)
+
+    const projectUnit = plan.units.find(u => u.dir === outsideRoot)
+    expect(projectUnit?.name).toBe('project-root')
+    expect(plan.scopeByLayer.get('app-admin')).toContain('project-root')
+    expect(plan.scopeByLayer.get('root')).toContain('project-root')
+  })
+
+  it('project dir covered by a unit: no synthetic project-root unit', () => {
+    const config = createMultiAppConfig()
+    const plan = buildOrphanScanPlan(config, config.rootDir)
+    expect(plan.units.some(u => u.name === 'project-root')).toBe(false)
+  })
+})
+
+// ─── Scoped checking against a real source tree ─────────────────
+
+describe('findOrphanKeysForConfig — scope-aware plan', () => {
+  let projectDir: string
+  let adminDir: string
+  let shopDir: string
+  let config: I18nConfig
+
+  const keysByLayer = () => new Map([
+    ['root', {
+      keys: ['root.shared.used', 'root.shared.usedByAdmin', 'root.shared.orphan'],
+      localeDir: { layer: 'root' },
+    }],
+    ['app-admin', {
+      keys: ['admin.used', 'admin.usedFromShop', 'admin.fromRoot', 'admin.dyn.one', 'admin.orphan'],
+      localeDir: { layer: 'app-admin' },
+    }],
+    ['app-shop', {
+      keys: ['shop.used'],
+      localeDir: { layer: 'app-shop' },
+    }],
+  ])
+
+  const scanOptions = (overrides?: Partial<OrphanScanOptions>): OrphanScanOptions => ({
+    keysByLayer: keysByLayer(),
+    scanPlan: buildOrphanScanPlan(config, projectDir),
+    resolveIgnorePatterns: () => undefined,
+    ...overrides,
+  })
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'i18n-scope-scan-'))
+    adminDir = join(projectDir, 'app-admin')
+    shopDir = join(projectDir, 'app-shop')
+
+    // Root-layer code (outside both app dirs): uses a root key and — the
+    // misplaced case — an app-admin key.
+    await mkdir(join(projectDir, 'components'), { recursive: true })
+    await writeFile(join(projectDir, 'components/Shared.vue'), [
+      `{{ $t('root.shared.used') }}`,
+      `{{ $t('admin.fromRoot') }}`,
+    ].join('\n'))
+
+    // app-admin uses its own key and a shared root key.
+    await mkdir(join(adminDir, 'pages'), { recursive: true })
+    await writeFile(join(adminDir, 'pages/index.vue'), [
+      `{{ $t('admin.used') }}`,
+      `{{ $t('root.shared.usedByAdmin') }}`,
+    ].join('\n'))
+
+    // app-shop uses its own key, an app-admin key statically (misplaced),
+    // and an app-admin key via a dynamic template (misplaced via pattern).
+    await mkdir(join(shopDir, 'pages'), { recursive: true })
+    await writeFile(join(shopDir, 'pages/index.vue'), [
+      `{{ $t('shop.used') }}`,
+      `{{ $t('admin.usedFromShop') }}`,
+      'const label = t(`admin.dyn.${variant}`)',
+    ].join('\n'))
+
+    config = createTempMultiAppConfig(projectDir)
+  })
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('scans each file exactly once despite nested unit dirs', async () => {
+    const result = await findOrphanKeysForConfig(scanOptions())
+    expect(result.totalFilesScanned).toBe(3)
+  })
+
+  it('shared-layer keys are vouched for by any consuming app', async () => {
+    const result = await findOrphanKeysForConfig(scanOptions())
+    // Used in root-layer code and in app-admin code respectively.
+    expect(result.orphansByLayer['root']).toEqual(['root.shared.orphan'])
+  })
+
+  it('app-layer key used only from non-consuming units is misplaced, not orphan or used', async () => {
+    const result = await findOrphanKeysForConfig(scanOptions())
+
+    expect(result.orphansByLayer['app-admin']).toEqual(['admin.orphan'])
+    expect(result.misplacedUsages).toEqual([
+      { key: 'admin.dyn.one', layer: 'app-admin', usingApps: ['app-shop'] },
+      { key: 'admin.fromRoot', layer: 'app-admin', usingApps: ['root'] },
+      { key: 'admin.usedFromShop', layer: 'app-admin', usingApps: ['app-shop'] },
+    ])
+    // Not double-reported as orphans.
+    const orphanKeys = Object.values(result.orphansByLayer).flat()
+    for (const m of result.misplacedUsages) {
+      expect(orphanKeys).not.toContain(m.key)
+    }
+  })
+
+  it('reports each layer\'s effective scan scope', async () => {
+    const result = await findOrphanKeysForConfig(scanOptions())
+
+    expect(result.scanScopeByLayer['root']?.sort()).toEqual([adminDir, shopDir, projectDir].sort())
+    expect(result.scanScopeByLayer['app-admin']).toEqual([adminDir])
+    expect(result.scanScopeByLayer['app-shop']).toEqual([shopDir])
+  })
+
+  it('explicit scanDirs restores the global combined-scan behavior', async () => {
+    const result = await findOrphanKeysForConfig(scanOptions({
+      scanDirs: [projectDir],
+      scanPlan: undefined,
+    }))
+
+    // Cross-app usages count as "used" — no misplaced findings.
+    expect(result.misplacedUsages).toEqual([])
+    expect(result.orphansByLayer['app-admin']).toEqual(['admin.orphan'])
+    expect(result.orphansByLayer['root']).toEqual(['root.shared.orphan'])
+    // Every layer's scope is the explicit dir list.
+    expect(result.scanScopeByLayer['app-admin']).toEqual([projectDir])
+    expect(result.dirsScanned).toEqual([projectDir])
+  })
+
+  it('degenerate no-app plan produces results identical to the global scan', async () => {
+    const noAppsConfig: I18nConfig = { ...config, apps: [] }
+    const planned = await findOrphanKeysForConfig(scanOptions({
+      scanPlan: buildOrphanScanPlan(noAppsConfig, projectDir),
+    }))
+    const global = await findOrphanKeysForConfig(scanOptions({
+      scanDirs: [projectDir],
+      scanPlan: undefined,
+    }))
+
+    expect(planned.orphansByLayer).toEqual(global.orphansByLayer)
+    expect(planned.uncertainByLayer).toEqual(global.uncertainByLayer)
+    expect(planned.orphanCount).toBe(global.orphanCount)
+    expect(planned.uncertainCount).toBe(global.uncertainCount)
+    expect(planned.dynamicMatchedCount).toBe(global.dynamicMatchedCount)
+    expect(planned.ignoredCount).toBe(global.ignoredCount)
+    expect(planned.totalFilesScanned).toBe(global.totalFilesScanned)
+    expect(planned.misplacedUsages).toEqual([])
+  })
+})

--- a/packages/cli/tests/scanner/orphan-scan-scope.test.ts
+++ b/packages/cli/tests/scanner/orphan-scan-scope.test.ts
@@ -75,7 +75,7 @@ describe('findOrphanKeysForConfig — scope-aware plan', () => {
       localeDir: { layer: 'root' },
     }],
     ['app-admin', {
-      keys: ['admin.used', 'admin.usedFromShop', 'admin.fromRoot', 'admin.dyn.one', 'admin.orphan'],
+      keys: ['admin.used', 'admin.usedEverywhere', 'admin.usedFromShop', 'admin.fromRoot', 'admin.dyn.one', 'admin.orphan'],
       localeDir: { layer: 'app-admin' },
     }],
     ['app-shop', {
@@ -108,6 +108,7 @@ describe('findOrphanKeysForConfig — scope-aware plan', () => {
     await mkdir(join(adminDir, 'pages'), { recursive: true })
     await writeFile(join(adminDir, 'pages/index.vue'), [
       `{{ $t('admin.used') }}`,
+      `{{ $t('admin.usedEverywhere') }}`,
       `{{ $t('root.shared.usedByAdmin') }}`,
     ].join('\n'))
 
@@ -116,6 +117,7 @@ describe('findOrphanKeysForConfig — scope-aware plan', () => {
     await mkdir(join(shopDir, 'pages'), { recursive: true })
     await writeFile(join(shopDir, 'pages/index.vue'), [
       `{{ $t('shop.used') }}`,
+      `{{ $t('admin.usedEverywhere') }}`,
       `{{ $t('admin.usedFromShop') }}`,
       'const label = t(`admin.dyn.${variant}`)',
     ].join('\n'))
@@ -142,6 +144,9 @@ describe('findOrphanKeysForConfig — scope-aware plan', () => {
     const result = await findOrphanKeysForConfig(scanOptions())
 
     expect(result.orphansByLayer['app-admin']).toEqual(['admin.orphan'])
+    // In-scope evidence wins: a key also used by a non-consuming unit is
+    // plain "used" — neither orphan nor misplaced.
+    expect(result.misplacedUsages.map(m => m.key)).not.toContain('admin.usedEverywhere')
     expect(result.misplacedUsages).toEqual([
       { key: 'admin.dyn.one', layer: 'app-admin', usingApps: ['app-shop'] },
       { key: 'admin.fromRoot', layer: 'app-admin', usingApps: ['root'] },

--- a/packages/cli/tests/tools/orphan-scope.test.ts
+++ b/packages/cli/tests/tools/orphan-scope.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Scope-aware orphan operations end-to-end (#236): findOrphanKeys and
+ * removeOrphanKeys over a multi-app temp project — misplacedUsages section,
+ * per-layer scanScope in the summary, explicit-scanDirs override, and
+ * removal never touching misplaced keys.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdir, writeFile, rm, mkdtemp, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { I18nConfig } from '../../src/config/types.js'
+import { createTempMultiAppConfig } from '../fixtures/config.js'
+
+const holder = vi.hoisted(() => ({ config: undefined as unknown }))
+
+vi.mock('../../src/config/detector.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/config/detector.js')>()
+  return {
+    ...original,
+    detectI18nConfig: async () => {
+      if (!holder.config) throw new Error('Test config not initialized')
+      return holder.config as I18nConfig
+    },
+    clearConfigCache: () => { },
+    getCachedConfig: () => (holder.config as I18nConfig | undefined) ?? null,
+  }
+})
+
+const { findOrphanKeys, removeOrphanKeys } = await import('../../src/core/operations.js')
+
+let projectDir: string
+let adminDir: string
+let shopDir: string
+
+const readLocale = async (dir: string): Promise<Record<string, unknown>> =>
+  JSON.parse(await readFile(join(dir, 'i18n/locales/de-DE.json'), 'utf-8'))
+
+beforeAll(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'i18n-scope-ops-'))
+  adminDir = join(projectDir, 'app-admin')
+  shopDir = join(projectDir, 'app-shop')
+
+  // Locale files.
+  await mkdir(join(projectDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(projectDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    root: { shared: { used: 'a', usedByAdmin: 'b', orphan: 'c' } },
+  }))
+  await mkdir(join(adminDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(adminDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    admin: { used: 'a', usedFromShop: 'b', orphan: 'c' },
+  }))
+  await mkdir(join(shopDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(shopDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    shop: { used: 'a' },
+  }))
+
+  // Source files: root-layer code uses root key; app-admin uses its own and a
+  // shared key; app-shop uses its own key plus an app-admin key (misplaced).
+  await mkdir(join(projectDir, 'components'), { recursive: true })
+  await writeFile(join(projectDir, 'components/Shared.vue'), `{{ $t('root.shared.used') }}`)
+  await mkdir(join(adminDir, 'pages'), { recursive: true })
+  await writeFile(join(adminDir, 'pages/index.vue'), [
+    `{{ $t('admin.used') }}`,
+    `{{ $t('root.shared.usedByAdmin') }}`,
+  ].join('\n'))
+  await mkdir(join(shopDir, 'pages'), { recursive: true })
+  await writeFile(join(shopDir, 'pages/index.vue'), [
+    `{{ $t('shop.used') }}`,
+    `{{ $t('admin.usedFromShop') }}`,
+  ].join('\n'))
+
+  holder.config = createTempMultiAppConfig(projectDir)
+})
+
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true })
+})
+
+const expectedOrphans = {
+  'app-admin': ['admin.orphan'],
+  'root': ['root.shared.orphan'],
+}
+const expectedMisplaced = [
+  { key: 'admin.usedFromShop', layer: 'app-admin', usingApps: ['app-shop'] },
+]
+
+describe('findOrphanKeys — scope-aware', () => {
+  it('reports scoped orphans, misplaced usages, and per-layer scan scope', async () => {
+    const result = await findOrphanKeys({ projectDir })
+
+    expect(result.orphanKeys).toEqual(expectedOrphans)
+    expect(result.misplacedUsages).toEqual(expectedMisplaced)
+    expect(result.misplacedUsageNote).toMatch(/broader.*layer|usage is a bug/)
+
+    const summary = result.summary as Record<string, unknown>
+    expect(summary.orphanCount).toBe(2)
+    expect(summary.misplacedCount).toBe(1)
+    // 7 keys total: 4 used, 2 orphans, 1 misplaced.
+    expect(summary.totalKeys).toBe(7)
+    expect(summary.usedCount).toBe(4)
+
+    const scanScope = summary.scanScope as Record<string, string[]>
+    expect(scanScope['app-admin']).toEqual(['app-admin'])
+    expect(scanScope['app-shop']).toEqual(['app-shop'])
+    expect(scanScope['root']?.sort()).toEqual(['.', 'app-admin', 'app-shop'])
+  })
+
+  it('explicit scanDirs keeps the global behavior — no misplaced findings', async () => {
+    const result = await findOrphanKeys({ projectDir, scanDirs: [projectDir] })
+
+    expect(result.orphanKeys).toEqual(expectedOrphans)
+    expect(result.misplacedUsages).toBeUndefined()
+
+    const summary = result.summary as Record<string, unknown>
+    expect(summary.misplacedCount).toBe(0)
+    expect(summary.usedCount).toBe(5)
+    expect((summary.scanScope as Record<string, string[]>)['app-admin']).toEqual(['.'])
+  })
+})
+
+describe('removeOrphanKeys — scope-aware', () => {
+  it('dry run (default) reports scoped orphans and misplaced usages without writing', async () => {
+    const result = await removeOrphanKeys({ projectDir })
+
+    const summary = result.summary as Record<string, unknown>
+    expect(summary.dryRun).toBe(true)
+    expect(result.orphanKeys).toEqual(expectedOrphans)
+    expect(result.misplacedUsages).toEqual(expectedMisplaced)
+    expect(summary.misplacedCount).toBe(1)
+    expect((summary.scanScope as Record<string, string[]>)['app-admin']).toEqual(['app-admin'])
+    expect(summary.message).toContain('misplacedUsages')
+
+    // Nothing removed.
+    expect(await readLocale(adminDir)).toEqual({ admin: { used: 'a', usedFromShop: 'b', orphan: 'c' } })
+  })
+
+  it('dryRun: false removes orphans but never misplaced keys', async () => {
+    const result = await removeOrphanKeys({ projectDir, dryRun: false })
+
+    expect(result.removed).toEqual(expectedOrphans)
+    expect(result.misplacedUsages).toEqual(expectedMisplaced)
+
+    // Misplaced key survives; orphans are gone.
+    expect(await readLocale(adminDir)).toEqual({ admin: { used: 'a', usedFromShop: 'b' } })
+    expect(await readLocale(projectDir)).toEqual({ root: { shared: { used: 'a', usedByAdmin: 'b' } } })
+    expect(await readLocale(shopDir)).toEqual({ shop: { used: 'a' } })
+  })
+})

--- a/packages/cli/tests/tools/orphan-scope.test.ts
+++ b/packages/cli/tests/tools/orphan-scope.test.ts
@@ -5,7 +5,7 @@
  * removal never touching misplaced keys.
  */
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
 import { mkdir, writeFile, rm, mkdtemp, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -41,19 +41,6 @@ beforeAll(async () => {
   adminDir = join(projectDir, 'app-admin')
   shopDir = join(projectDir, 'app-shop')
 
-  // Locale files.
-  await mkdir(join(projectDir, 'i18n/locales'), { recursive: true })
-  await writeFile(join(projectDir, 'i18n/locales/de-DE.json'), JSON.stringify({
-    root: { shared: { used: 'a', usedByAdmin: 'b', orphan: 'c' } },
-  }))
-  await mkdir(join(adminDir, 'i18n/locales'), { recursive: true })
-  await writeFile(join(adminDir, 'i18n/locales/de-DE.json'), JSON.stringify({
-    admin: { used: 'a', usedFromShop: 'b', orphan: 'c' },
-  }))
-  await mkdir(join(shopDir, 'i18n/locales'), { recursive: true })
-  await writeFile(join(shopDir, 'i18n/locales/de-DE.json'), JSON.stringify({
-    shop: { used: 'a' },
-  }))
 
   // Source files: root-layer code uses root key; app-admin uses its own and a
   // shared key; app-shop uses its own key plus an app-admin key (misplaced).
@@ -71,6 +58,23 @@ beforeAll(async () => {
   ].join('\n'))
 
   holder.config = createTempMultiAppConfig(projectDir)
+})
+
+// Fresh locale contents per test: the destructive removeOrphanKeys case
+// mutates them, and the suite must not be order-dependent.
+beforeEach(async () => {
+  await mkdir(join(projectDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(projectDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    root: { shared: { used: 'a', usedByAdmin: 'b', orphan: 'c' } },
+  }))
+  await mkdir(join(adminDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(adminDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    admin: { used: 'a', usedFromShop: 'b', orphan: 'c' },
+  }))
+  await mkdir(join(shopDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(shopDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    shop: { used: 'a' },
+  }))
 })
 
 afterAll(async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -694,7 +694,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       description:
         'Find translation keys that exist in locale JSON files but are not referenced in any Vue/TS source code. '
         + 'Scans a specific layer or all layers. Reports keys that can potentially be removed. '
-        + 'Also detects dynamic key patterns and uncertain matches.',
+        + 'Also detects dynamic key patterns and uncertain matches. '
+        + 'Scope-aware: each layer is checked only against code of the apps that consume it (summary.scanScope shows each layer\'s effective scope); '
+        + 'keys referenced only from non-consuming apps are reported separately as misplacedUsages, not orphans.',
       inputSchema: {
         layer: z
           .string()
@@ -707,7 +709,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
         scanDirs: z
           .array(z.string())
           .optional()
-          .describe('Absolute paths to directories to scan for source code usage. Defaults to all layer root directories. Example: ["/home/user/my-app/apps/admin"].'),
+          .describe('Absolute paths to directories to scan for source code usage. Overrides scope-aware scanning: all layers are checked globally against these dirs. Example: ["/home/user/my-app/apps/admin"].'),
         excludeDirs: z
           .array(z.string())
           .optional()
@@ -739,7 +741,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     {
       title: 'Remove Orphan Keys',
       description:
-        'Find orphan keys (not referenced in source code) and remove them from all locale files. Always does a dry run first.',
+        'Find orphan keys (not referenced in source code) and remove them from all locale files. Always does a dry run first. '
+        + 'Scope-aware like find_orphan_keys: each layer is checked against its consuming apps (summary.scanScope), and keys referenced only from '
+        + 'non-consuming apps are reported as misplacedUsages and never removed.',
       inputSchema: {
         layer: z
           .string()
@@ -752,7 +756,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
         scanDirs: z
           .array(z.string())
           .optional()
-          .describe('Absolute paths to directories to scan for source code usage. Defaults to all layer root directories. Example: ["/home/user/my-app/apps/admin"].'),
+          .describe('Absolute paths to directories to scan for source code usage. Overrides scope-aware scanning: all layers are checked globally against these dirs. Example: ["/home/user/my-app/apps/admin"].'),
         excludeDirs: z
           .array(z.string())
           .optional()


### PR DESCRIPTION
Closes #236 (parent #202, step 4 — see the scope-aware-orphan-scan comment there).

## Problem

`findOrphanKeys`/`removeOrphanKeys` checked every layer's keys against ONE global usage set from a whole-project scan — correct by accident for shared layers, silently unsound for app layers: an `app-admin` key referenced only from `app-shop` counted as used and was never flagged.

## What changed

**Scan planning** (`buildOrphanScanPlan`, `packages/cli/src/core/ops-orphans.ts`): scan units are derived from the layer graph (#234) — one unit per distinct app root dir / canonical layer root dir. Each dir is scanned exactly once: nested unit dirs are carved out of ancestor scans, so total file work equals the old single recursive scan. Each unit keeps its own usage set (uniqueKeys, bare string candidates, dynamic key patterns).

**Scoped checking** (`findOrphanKeysForConfig`, `packages/cli/src/scanner/code-scanner.ts`): layer L's keys are checked against the union of usage sets of L's own layer dir plus the apps in `appsUsingLayer(L)` — root → all apps (unchanged), app layer → its own app only.

**Regression guarantees**
- Degenerate configs (no app info — Laravel/generic; single-app; layer consumed by no app) fall back to ALL units per the layer graph's documented semantics → results identical to the old global scan (all existing orphan tests pass unchanged; explicit equality test included).
- Code outside every app/layer dir is claimed by a synthetic `project-root` unit that vouches for every layer, so scoping never introduces orphans a whole-project scan would not have reported.
- Explicit `scanDirs` = manual scope control → old global combined-scan behavior, documented on the option and in the MCP schemas.

**New report fields** (both `find_orphan_keys` and `remove_orphan_keys`)
- `misplacedUsages`: `{ key, layer, usingApps }` for keys found only in usage sets of non-consuming units, plus a note that either the key belongs in a broader layer or the usage is a bug. Not double-reported as orphans; never removed.
- `summary.scanScope`: per-layer dirs that vouched for "used".
- `summary.misplacedCount`; `usedCount` now excludes misplaced keys.

`removeOrphanKeys` inherits all of this via the shared scan path; dry-run-default semantics untouched. MCP tool descriptions for both tools mention scope-awareness and `misplacedUsages`.

**Known quirk (unchanged, documented):** `dynamicMatchedCount`/`ignoredCount` still accumulate across layers; the restructure keeps per-layer counting shared, so this is now noted on `OrphanScanResult` rather than silently ambient.

## Tests

14 new tests (671 → 685 total):
- `tests/scanner/orphan-scan-scope.test.ts` (10): plan builder (multi-app scopes incl. alias resolution, no-app fallback, project-root remainder unit), once-per-file nested scanning, shared-layer vouching, misplaced detection (static + dynamic-pattern evidence), scanScope reporting, explicit-scanDirs global behavior, degenerate-plan ≡ global-scan equality.
- `tests/tools/orphan-scope.test.ts` (4): end-to-end `findOrphanKeys`/`removeOrphanKeys` over a real multi-app temp project — misplacedUsages output, summary.scanScope, scanDirs override, dry-run default, and `dryRun: false` removing orphans while misplaced keys survive.

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ (685 cli + 14 mcp)
- `pnpm -r --filter='./packages/*' typecheck` ✓
- `pnpm lint` ✓ (3 pre-existing warnings elsewhere)
- `npx fallow audit --base origin/main` → warn only; the single gated complexity finding is inherited (`extractKeys`, untouched, `introduced: false`); new duplication was refactored out (shared `runOrphanScan` helper, shared test fixture builder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orphan-key scanning now respects application and layer boundaries.
  * Reports identify keys used outside their expected scope, including affected applications and scan locations.
  * Removal and dry-run summaries now account for misplaced key usage.
  * Explicit scan directories continue to support global scanning across all layers.
* **Documentation**
  * Updated tool guidance to explain scoped scanning and misplaced usage reporting.
* **Tests**
  * Added coverage for multi-application projects, scoped detection, dry runs, and safe removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->