### PR TITLE
feat(cli): check — used-but-undefined key detection with CI exit gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The-i18n-kit auto-detects your project structure (Nuxt, Laravel, or any generic 
 ```bash
 the-i18n-cli missing              # what's not translated yet?
 the-i18n-cli remove-orphans      # what keys are dead code? (dry-run by default)
+the-i18n-cli check               # what keys are used but never defined? (non-zero exit — CI gate)
 the-i18n-cli rename --layer root --oldKey old.key --newKey new.key   # rename across all locales at once
 the-i18n-cli translate-key --layer root --key common.save --sourceLocale en-US --sourceValue "Save"  # update one key and translate targets
 the-i18n-cli translate --layer root --provider google --model gemini-2.5-flash  # auto-translate all missing keys

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,7 @@ the-i18n-cli write --layer root --translations '{"common.btn.ok": {"en": "OK", "
 the-i18n-cli translate-key --layer root --key common.btn.save --sourceLocale en-US --sourceValue "Save"
 the-i18n-cli translate --layer root --provider openai --model gpt-4o-mini   # Auto-translate missing keys
 the-i18n-cli remove-orphans                  # Find orphan keys (dry-run by default)
+the-i18n-cli check                           # Find used-but-undefined keys (non-zero exit — CI gate)
 ```
 
 ## Commands
@@ -45,6 +46,8 @@ the-i18n-cli remove-orphans                  # Find orphan keys (dry-run by defa
 | `translate` | Find missing translations and translate them via LLM (see Translation Modes). Also available as `translate-missing`, matching the MCP tool name |
 | `translate-key` | Translate one source key into target locales; can overwrite stale values |
 | `remove-orphans` | Find and remove keys not referenced in source code (dry-run by default) |
+| `check` | Find keys referenced in code but defined in no consumed locale layer — the inverse of `remove-orphans`. Exits non-zero when any are found, so it can gate CI. Dynamically built keys are reported as uncertain, never as hard findings |
+| `find-duplicates` | Find keys defined in both a shared layer and a consuming child layer (with divergence detection) |
 | `scaffold` | Create empty locale files for new languages |
 
 Run `the-i18n-cli <command> --help` for per-command options.
@@ -56,7 +59,7 @@ Run `the-i18n-cli <command> --help` for per-command options.
 | `-d, --projectDir <dir>` | Project directory (default: cwd) |
 | `--json` | Output as JSON (default when piped) |
 | `--dryRun` | Preview changes without writing |
-| `--output-file <path>` | `missing` / `remove-orphans`: write the full report to a file, return only a summary |
+| `--output-file <path>` | `missing` / `remove-orphans` / `check`: write the full report to a file, return only a summary |
 
 ## Translation Modes
 

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -8,6 +8,13 @@ export function createCommand(opts: {
   name: string
   description: string
   args?: Record<string, unknown>
+  /**
+   * Command-specific CI gate: when it returns true for the (already
+   * emitted) result, the process exits non-zero — e.g. `check` failing
+   * the build on undefined-key findings. Runs in addition to the generic
+   * isTotalFailure check.
+   */
+  failWhen?: (result: unknown) => boolean
   run: (args: any) => Promise<unknown>
 }): CommandDef {
   return defineCommand({
@@ -16,7 +23,7 @@ export function createCommand(opts: {
     async run({ args }) {
       const result = await opts.run(args)
       outputResult(result, args)
-      if (isTotalFailure(result)) {
+      if (isTotalFailure(result) || opts.failWhen?.(result)) {
         process.exitCode = 1
       }
     },

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,32 @@
+import { createCommand } from './_shared.js'
+import { checkUndefinedKeys } from '../core/operations.js'
+
+/**
+ * CI gate for `check`: any undefined-key finding fails the build.
+ * Reads summary.undefinedCount, so it works for inline results and for
+ * the { reportFile, summary } shape alike. Uncertain findings never fail.
+ */
+export function hasUndefinedKeys(result: unknown): boolean {
+  if (result === null || typeof result !== 'object') return false
+  const summary = (result as Record<string, unknown>).summary
+  if (summary === null || typeof summary !== 'object') return false
+  const count = (summary as Record<string, unknown>).undefinedCount
+  return typeof count === 'number' && count > 0
+}
+
+export default createCommand({
+  name: 'check',
+  description: 'Find keys referenced in code but defined in no consumed locale layer (they render as raw keys); exits non-zero when any are found',
+  args: {
+    locale: { type: 'string', description: 'Reference locale to resolve definitions in (default: project default)' },
+    outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
+  },
+  failWhen: hasUndefinedKeys,
+  async run(args) {
+    return checkUndefinedKeys({
+      locale: args.locale,
+      projectDir: args.projectDir,
+      outputFile: args.outputFile,
+    })
+  },
+})

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -24,6 +24,7 @@ export const commands = {
   }),
   'translate-key': () => import('./translate-key.js').then(m => m.default as CommandDef),
   'scan': () => import('./scan.js').then(m => m.default as CommandDef),
+  'check': () => import('./check.js').then(m => m.default as CommandDef),
   'find-duplicates': () => import('./find-duplicates.js').then(m => m.default as CommandDef),
   'remove-orphans': () => import('./remove-orphans.js').then(m => m.default as CommandDef),
   'scaffold': () => import('./scaffold.js').then(m => m.default as CommandDef),

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -74,3 +74,13 @@ export type {
   FindDuplicateKeysResult,
   FindDuplicateKeysSummary,
 } from './ops-duplicates.js'
+
+export { checkUndefinedKeys } from './ops-check.js'
+
+export type {
+  KeyUsageLocation,
+  UndefinedKeyFinding,
+  UncertainKeyFinding,
+  CheckUndefinedKeysResult,
+  CheckUndefinedKeysSummary,
+} from './ops-check.js'

--- a/packages/cli/src/core/ops-check.ts
+++ b/packages/cli/src/core/ops-check.ts
@@ -1,0 +1,411 @@
+/**
+ * Used-but-undefined key detection — the inverse of orphan scanning.
+ *
+ * A key referenced in source code but defined in no locale file of the
+ * using app's consumed layers renders as a raw key at runtime. Nothing
+ * else catches this direction (orphan scanning only computes
+ * locale − code; this computes code − locale, per scan unit).
+ */
+
+import { detectI18nConfig } from '../config/detector.js'
+import type { I18nConfig, LocaleDefinition } from '../config/types.js'
+import { writeReportFile } from '../io/json-writer.js'
+import { readLocaleData } from '../io/locale-data.js'
+import { getLeafKeys } from '../io/key-operations.js'
+import {
+  scanSourceFiles,
+  toRelativePath,
+  buildDynamicKeyRegexes,
+  buildIgnorePatternRegexes,
+  nestedUnitIgnores,
+} from '../scanner/code-scanner.js'
+import type { DynamicKeyUsage, KeyUsage, ScanResult, ScanUnit } from '../scanner/code-scanner.js'
+import { getPatternSet } from '../scanner/patterns.js'
+
+import { resolveReferenceLocale } from './shared.js'
+import { resolveReportFilePath } from './report.js'
+import { buildOrphanScanPlan, resolveOrphanIgnorePatterns } from './ops-orphans.js'
+
+export interface KeyUsageLocation {
+  /** Source file path, relative to the project dir. */
+  file: string
+  line: number
+}
+
+export interface UndefinedKeyFinding {
+  key: string
+  /** Scan unit the usage lives in (app name, layer name, or project-root). */
+  app: string
+  /** Layers whose keys this unit can resolve — all were searched. */
+  searchedLayers: string[]
+  usages: KeyUsageLocation[]
+}
+
+export interface UncertainKeyFinding extends UndefinedKeyFinding {
+  /** Why this is not a hard finding. */
+  reason: string
+}
+
+export interface CheckUndefinedKeysSummary {
+  /** Distinct statically referenced keys across all scan units. */
+  usedKeysChecked: number
+  undefinedCount: number
+  uncertainCount: number
+  /** Unresolvable keys excluded by orphanScan ignorePatterns. */
+  ignoredCount: number
+  filesScanned: number
+  locale: string
+  /** Scan unit → layers searched for that unit's key usages. */
+  searchedLayersByApp: Record<string, string[]>
+  message: string
+}
+
+export interface CheckUndefinedKeysResult {
+  undefinedKeys: UndefinedKeyFinding[]
+  uncertainKeys: UncertainKeyFinding[]
+  limitation: string
+  summary: CheckUndefinedKeysSummary
+}
+
+const CHECK_LIMITATION
+  = 'Static extraction is line-based: dynamically built keys (template literals, string '
+  + 'concatenation) cannot be verified and appear under uncertainKeys, never as hard findings. '
+  + 'Multiline translation calls are only caught heuristically.'
+
+const UNCERTAIN_DYNAMIC_USAGE
+  = 'dynamically built key — no defined key matches its pattern, but static analysis cannot verify which concrete keys it produces'
+const UNCERTAIN_DYNAMIC_OVERLAP
+  = 'matches a dynamic key pattern used in this app — may be a partial extraction of that expression'
+const UNCERTAIN_EXISTENCE_CHECK
+  = 'referenced only via existence checks ($te) — likely a deliberately optional key'
+
+/** Existence-check callees probe whether a key is defined; a miss is handled by the caller. */
+function isExistenceCheckCallee(callee: string): boolean {
+  return callee === '$te' || callee === 'this.$te'
+}
+
+/**
+ * All resolvable dot-paths of one layer in the reference locale: leaf keys
+ * plus every ancestor prefix, so parent-node references (`$tm('a.b')`,
+ * scoped `useI18n` roots) resolve too.
+ */
+async function layerKeyPaths(
+  config: I18nConfig,
+  layer: string,
+  locale: LocaleDefinition,
+): Promise<Set<string>> {
+  // readLocaleData yields {} for missing files; real failures (parse errors,
+  // permissions) must surface — reading them as "no keys" would flag every
+  // key of that layer as undefined.
+  const data = await readLocaleData(config, layer, locale)
+  const paths = new Set<string>()
+  for (const leaf of getLeafKeys(data)) {
+    paths.add(leaf)
+    let prefix = leaf
+    for (let idx = prefix.lastIndexOf('.'); idx > 0; idx = prefix.lastIndexOf('.')) {
+      prefix = prefix.slice(0, idx)
+      if (paths.has(prefix)) break
+      paths.add(prefix)
+    }
+  }
+  return paths
+}
+
+function toLocations(usages: Array<{ file: string; line: number }>, projectDir: string): KeyUsageLocation[] {
+  const seen = new Set<string>()
+  const locations: KeyUsageLocation[] = []
+  for (const u of usages) {
+    const file = toRelativePath(u.file, projectDir)
+    const id = `${file}:${u.line}`
+    if (seen.has(id)) continue
+    seen.add(id)
+    locations.push({ file, line: u.line })
+  }
+  return locations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)
+}
+
+const byAppThenKey = (a: { app: string; key: string }, b: { app: string; key: string }): number =>
+  a.app.localeCompare(b.app) || a.key.localeCompare(b.key)
+
+// ─── Scan planning ──────────────────────────────────────────────
+
+interface CheckScanPlan {
+  units: ScanUnit[]
+  /** True with explicit scanDirs: every layer resolvable from every unit. */
+  globalScope: boolean
+  /**
+   * Layers a unit's code can resolve = layers whose orphan-scan scope
+   * includes the unit (for app units this equals layersOfApp plus layers
+   * with degenerate all-unit scope; project-root resolves everything).
+   */
+  layersForUnit: (unitName: string) => string[]
+}
+
+function buildCheckScanPlan(config: I18nConfig, projectDir: string, scanDirs: string[] | undefined): CheckScanPlan {
+  const allLayerNames = config.localeDirs.filter(d => !d.aliasOf).map(d => d.layer)
+
+  // An empty scanDirs array means "not provided" (matches the orphan ops).
+  if (scanDirs?.length) {
+    return {
+      units: scanDirs.map(d => ({ name: toRelativePath(d, projectDir) || '.', dir: d })),
+      globalScope: true,
+      layersForUnit: () => allLayerNames,
+    }
+  }
+
+  const plan = buildOrphanScanPlan(config, projectDir)
+  return {
+    units: plan.units,
+    globalScope: false,
+    layersForUnit: unitName => allLayerNames.filter((layer) => {
+      const scope = plan.scopeByLayer.get(layer)
+      return !scope || scope.includes(unitName)
+    }),
+  }
+}
+
+// ─── Per-unit classification ────────────────────────────────────
+
+interface UnitCheckContext {
+  unitName: string
+  searchedLayers: string[]
+  resolvable: Set<string>
+  ignoreRegexes: RegExp[]
+  projectDir: string
+}
+
+interface UnitCheckOutcome {
+  undefinedKeys: UndefinedKeyFinding[]
+  uncertainKeys: UncertainKeyFinding[]
+  ignoredCount: number
+  checkedKeys: Set<string>
+}
+
+function groupBy<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyOf(item)
+    const list = groups.get(key) ?? []
+    list.push(item)
+    groups.set(key, list)
+  }
+  return groups
+}
+
+/**
+ * Classify one unit's static keys: keys not resolvable in the searched
+ * layers become undefined findings — unless an ignore pattern excludes
+ * them, a dynamic pattern overlaps them (possible partial extraction of a
+ * dynamic expression), or they are only probed via $te.
+ */
+function classifyStaticKeys(
+  usages: KeyUsage[],
+  dynRegexes: RegExp[],
+  ctx: UnitCheckContext,
+  outcome: UnitCheckOutcome,
+): void {
+  for (const [key, keyUsages] of groupBy(usages, u => u.key)) {
+    // Concat-prefix artifact: the static pattern also extracts the quoted
+    // prefix of `t('some.prefix.' + x)`. A trailing dot can never be a real
+    // key, and the concat usage is already covered as a dynamic expression.
+    if (key.endsWith('.')) continue
+    if (ctx.resolvable.has(key)) continue
+    if (ctx.ignoreRegexes.some(re => re.test(key))) {
+      outcome.ignoredCount++
+      continue
+    }
+    if (dynRegexes.some(re => re.test(key))) {
+      pushUncertain(outcome, ctx, key, keyUsages, UNCERTAIN_DYNAMIC_OVERLAP)
+      continue
+    }
+    if (keyUsages.every(u => isExistenceCheckCallee(u.callee))) {
+      pushUncertain(outcome, ctx, key, keyUsages, UNCERTAIN_EXISTENCE_CHECK)
+      continue
+    }
+    outcome.undefinedKeys.push({
+      key,
+      app: ctx.unitName,
+      searchedLayers: ctx.searchedLayers,
+      usages: toLocations(keyUsages, ctx.projectDir),
+    })
+  }
+}
+
+/**
+ * Dynamic usages whose pattern matches NO resolvable key are likely to
+ * produce raw keys too — but unverifiable, so always uncertain.
+ */
+function classifyDynamicUsages(
+  dynamicKeys: DynamicKeyUsage[],
+  ctx: UnitCheckContext,
+  outcome: UnitCheckOutcome,
+): void {
+  for (const [expression, usages] of groupBy(dynamicKeys, dk => dk.expression)) {
+    const [regex] = buildDynamicKeyRegexes([{ expression }])
+    if (!regex) continue // no interpolation — already handled as static
+    if ([...ctx.resolvable].some(key => regex.test(key))) continue
+    pushUncertain(outcome, ctx, expression, usages, UNCERTAIN_DYNAMIC_USAGE)
+  }
+}
+
+function pushUncertain(
+  outcome: UnitCheckOutcome,
+  ctx: UnitCheckContext,
+  key: string,
+  usages: Array<{ file: string; line: number }>,
+  reason: string,
+): void {
+  outcome.uncertainKeys.push({
+    key,
+    app: ctx.unitName,
+    searchedLayers: ctx.searchedLayers,
+    usages: toLocations(usages, ctx.projectDir),
+    reason,
+  })
+}
+
+/** Classify one unit's scan evidence (static keys, then dynamic usages). */
+function classifyUnitUsages(scan: ScanResult, ctx: UnitCheckContext): UnitCheckOutcome {
+  const outcome: UnitCheckOutcome = {
+    undefinedKeys: [],
+    uncertainKeys: [],
+    ignoredCount: 0,
+    checkedKeys: new Set(scan.uniqueKeys),
+  }
+
+  // Dynamic evidence downgrades static findings to uncertain: bare
+  // candidates are included here (conservative), but only located t()
+  // dynamic calls are themselves reported as uncertain usages.
+  const dynRegexes = buildDynamicKeyRegexes([
+    ...scan.dynamicKeys,
+    ...[...scan.bareDynamicCandidates].map(expression => ({ expression })),
+  ])
+
+  classifyStaticKeys(scan.usages, dynRegexes, ctx, outcome)
+  classifyDynamicUsages(scan.dynamicKeys, ctx, outcome)
+  return outcome
+}
+
+function buildCheckMessage(undefinedCount: number, uncertainCount: number): string {
+  const uncertainNote = uncertainCount > 0
+    ? ` ${uncertainCount} reference(s) are uncertain (see uncertainKeys).`
+    : ''
+  if (undefinedCount === 0) {
+    return 'All statically referenced keys resolve to a definition in their app\'s consumed layers.'
+      + uncertainNote
+  }
+  return `${undefinedCount} key(s) are referenced in code but defined in no locale file of the `
+    + 'using app\'s consumed layers — they render as raw keys at runtime.'
+    + uncertainNote
+}
+
+// ─── Operation ──────────────────────────────────────────────────
+
+/**
+ * Find keys referenced in source code that resolve to no definition in the
+ * using app's consumed layers (reference locale, default: project default).
+ *
+ * Mirrors the orphan scan's per-unit structure: with no explicit scanDirs,
+ * the scope-aware plan from the layer graph decides which layers each scan
+ * unit's code can resolve (the inversion of the orphan scan's
+ * scopeByLayer — a unit resolves exactly the layers it vouches for). The
+ * graph's degenerate semantics carry over: with no app info every layer is
+ * resolvable everywhere, so only keys defined in NO layer are flagged.
+ */
+export async function checkUndefinedKeys(opts: {
+  locale?: string
+  /**
+   * Explicit scan roots — manual scope control. Every layer is treated as
+   * resolvable from every scanned dir (global behavior, no per-app scoping).
+   */
+  scanDirs?: string[]
+  excludeDirs?: string[]
+  projectDir?: string
+  outputFile?: string
+} = {}): Promise<CheckUndefinedKeysResult | { reportFile: string; summary: CheckUndefinedKeysSummary }> {
+  const dir = opts.projectDir ?? process.cwd()
+  const config = await detectI18nConfig(dir)
+  const { localeCode, localeDef } = resolveReferenceLocale(config, opts.locale)
+
+  const pathsByLayer = new Map<string, Set<string>>()
+  for (const localeDir of config.localeDirs.filter(d => !d.aliasOf)) {
+    pathsByLayer.set(localeDir.layer, await layerKeyPaths(config, localeDir.layer, localeDef))
+  }
+
+  const { units, globalScope, layersForUnit } = buildCheckScanPlan(config, dir, opts.scanDirs)
+
+  // Memoized per searched-layers signature — sibling units often share one.
+  const resolvableCache = new Map<string, Set<string>>()
+  const resolvablePaths = (layers: string[]): Set<string> => {
+    const signature = layers.join(' ')
+    let cached = resolvableCache.get(signature)
+    if (!cached) {
+      cached = new Set(layers.flatMap(layer => [...(pathsByLayer.get(layer) ?? [])]))
+      resolvableCache.set(signature, cached)
+    }
+    return cached
+  }
+
+  const patterns = getPatternSet(config.localeFileFormat)
+  const undefinedKeys: UndefinedKeyFinding[] = []
+  const uncertainKeys: UncertainKeyFinding[] = []
+  const searchedLayersByApp: Record<string, string[]> = {}
+  const checkedKeys = new Set<string>()
+  let filesScanned = 0
+  let ignoredCount = 0
+
+  for (const unit of units) {
+    const ignores = globalScope ? [] : nestedUnitIgnores(unit, units)
+    const scan = await scanSourceFiles(unit.dir, [...(opts.excludeDirs ?? []), ...ignores], patterns)
+    filesScanned += scan.filesScanned
+
+    const searchedLayers = layersForUnit(unit.name)
+    searchedLayersByApp[unit.name] = searchedLayers
+
+    const outcome = classifyUnitUsages(scan, {
+      unitName: unit.name,
+      searchedLayers,
+      resolvable: resolvablePaths(searchedLayers),
+      ignoreRegexes: buildIgnorePatternRegexes(
+        searchedLayers.flatMap(layer => resolveOrphanIgnorePatterns(config, layer) ?? []),
+      ),
+      projectDir: dir,
+    })
+    undefinedKeys.push(...outcome.undefinedKeys)
+    uncertainKeys.push(...outcome.uncertainKeys)
+    ignoredCount += outcome.ignoredCount
+    for (const key of outcome.checkedKeys) checkedKeys.add(key)
+  }
+
+  undefinedKeys.sort(byAppThenKey)
+  uncertainKeys.sort(byAppThenKey)
+
+  const summary: CheckUndefinedKeysSummary = {
+    usedKeysChecked: checkedKeys.size,
+    undefinedCount: undefinedKeys.length,
+    uncertainCount: uncertainKeys.length,
+    ignoredCount,
+    filesScanned,
+    locale: localeCode,
+    searchedLayersByApp,
+    message: buildCheckMessage(undefinedKeys.length, uncertainKeys.length),
+  }
+
+  const output: CheckUndefinedKeysResult = {
+    undefinedKeys,
+    uncertainKeys,
+    limitation: CHECK_LIMITATION,
+    summary,
+  }
+
+  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_undefined_keys')
+  if (reportPath) {
+    await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
+      tool: 'find_undefined_keys',
+      args: { locale: opts.locale, scanDirs: opts.scanDirs, excludeDirs: opts.excludeDirs },
+    })
+    return { reportFile: reportPath, summary }
+  }
+
+  return output
+}

--- a/packages/cli/src/core/ops-check.ts
+++ b/packages/cli/src/core/ops-check.ts
@@ -23,7 +23,7 @@ import type { DynamicKeyUsage, KeyUsage, ScanResult, ScanUnit } from '../scanner
 import { getPatternSet } from '../scanner/patterns.js'
 
 import { resolveReferenceLocale } from './shared.js'
-import { resolveReportFilePath } from './report.js'
+import { resolveReportFilePath, validateReportPath } from './report.js'
 import { buildOrphanScanPlan, resolveOrphanIgnorePatterns } from './ops-orphans.js'
 
 export interface KeyUsageLocation {
@@ -399,6 +399,9 @@ export async function checkUndefinedKeys(opts: {
   }
 
   const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_undefined_keys')
+  if (reportPath) {
+    validateReportPath(dir, reportPath)
+  }
   if (reportPath) {
     await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
       tool: 'find_undefined_keys',

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -16,7 +16,7 @@ import type { OrphanScanPlan, OrphanScanResult } from '../scanner/code-scanner.j
 import { getPatternSet } from '../scanner/patterns.js'
 import { ToolError } from '../utils/errors.js'
 
-import { findLayerOrThrow, findLocaleImpl } from './shared.js'
+import { findLayerOrThrow, resolveReferenceLocale } from './shared.js'
 import { validateReportPath, resolveReportFilePath } from './report.js'
 
 const MISPLACED_USAGE_NOTE
@@ -146,14 +146,7 @@ async function resolveOrphanScanContext(
   totalKeys: number
   localeCode: string
 }> {
-  const localeCode = opts.locale ?? config.defaultLocale
-  const localeDef = findLocaleImpl(config, localeCode)
-  if (!localeDef) {
-    throw new ToolError(
-      `Locale not found: "${localeCode}". Available: ${config.locales.map(l => l.code).join(', ')}`,
-      'LOCALE_NOT_FOUND',
-    )
-  }
+  const { localeCode, localeDef } = resolveReferenceLocale(config, opts.locale)
 
   const layersToCheck = opts.layer
     ? config.localeDirs.filter(d => d.layer === opts.layer)

--- a/packages/cli/src/core/shared.ts
+++ b/packages/cli/src/core/shared.ts
@@ -69,6 +69,25 @@ export function findLocaleImpl(config: I18nConfig, localeRef: string) {
   )
 }
 
+/**
+ * Resolve the reference locale for scan operations: the requested ref or the
+ * project default. Throws LOCALE_NOT_FOUND listing the available codes.
+ */
+export function resolveReferenceLocale(
+  config: I18nConfig,
+  requested?: string,
+): { localeCode: string; localeDef: LocaleDefinition } {
+  const localeCode = requested ?? config.defaultLocale
+  const localeDef = findLocaleImpl(config, localeCode)
+  if (!localeDef) {
+    throw new ToolError(
+      `Locale not found: "${localeCode}". Available: ${config.locales.map(l => l.code).join(', ')}`,
+      'LOCALE_NOT_FOUND',
+    )
+  }
+  return { localeCode, localeDef }
+}
+
 export function findLocaleOrThrow(config: I18nConfig, localeRef: string): LocaleDefinition {
   const locale = findLocaleImpl(config, localeRef)
   if (!locale) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ export {
   scanCodeUsage,
   removeOrphanKeys,
   findDuplicateKeys,
+  checkUndefinedKeys,
   scaffoldLocaleFiles,
   listNamespaces,
   findLocaleImpl,
@@ -28,6 +29,11 @@ export type {
   DuplicateKeyCollision,
   FindDuplicateKeysResult,
   FindDuplicateKeysSummary,
+  KeyUsageLocation,
+  UndefinedKeyFinding,
+  UncertainKeyFinding,
+  CheckUndefinedKeysResult,
+  CheckUndefinedKeysSummary,
 } from './core/operations.js'
 
 // Core types

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -434,7 +434,7 @@ interface UnitEvidence {
  * scope-aware scan visits every file exactly once and attributes it to the
  * innermost unit.
  */
-function nestedUnitIgnores(unit: ScanUnit, units: ScanUnit[]): string[] {
+export function nestedUnitIgnores(unit: ScanUnit, units: ScanUnit[]): string[] {
   const ignores: string[] = []
   for (const other of units) {
     if (other.dir === unit.dir) continue

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -238,11 +238,12 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   /** Matches PHP double-quoted strings containing $var or {$var} interpolation with at least one dot */
   const BARE_PHP_DYNAMIC = /"((?:[^"\\]|\\.)*(?:\{\$|\$[a-zA-Z_])(?:[^"\\]|\\.)*)"/g
   /**
-   * Matches string concat prefixes ending with a dot: 'some.key.' + var
+   * Matches string concat prefixes ending with a dot: 'some.key.' + var —
+   * including single-segment prefixes like 'menu.' + var.
    * Catches multiline t() calls where the prefix is on a separate line from t(.
-   * Group 1: the prefix without trailing dot.
+   * Group 2: the prefix without trailing dot.
    */
-  const BARE_CONCAT_PREFIX = /['"](((?:[\w-]+\.)+[\w-]+)\.)['"]\s*\+/g
+  const BARE_CONCAT_PREFIX = /['"](([\w-]+(?:\.[\w-]+)*)\.)['"]\s*\+/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)

--- a/packages/cli/tests/cli/check-exit-code.test.ts
+++ b/packages/cli/tests/cli/check-exit-code.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+/**
+ * CI exit-code gating for the `check` command (#195): undefined-key
+ * findings must fail the build. Unit-tests the predicate (cf.
+ * exit-code.test.ts for isTotalFailure) and the createCommand failWhen
+ * mechanism that turns it into process.exitCode = 1.
+ */
+
+// writeResult bypasses stdout spies via a bound reference captured at module
+// load — mock the guard so command output stays out of the test stream.
+vi.mock('../../src/utils/stdout-guard.js', () => ({
+  guardStdout: vi.fn(),
+  writeResult: vi.fn(),
+}))
+
+const { hasUndefinedKeys } = await import('../../src/commands/check.js')
+const { createCommand } = await import('../../src/commands/_shared.js')
+
+describe('hasUndefinedKeys', () => {
+  it('flags results with undefined-key findings', () => {
+    expect(hasUndefinedKeys({
+      undefinedKeys: [{ key: 'common.terms.none' }],
+      summary: { undefinedCount: 1, uncertainCount: 0 },
+    })).toBe(true)
+  })
+
+  it('accepts clean results, even with uncertain or ignored findings', () => {
+    expect(hasUndefinedKeys({ undefinedKeys: [], summary: { undefinedCount: 0, uncertainCount: 3, ignoredCount: 2 } })).toBe(false)
+  })
+
+  it('works on the reportFile shape (summary only)', () => {
+    expect(hasUndefinedKeys({ reportFile: '/tmp/r.json', summary: { undefinedCount: 2 } })).toBe(true)
+    expect(hasUndefinedKeys({ reportFile: '/tmp/r.json', summary: { undefinedCount: 0 } })).toBe(false)
+  })
+
+  it('never flags malformed or unrelated results', () => {
+    expect(hasUndefinedKeys(null)).toBe(false)
+    expect(hasUndefinedKeys(undefined)).toBe(false)
+    expect(hasUndefinedKeys('string')).toBe(false)
+    expect(hasUndefinedKeys({})).toBe(false)
+    expect(hasUndefinedKeys({ summary: 'text' })).toBe(false)
+    expect(hasUndefinedKeys({ summary: { undefinedCount: '1' } })).toBe(false)
+    expect(hasUndefinedKeys({ summary: { orphanCount: 5 } })).toBe(false)
+  })
+})
+
+describe('createCommand failWhen gating', () => {
+  const savedExitCode = process.exitCode
+
+  afterEach(() => {
+    process.exitCode = savedExitCode
+  })
+
+  const runFake = async (result: unknown): Promise<void> => {
+    const cmd = createCommand({
+      name: 'fake-check',
+      description: 'test double',
+      failWhen: hasUndefinedKeys,
+      run: async () => result,
+    }) as unknown as { run: (ctx: { args: Record<string, unknown> }) => Promise<void> }
+    await cmd.run({ args: { json: true } })
+  }
+
+  it('sets exitCode 1 when the check found undefined keys', async () => {
+    await runFake({ undefinedKeys: [{ key: 'a.b' }], summary: { undefinedCount: 1 } })
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('leaves the exit code untouched on a clean result', async () => {
+    await runFake({ undefinedKeys: [], summary: { undefinedCount: 0, uncertainCount: 1 } })
+    expect(process.exitCode).toBe(savedExitCode)
+  })
+})

--- a/packages/cli/tests/fixtures/holder-detector.ts
+++ b/packages/cli/tests/fixtures/holder-detector.ts
@@ -1,0 +1,31 @@
+import type { I18nConfig } from '../../src/config/types.js'
+
+type DetectorModule = typeof import('../../src/config/detector.js')
+
+/**
+ * Detector-mock factory backed by a mutable holder: tests assign
+ * `holder.config` and every `detectI18nConfig` call returns it, regardless
+ * of projectDir. This file must stay free of `vi.mock` literals (they would
+ * be hoisted on import); use it from inside a test file's factory:
+ *
+ * ```ts
+ * const holder = vi.hoisted(() => ({ config: undefined as unknown }))
+ * vi.mock('../../src/config/detector.js', async importOriginal =>
+ *   (await import('../fixtures/holder-detector.js')).holderDetectorMock(holder, importOriginal))
+ * ```
+ */
+export async function holderDetectorMock(
+  holder: { config: unknown },
+  importOriginal: <T>() => Promise<T>,
+): Promise<DetectorModule> {
+  const original = await importOriginal<DetectorModule>()
+  return {
+    ...original,
+    detectI18nConfig: (async () => {
+      if (!holder.config) throw new Error('Test config not initialized')
+      return holder.config as I18nConfig
+    }) as DetectorModule['detectI18nConfig'],
+    clearConfigCache: () => { },
+    getCachedConfig: () => ((holder.config as I18nConfig | undefined) ?? null),
+  }
+}

--- a/packages/cli/tests/tools/check-undefined.test.ts
+++ b/packages/cli/tests/tools/check-undefined.test.ts
@@ -191,6 +191,45 @@ describe('checkUndefinedKeys — scope-aware', () => {
     }
   })
 
+  it('multiline single-segment concat: the bare fallback downgrades matching static keys', async () => {
+    // `t(` and the 'menu.' + suffix prefix on separate lines: only the
+    // BARE_CONCAT_PREFIX fallback sees this usage. Its `menu.${_}` candidate
+    // must downgrade the statically used, nowhere-defined menu.ghost from a
+    // hard undefined finding to uncertain.
+    const dir = await mkdtemp(join(tmpdir(), 'i18n-check-concat-'))
+    try {
+      const write = async (rel: string, content: string): Promise<void> => {
+        const path = join(dir, rel)
+        await mkdir(dirname(path), { recursive: true })
+        await writeFile(path, content)
+      }
+      await write('i18n/locales/de-DE.json', JSON.stringify({ root: { used: 'a' } }))
+      await write('app-admin/i18n/locales/de-DE.json', '{}')
+      await write('app-shop/i18n/locales/de-DE.json', '{}')
+      await write('components/Menu.vue', [
+        'const menuLabel = t(',
+        `  'menu.' + suffix,`,
+        ')',
+        `{{ $t('menu.ghost') }}`,
+      ].join('\n'))
+      holder.config = createTempMultiAppConfig(dir)
+
+      const result = await checkUndefinedKeys({ projectDir: dir })
+      if ('reportFile' in result) throw new Error('Expected inline result')
+
+      expect(result.undefinedKeys).toEqual([])
+      expect(result.uncertainKeys).toContainEqual(
+        expect.objectContaining({
+          key: 'menu.ghost',
+          reason: expect.stringContaining('dynamic key pattern'),
+        }),
+      )
+    } finally {
+      holder.config = config
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('honors outputFile: writes the full report and returns only the summary', async () => {
     const reportPath = join(projectDir, 'undefined-report.json')
     const result = await checkUndefinedKeys({ projectDir, outputFile: reportPath })

--- a/packages/cli/tests/tools/check-undefined.test.ts
+++ b/packages/cli/tests/tools/check-undefined.test.ts
@@ -1,0 +1,207 @@
+/**
+ * checkUndefinedKeys (#195) — the inverse of orphan scanning: keys
+ * referenced in source code but defined in no locale file of the using
+ * app's consumed layers. Covers scope-correct resolution over a multi-app
+ * temp project, dynamic-usage downgrades to uncertain, ignorePatterns,
+ * the no-app-info degenerate fallback, and the outputFile plumbing.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdir, writeFile, rm, mkdtemp, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { I18nConfig } from '../../src/config/types.js'
+import type { CheckUndefinedKeysResult } from '../../src/core/ops-check.js'
+import { createTempMultiAppConfig } from '../fixtures/config.js'
+
+const holder = vi.hoisted(() => ({ config: undefined as unknown }))
+vi.mock('../../src/config/detector.js', async importOriginal =>
+  (await import('../fixtures/holder-detector.js')).holderDetectorMock(holder, importOriginal))
+
+const adminPage = join('app-admin', 'pages/index.vue')
+const { checkUndefinedKeys } = await import('../../src/core/operations.js')
+
+let projectDir: string
+let config: I18nConfig
+
+beforeAll(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'i18n-check-undefined-'))
+  const write = async (rel: string, content: string): Promise<void> => {
+    const path = join(projectDir, rel)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, content)
+  }
+
+  // Locale files: the root layer defines root.shared.used, each app layer
+  // defines its own keys. Nothing defines admin.ghost or admin.dyn.*.
+  await write('i18n/locales/de-DE.json', JSON.stringify({ root: { shared: { used: 'a' } } }))
+  await write('app-admin/i18n/locales/de-DE.json', JSON.stringify({ admin: { used: 'a' } }))
+  await write('app-shop/i18n/locales/de-DE.json', JSON.stringify({ shop: { only: 'a' } }))
+
+  // Root-layer code uses a root key — clean.
+  await write('components/Shared.vue', `{{ $t('root.shared.used') }}`)
+
+  // app-admin exercises every classification (line numbers matter below).
+  await write(adminPage, [
+    `{{ $t('admin.used') }}`, // line 1: own layer — clean
+    `{{ $t('root.shared.used') }}`, // line 2: consumed shared layer — clean
+    `{{ $t('admin.ghost') }}`, // line 3: defined nowhere — undefined
+    `{{ $t('shop.only') }}`, // line 4: only in non-consumed app-shop — undefined here
+    'const label = t(`admin.dyn.${variant}`)', // line 5: dynamic — uncertain
+    `{{ $te('admin.optional') }}`, // line 6: existence check only — uncertain
+    `{{ $t('admin.ignored.x') }}`, // line 7: matches ignorePatterns — ignored
+    `{{ $t('root.shared') }}`, // line 8: parent node of a leaf — clean
+    `{{ $t('admin.ghost') }}`, // line 9: second usage aggregates
+    `{{ $t('admin.concat.' + kind) }}`, // line 10: concat — dynamic uncertain, prefix never a hard finding
+  ].join('\n'))
+
+  // app-shop uses its own key — clean in its scope.
+  await write('app-shop/pages/index.vue', `{{ $t('shop.only') }}`)
+
+  config = {
+    ...createTempMultiAppConfig(projectDir),
+    projectConfig: {
+      orphanScan: { 'app-admin': { ignorePatterns: ['admin.ignored.**'] } },
+    },
+  }
+  holder.config = config
+})
+
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true })
+})
+
+async function runCheck(): Promise<CheckUndefinedKeysResult> {
+  const result = await checkUndefinedKeys({ projectDir })
+  if ('reportFile' in result) throw new Error('Expected inline result, got report file')
+  return result
+}
+
+describe('checkUndefinedKeys — scope-aware', () => {
+  it('keys defined in a consumed layer (own, shared, or parent node) are clean', async () => {
+    const result = await runCheck()
+
+    const flagged = [...result.undefinedKeys, ...result.uncertainKeys].map(f => f.key)
+    for (const clean of ['admin.used', 'root.shared.used', 'root.shared']) {
+      expect(flagged).not.toContain(clean)
+    }
+  })
+
+  it('reports a key defined nowhere with all its usage locations', async () => {
+    const result = await runCheck()
+
+    expect(result.undefinedKeys).toContainEqual({
+      key: 'admin.ghost',
+      app: 'app-admin',
+      searchedLayers: ['root', 'app-admin'],
+      usages: [
+        { file: adminPage, line: 3 },
+        { file: adminPage, line: 9 },
+      ],
+    })
+  })
+
+  it('a key defined only in a non-consumed app layer is undefined for the using app', async () => {
+    const result = await runCheck()
+
+    expect(result.undefinedKeys).toContainEqual(
+      expect.objectContaining({ key: 'shop.only', app: 'app-admin' }),
+    )
+    // …but clean where the defining layer IS consumed.
+    expect(result.undefinedKeys.filter(f => f.app === 'app-shop')).toEqual([])
+    expect(result.undefinedKeys).toHaveLength(2)
+  })
+
+  it('dynamic usages and existence-check-only keys are uncertain, never hard findings', async () => {
+    const result = await runCheck()
+
+    expect(result.uncertainKeys).toContainEqual(
+      expect.objectContaining({
+        key: '`admin.dyn.${variant}`',
+        app: 'app-admin',
+        usages: [{ file: adminPage, line: 5 }],
+      }),
+    )
+    expect(result.uncertainKeys).toContainEqual(
+      expect.objectContaining({ key: 'admin.optional', app: 'app-admin' }),
+    )
+    const undefinedKeyNames = result.undefinedKeys.map(f => f.key)
+    expect(undefinedKeyNames).not.toContain('`admin.dyn.${variant}`')
+    expect(undefinedKeyNames).not.toContain('admin.optional')
+  })
+
+  it('concat usage: the quoted prefix is never a hard finding, the expression is uncertain', async () => {
+    const result = await runCheck()
+
+    // Static extraction also captures 'admin.concat.' from the concat call —
+    // a trailing-dot artifact, not a key.
+    expect(result.undefinedKeys.map(f => f.key)).not.toContain('admin.concat.')
+    expect(result.uncertainKeys).toContainEqual(
+      expect.objectContaining({
+        key: '`admin.concat.${_}`',
+        app: 'app-admin',
+        usages: [{ file: adminPage, line: 10 }],
+      }),
+    )
+  })
+
+  it('respects orphanScan ignorePatterns and counts the exclusions', async () => {
+    const result = await runCheck()
+
+    const flagged = [...result.undefinedKeys, ...result.uncertainKeys].map(f => f.key)
+    expect(flagged).not.toContain('admin.ignored.x')
+    expect(result.summary.ignoredCount).toBe(1)
+  })
+
+  it('summarizes counts, locale, and per-app searched layers', async () => {
+    const result = await runCheck()
+
+    expect(result.summary).toMatchObject({
+      usedKeysChecked: 8, // incl. the concat-prefix artifact captured statically
+      undefinedCount: 2,
+      uncertainCount: 3,
+      ignoredCount: 1,
+      filesScanned: 3,
+      locale: 'de',
+    })
+    expect(result.summary.searchedLayersByApp).toEqual({
+      'root': ['root'],
+      'app-admin': ['root', 'app-admin'],
+      'app-shop': ['root', 'app-shop'],
+    })
+    expect(result.summary.message).toContain('raw keys')
+    expect(result.limitation).toContain('line-based')
+  })
+
+  it('no-app-info degenerate: a key defined in ANY layer counts as resolvable', async () => {
+    holder.config = { ...config, apps: [] }
+    try {
+      const result = await runCheck()
+
+      // shop.only now resolves for app-admin code too; only the truly
+      // nowhere-defined key remains.
+      expect(result.undefinedKeys).toEqual([
+        expect.objectContaining({
+          key: 'admin.ghost',
+          searchedLayers: ['root', 'app-admin', 'app-shop'],
+        }),
+      ])
+    } finally {
+      holder.config = config
+    }
+  })
+
+  it('honors outputFile: writes the full report and returns only the summary', async () => {
+    const reportPath = join(projectDir, 'undefined-report.json')
+    const result = await checkUndefinedKeys({ projectDir, outputFile: reportPath })
+
+    expect(result).toEqual({
+      reportFile: reportPath,
+      summary: expect.objectContaining({ undefinedCount: 2, uncertainCount: 3 }),
+    })
+
+    const report = JSON.parse(await readFile(reportPath, 'utf-8')) as Record<string, unknown>
+    expect(report.tool).toBe('find_undefined_keys')
+    expect(report.undefinedKeys).toHaveLength(2)
+  })
+})

--- a/packages/cli/tests/tools/orphan-scope.test.ts
+++ b/packages/cli/tests/tools/orphan-scope.test.ts
@@ -9,23 +9,11 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vites
 import { mkdir, writeFile, rm, mkdtemp, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import type { I18nConfig } from '../../src/config/types.js'
 import { createTempMultiAppConfig } from '../fixtures/config.js'
 
 const holder = vi.hoisted(() => ({ config: undefined as unknown }))
-
-vi.mock('../../src/config/detector.js', async (importOriginal) => {
-  const original = await importOriginal<typeof import('../../src/config/detector.js')>()
-  return {
-    ...original,
-    detectI18nConfig: async () => {
-      if (!holder.config) throw new Error('Test config not initialized')
-      return holder.config as I18nConfig
-    },
-    clearConfigCache: () => { },
-    getCachedConfig: () => (holder.config as I18nConfig | undefined) ?? null,
-  }
-})
+vi.mock('../../src/config/detector.js', async importOriginal =>
+  (await import('../fixtures/holder-detector.js')).holderDetectorMock(holder, importOriginal))
 
 const { findOrphanKeys, removeOrphanKeys } = await import('../../src/core/operations.js')
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -110,6 +110,7 @@ Then just ask your agent:
 | `translate_missing` | Find and translate missing keys — provider mode translates directly, agent mode returns fallback contexts |
 | `translate_key` | Translate one source key into target locales; can overwrite stale values |
 | `find_orphan_keys` | Find keys not referenced in source code |
+| `find_undefined_keys` | Find keys referenced in code but defined in no consumed locale layer — the inverse of `find_orphan_keys` (this direction ships raw keys to production). Dynamic keys are reported as uncertain |
 | `remove_orphan_keys` | Find + remove orphan keys. **Dry-run by default** |
 | `scaffold_locale` | Create empty locale files for new languages |
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -24,6 +24,7 @@ import {
   findOrphanKeys,
   removeOrphanKeys,
   findDuplicateKeys,
+  checkUndefinedKeys,
   scaffoldLocaleFiles,
   listNamespaces,
   findLocaleImpl,
@@ -163,6 +164,17 @@ function jsonContent(data: unknown) {
     content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
   }
 }
+
+// Shared input-schema fragments (identical wording across tools).
+const projectDirInput = () => z
+  .string()
+  .optional()
+  .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".')
+
+const outputFileInput = (example: string) => z
+  .string()
+  .optional()
+  .describe(`Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "${example}"`)
 
 export interface CreateServerOptions {
   /**
@@ -735,6 +747,46 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     },
   )
 
+  // ─── Tool: find_undefined_keys ────────────────────────────────
+
+  server.registerTool(
+    'find_undefined_keys',
+    {
+      title: 'Find Used-But-Undefined Translation Keys',
+      description:
+        'The inverse of find_orphan_keys: find keys referenced in source code but defined in NO locale file of the '
+        + 'using app\'s consumed layers — the direction that ships raw keys to production. '
+        + 'Scope-aware: each scan unit (app) is checked against the layers it consumes (summary.searchedLayersByApp); '
+        + 'a key defined only in a layer the using app does not consume is still undefined for that app. '
+        + 'Known limitation: extraction is line-based and static — dynamically built keys (template literals, '
+        + 'concatenation) cannot be verified and are reported as uncertainKeys, never as hard findings.',
+      inputSchema: {
+        locale: z
+          .string()
+          .optional()
+          .describe('Reference locale to resolve key definitions in (e.g., "en", "en-US"). Defaults to the project default locale.'),
+        scanDirs: z
+          .array(z.string())
+          .optional()
+          .describe('Absolute paths to directories to scan for source code usage. Overrides scope-aware scanning: every layer counts as resolvable from these dirs. Example: ["/home/user/my-app/apps/admin"].'),
+        excludeDirs: z
+          .array(z.string())
+          .optional()
+          .describe('Directory names to skip when scanning source files. Example: ["storybook", "__tests__", "node_modules"].'),
+        projectDir: projectDirInput(),
+        outputFile: outputFileInput('/tmp/undefined-keys.json'),
+      },
+    },
+    async ({ locale, scanDirs, excludeDirs, projectDir, outputFile }) => {
+      try {
+        const result = await checkUndefinedKeys({ locale, scanDirs, excludeDirs, projectDir, outputFile })
+        return jsonContent(result)
+      } catch (error) {
+        return toolErrorResponse('finding undefined keys', error)
+      }
+    },
+  )
+
   // ─── Tool: find_duplicate_keys ────────────────────────────────
 
   server.registerTool(
@@ -752,14 +804,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
           .string()
           .optional()
           .describe('Locale code to compare values in (e.g., "de", "en-US"). Defaults to the project default locale.'),
-        projectDir: z
-          .string()
-          .optional()
-          .describe('Absolute path to the Nuxt project root. Defaults to server cwd. Example: "/home/user/my-app".'),
-        outputFile: z
-          .string()
-          .optional()
-          .describe('Absolute path to write full JSON output. Returns only a compact summary to the caller — use this for large outputs to avoid flooding the conversation context. Example: "/tmp/duplicate-keys.json"'),
+        projectDir: projectDirInput(),
+        outputFile: outputFileInput('/tmp/duplicate-keys.json'),
       },
     },
     async ({ locale, projectDir, outputFile }) => {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -94,6 +94,7 @@ describe('the-i18n-mcp server over in-memory transport', () => {
       'discover',
       'find_duplicate_keys',
       'find_orphan_keys',
+      'find_undefined_keys',
       'get_missing_translations',
       'get_translations',
       'list_namespaces',
@@ -189,6 +190,17 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.summary.locale).toBe('de')
     expect(json?.summary.message).toBeDefined()
     expect(json?.guidance).toBeDefined()
+  })
+
+  it('find_undefined_keys returns a clean result for a project without code usage', async () => {
+    const { json } = await callTool('find_undefined_keys', { projectDir })
+
+    expect(json?.undefinedKeys).toEqual([])
+    expect(json?.uncertainKeys).toEqual([])
+    expect(json?.summary.undefinedCount).toBe(0)
+    expect(json?.summary.usedKeysChecked).toBe(0)
+    expect(json?.summary.locale).toBe('de')
+    expect(json?.limitation).toContain('line-based')
   })
 
   it('rejects invalid tool input via schema validation', async () => {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -203,6 +203,40 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.limitation).toContain('line-based')
   })
 
+  it('find_undefined_keys reports an undefined key and an uncertain dynamic usage', async () => {
+    const dir = await makeProject()
+    try {
+      await mkdir(join(dir, 'components'), { recursive: true })
+      await writeFile(join(dir, 'components/Page.vue'), [
+        `{{ $t('actions.save') }}`,
+        `{{ $t('missing.key') }}`,
+        'const label = t(`dyn.${variant}`)',
+      ].join('\n'))
+
+      const { json } = await callTool('find_undefined_keys', { projectDir: dir })
+
+      expect(json?.undefinedKeys).toEqual([
+        expect.objectContaining({
+          key: 'missing.key',
+          searchedLayers: ['root'],
+          usages: [{ file: join('components', 'Page.vue'), line: 2 }],
+        }),
+      ])
+      expect(json?.uncertainKeys).toEqual([
+        expect.objectContaining({
+          key: '`dyn.${variant}`',
+          usages: [{ file: join('components', 'Page.vue'), line: 3 }],
+          reason: expect.stringContaining('dynamically built key'),
+        }),
+      ])
+      expect(json?.summary.undefinedCount).toBe(1)
+      expect(json?.summary.uncertainCount).toBe(1)
+      expect(json?.summary.searchedLayersByApp).toEqual({ default: ['root'] })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('rejects invalid tool input via schema validation', async () => {
     const { result } = await callTool('write_translations', {
       layer: 'root',


### PR DESCRIPTION
Closes #195

## What

The inverse of orphan scanning: keys referenced in source code but defined in **no** locale file of the using app's consumed layers render as raw keys in production (the `common.terms.none` incident). Orphan scanning only computes `locale − code`; this adds `code − locale`, per scan unit.

## How

**New operation `checkUndefinedKeys`** (`packages/cli/src/core/ops-check.ts`):
- Reuses the scanner's static `uniqueKeys` (not the bare-string heuristics) per scan unit via `buildOrphanScanPlan`.
- A unit's resolvable key set is the union of leaf keys **plus ancestor prefixes** (so `$tm('a.b')`-style parent references resolve) in the reference locale, across the layers whose orphan-scan scope includes the unit — i.e. `layersOfApp` plus the graph's degenerate semantics (no-app-info configs: every layer resolvable everywhere).
- Finding shape: `{ key, app, searchedLayers, usages: [{file, line}] }`.
- Never hard findings (→ `uncertainKeys` with a reason):
  - dynamically built keys whose pattern matches no resolvable key,
  - static keys overlapping a dynamic pattern of the same unit (possible partial extraction),
  - keys probed only via `$te` existence checks.
- Concat-prefix extraction artifacts (`t('some.prefix.' + x)` → trailing-dot pseudo-key) are filtered — found and fixed during the battle test.
- `orphanScan` ignorePatterns of the searched layers are respected; `outputFile`/`reportOutput` plumbing as in the sibling ops.

**Surfaces**
- CLI `check` — **exits non-zero when undefined keys are found** via a new per-command `failWhen` hook in `createCommand` (`isTotalFailure` untouched). CI gating is now one pipeline line.
- MCP tool `find_undefined_keys` — described as the inverse of `find_orphan_keys`; the line-based-extraction limitation is documented in the description and in a `limitation` field of every result.

**Refactors along the way**: shared `resolveReferenceLocale` (was duplicated between ops), exported `nestedUnitIgnores`, shared MCP input-schema fragments, reusable holder-backed detector mock fixture (`tests/fixtures/holder-detector.ts`).

## Battle test (read-only)

**playground/nuxt** — exit 1, 2 undefined, 0 uncertain, 6 keys checked / 4 files. Both findings genuine and scope-correct: `admin.dashboard.title` / `admin.dashboard.welcome` are used in `app/app.vue` (root app) but defined only in the `app-admin` layer, which the root app does not extend — they render raw in the root playground app.

**anny-ui** (`ci-i18n-pipeline`, branch `feat/new-langs`, 30 locales, 7 layers) — exit 1, **5,104 keys checked / 2,556 files scanned, 101 undefined, 31 uncertain** (83 root / 15 app-admin / 2 app-designer / 2 app-shop, after the artifact fix). Historical `common.terms.none` is meanwhile defined in the root layer and correctly not reported.

10 findings grep-verified against every locale JSON of the using app's consumed layers:

| App | Key | Usage | Verdict |
|---|---|---|---|
| app-admin | `common.actions.saved` | HolidayBlockerForm.vue:255 | genuine — defined nowhere |
| app-admin | `common.terms.barChart` | BaseBarChart.vue:222 | genuine — defined nowhere |
| app-admin | `pages.dashboard.t` | DashboardForm.vue:68 | genuine — literal `t('pages.dashboard.t')` in source (truncated key bug) |
| app-designer | `constants.displayTypes.` | DesignerDrawPanel.vue:111 | **false positive** — concat-prefix artifact of `t('constants.displayTypes.' + option)`; scanner static regex also captured the quoted prefix → now filtered (root-caused + regression-tested), count 102 → 101 |
| app-shop | `common.actions.more` | BusinessAccountMemberPreview.vue:167 | genuine — defined nowhere |
| root | `activity.logs.reason` | ActivityRow.vue:73 | genuine, scope-correct — defined only in app-admin layer; raw key in non-admin apps |
| root | `pages.calendar.tooltips.slotDuration` | AnnyFullCalendar.vue:273 | genuine, scope-correct — defined only in app-admin |
| root | `common.a11y.masterDetail.detailSection` | AnnyMasterDetailPage.vue:576 | genuine — defined nowhere |
| app-admin | `components.integrations.keycafe.authentication.missing` | KeycafeAuthentication.vue:178 | genuine — defined nowhere |
| root | `pages.resources.title` | ResourceTimeline.vue:135 | genuine, scope-correct — defined only in app-admin |

The 31 uncertain entries are dominated by prefix-interpolated expressions (`` `${i18nBase}.description` `` etc.) — correctly unverifiable by static analysis. anny-ui was not modified (report routed to /tmp).

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ — 698 CLI + 16 MCP tests (13 new: 9 ops seam, 6→ incl. gating unit tests, +1 MCP transport; tool-list assertion bumped)
- `pnpm -r --filter='./packages/*' typecheck` ✓, `pnpm lint` ✓ (0 errors; 3 pre-existing warnings)
- `npx fallow audit --base origin/main` ✓ exit 0 (new complexity/duplication findings fixed by refactoring; no baseline changes needed)

## Future work

Lifting the line-based limitation: [i18next-cli](https://github.com/i18next/i18next-cli) does SWC/AST extraction with type-aware expansion of *finite* dynamic keys (union types, `as const` arrays) — that approach would convert most `uncertainKeys` into verified findings. [nuxt-i18n-micro-cli](https://github.com/s00d/nuxt-i18n-micro-cli)'s `validate` is the same check without layer scoping. Tracked as inspiration for a future AST-based extractor behind the same operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI `check` command to detect translation keys used in code but missing from locale files.
  * Added CI-friendly failure reporting and optional JSON output reports.
  * Added the `find_undefined_keys` MCP tool with locale, directory, exclusion, and report options.
  * Dynamic or uncertain key references are reported separately without failing checks.
* **Documentation**
  * Updated CLI and MCP documentation with usage details and supported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->