### PR TITLE
chore(types): enable noUncheckedIndexedAccess

### DIFF
--- a/packages/cli/src/adapters/generic/index.ts
+++ b/packages/cli/src/adapters/generic/index.ts
@@ -61,7 +61,8 @@ export class GenericAdapter implements FrameworkAdapter {
       }
     }
 
-    const detectedFormat = await detectFileFormat(localeDirs[0].path)
+    // localeDirs mirrors projectConfig.localeDirs, whose emptiness is guarded above
+    const detectedFormat = await detectFileFormat(localeDirs[0]!.path)
     const discoveredLocales = projectConfig.locales ?? await discoverLocales(localeDirs, detectedFormat)
 
     if (discoveredLocales.length === 0) {

--- a/packages/cli/src/adapters/laravel/index.ts
+++ b/packages/cli/src/adapters/laravel/index.ts
@@ -255,7 +255,7 @@ function extractPhpConfigValue(content: string, key: string): string | null {
   )
   const envMatch = content.match(envPattern)
   if (envMatch) {
-    return envMatch[1]
+    return envMatch[1] ?? null
   }
 
   const directPattern = new RegExp(
@@ -263,7 +263,7 @@ function extractPhpConfigValue(content: string, key: string): string | null {
   )
   const directMatch = content.match(directPattern)
   if (directMatch) {
-    return directMatch[1]
+    return directMatch[1] ?? null
   }
 
   return null
@@ -274,13 +274,15 @@ function extractPhpArrayValue(content: string, key: string): string[] {
     `['"]${key}['"]\\s*=>\\s*\\[([^\\]]*)]`,
   )
   const match = content.match(pattern)
-  if (!match) return []
+  const arrayBody = match?.[1]
+  if (arrayBody === undefined) return []
 
   const itemPattern = /['"]([^'"]+)['"]/g
   const items: string[] = []
   let itemMatch: RegExpExecArray | null
-  while ((itemMatch = itemPattern.exec(match[1])) !== null) {
-    items.push(itemMatch[1])
+  while ((itemMatch = itemPattern.exec(arrayBody)) !== null) {
+    const item = itemMatch[1]
+    if (item) items.push(item)
   }
   return items
 }

--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -50,12 +50,14 @@ export class NuxtAdapter implements FrameworkAdapter {
       )
     }
 
-    if (appDirs.length === 1) {
-      const config = await loadSingleApp(appDirs[0], projectDir)
-      if (appDirs[0] !== projectDir) {
+    const [soleAppDir] = appDirs
+    if (appDirs.length === 1 && soleAppDir !== undefined) {
+      const config = await loadSingleApp(soleAppDir, projectDir)
+      if (soleAppDir !== projectDir) {
         config.rootDir = projectDir
-        if (config.apps.length > 0) {
-          config.apps[0].rootDir = projectDir
+        const rootApp = config.apps[0]
+        if (rootApp) {
+          rootApp.rootDir = projectDir
         }
       }
       log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories`)

--- a/packages/cli/src/adapters/nuxt/layer-dedup.ts
+++ b/packages/cli/src/adapters/nuxt/layer-dedup.ts
@@ -86,8 +86,8 @@ export function claimLocaleDir(
 
   if (owner !== existing.layer) {
     const ownerIndex = dirs.findIndex(d => d.layer === existing.layer && !d.aliasOf)
-    if (ownerIndex !== -1) {
-      const previousOwner = dirs[ownerIndex]
+    const previousOwner = ownerIndex !== -1 ? dirs[ownerIndex] : undefined
+    if (previousOwner) {
       const promoted = { ...incoming }
       delete promoted.aliasOf
       dirs[ownerIndex] = promoted

--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -58,14 +58,15 @@ export class ReactAdapter implements FrameworkAdapter {
     }
 
     const locales = await discoverLocales(localeDir)
-    if (locales.length === 0) {
+    const [firstLocale] = locales
+    if (firstLocale === undefined) {
       throw new ConfigError(
         `No locale files found in ${localeDir}. `
         + 'Make sure your React/Next.js project has locale directories like messages/en/ or locale JSON files.',
       )
     }
 
-    const defaultLocale = locales[0].code
+    const defaultLocale = firstLocale.code
     const fallbackLocale = { default: [defaultLocale] }
 
     return {
@@ -213,9 +214,10 @@ async function tryExtractFromNextConfig(
 
 function tryExtractPathFromConfig(projectDir: string, content: string): string | null {
   const pathMatch = content.match(/(?:messages|localeDir|locales)\s*:\s*['"]([^'"]+)/)
-  if (!pathMatch) return null
+  const rawPath = pathMatch?.[1]
+  if (!rawPath) return null
 
-  const path = pathMatch[1].replace(/\/\*\/\*$/, '').replace(/\/\*$/, '')
+  const path = rawPath.replace(/\/\*\/\*$/, '').replace(/\/\*$/, '')
   return existsSync(join(projectDir, path)) ? join(projectDir, path) : null
 }
 

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -61,7 +61,8 @@ export class VueAdapter implements FrameworkAdapter {
     }
 
     const rawLocales = await discoverLocales(localeDir)
-    if (rawLocales.length === 0) {
+    const [firstRawLocale] = rawLocales
+    if (firstRawLocale === undefined) {
       throw new ConfigError(
         `No JSON locale files found in ${localeDir}. `
         + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
@@ -69,7 +70,7 @@ export class VueAdapter implements FrameworkAdapter {
     }
 
     const locales = applyLocaleOverride(rawLocales, projectConfig?.locales)
-    const defaultLocale = extractDefaultLocale(projectDir) ?? locales[0].code
+    const defaultLocale = extractDefaultLocale(projectDir) ?? locales[0]?.code ?? firstRawLocale.code
     const fallbackLocale = { default: [defaultLocale] }
 
     return {
@@ -145,6 +146,10 @@ async function findLocaleDir(projectDir: string): Promise<string | null> {
   return tryCommonPaths(projectDir)
 }
 
+function firstMatchGroup(content: string, regex: RegExp): string | undefined {
+  return content.match(regex)?.[1]
+}
+
 async function tryExtractFromConfig(projectDir: string): Promise<string | null> {
   for (const file of I18N_CONFIG_FILES) {
     const fullPath = join(projectDir, file)
@@ -153,16 +158,16 @@ async function tryExtractFromConfig(projectDir: string): Promise<string | null> 
     try {
       const content = await readFile(fullPath, 'utf-8')
 
-      const dirMatch = content.match(LOCALE_DIR_REGEX)
+      const dirMatch = firstMatchGroup(content, LOCALE_DIR_REGEX)
       if (dirMatch) {
-        const extracted = resolve(projectDir, dirMatch[1])
+        const extracted = resolve(projectDir, dirMatch)
         if (existsSync(extracted)) return extracted
       }
 
-      const msgMatch = content.match(MESSAGES_REGEX)
+      const msgMatch = firstMatchGroup(content, MESSAGES_REGEX)
       if (msgMatch) {
         const configDir = fullPath.replace(/\/[^/]+$/, '')
-        const extracted = resolve(configDir, msgMatch[1])
+        const extracted = resolve(configDir, msgMatch)
         const parentDir = extracted.replace(/\/[^/]+$/, '')
         if (existsSync(parentDir)) return parentDir
       }

--- a/packages/cli/src/config/discovery.ts
+++ b/packages/cli/src/config/discovery.ts
@@ -110,10 +110,10 @@ export function deriveLayerName(
 
   if (!posixRel.startsWith('..')) {
     const segments = posixRel.split('/')
-    let candidate = segments[segments.length - 1]
+    let candidate = segments.pop() ?? posixRel
 
     if (usedNames) {
-      for (let i = segments.length - 2; i >= 0; i--) {
+      for (let i = segments.length - 1; i >= 0; i--) {
         if (!usedNames.has(candidate)) break
         candidate = `${segments[i]}/${candidate}`
       }
@@ -123,10 +123,10 @@ export function deriveLayerName(
   }
 
   const parts = layerRootDir.replace(/\\/g, '/').split('/')
-  let candidate = parts[parts.length - 1]
+  let candidate = parts.pop() ?? layerRootDir
 
   if (usedNames) {
-    for (let i = parts.length - 2; i >= 0; i--) {
+    for (let i = parts.length - 1; i >= 0; i--) {
       if (!usedNames.has(candidate)) break
       candidate = `${parts[i]}/${candidate}`
     }

--- a/packages/cli/src/core/ops-duplicates.ts
+++ b/packages/cli/src/core/ops-duplicates.ts
@@ -90,12 +90,12 @@ function deriveLayerPairs(config: I18nConfig, graph: ReturnType<typeof buildLaye
 
   for (const app of config.apps ?? []) {
     const ordered = orderedCanonicalLayers(app.layers, graph, canonicalByName)
-    for (let i = 0; i < ordered.length; i++) {
-      for (let j = i + 1; j < ordered.length; j++) {
-        const id = [ordered[i].layer, ordered[j].layer].sort().join('\u0000')
+    for (const [i, child] of ordered.entries()) {
+      for (const shared of ordered.slice(i + 1)) {
+        const id = [child.layer, shared.layer].sort().join('\u0000')
         if (seen.has(id)) continue
         seen.add(id)
-        pairs.push({ shared: ordered[j], child: ordered[i] })
+        pairs.push({ shared, child })
       }
     }
   }

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -325,8 +325,7 @@ export async function scanCodeUsage(opts: {
 
   const byKey: Record<string, Array<{ file: string; line: number; callee: string }>> = {}
   for (const usage of filteredUsages) {
-    if (!byKey[usage.key]) byKey[usage.key] = []
-    byKey[usage.key].push({
+    (byKey[usage.key] ??= []).push({
       file: toRelativePath(usage.file, dir),
       line: usage.line,
       callee: usage.callee,
@@ -334,8 +333,8 @@ export async function scanCodeUsage(opts: {
   }
 
   const sortedByKey: Record<string, Array<{ file: string; line: number; callee: string }>> = {}
-  for (const key of Object.keys(byKey).sort()) {
-    sortedByKey[key] = byKey[key]
+  for (const [key, locations] of Object.entries(byKey).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    sortedByKey[key] = locations
   }
 
   const notFound = keys

--- a/packages/cli/src/core/ops-read.ts
+++ b/packages/cli/src/core/ops-read.ts
@@ -71,9 +71,9 @@ export async function listLocaleDirs(projectDir?: string): Promise<LocaleDirInfo
       const jsonFiles = files.filter(f => f.endsWith('.json'))
 
       let topLevelKeys: string[] = []
-      if (config.locales.length > 0 && jsonFiles.length > 0) {
+      const sampleLocale = config.locales[0]
+      if (sampleLocale !== undefined && jsonFiles.length > 0) {
         try {
-          const sampleLocale = config.locales[0]
           const data = await readLocaleData(config, localeDir.layer, sampleLocale)
           topLevelKeys = Object.keys(data)
         } catch {}
@@ -230,10 +230,7 @@ export async function getMissingTranslations(opts: {
       })
 
       if (missing.length > 0) {
-        if (!result[target.code]) {
-          result[target.code] = {}
-        }
-        result[target.code][localeDir.layer] = missing
+        (result[target.code] ??= {})[localeDir.layer] = missing
         totalMissing += missing.length
       }
     }
@@ -315,8 +312,7 @@ export async function findEmptyTranslations(opts: {
       const empty = leafKeys.filter(k => getNestedValue(data, k) === '')
 
       if (empty.length > 0) {
-        if (!emptyKeys[loc.code]) emptyKeys[loc.code] = {}
-        emptyKeys[loc.code][localeDir.layer] = empty
+        (emptyKeys[loc.code] ??= {})[localeDir.layer] = empty
         totalEmpty += empty.length
       }
     }

--- a/packages/cli/src/core/ops-translate.ts
+++ b/packages/cli/src/core/ops-translate.ts
@@ -251,8 +251,10 @@ export function validatePlaceholders(
       const missing = new Set<string>()
       const extra = new Set<string>()
       for (const [index, sourceVariant] of sourceVariants.entries()) {
+        const targetVariant = targetVariants[index]
+        if (targetVariant === undefined) continue
         const variantPlaceholders = extractPlaceholders(sourceVariant, format)
-        const diff = diffPlaceholders(variantPlaceholders, targetVariants[index], format)
+        const diff = diffPlaceholders(variantPlaceholders, targetVariant, format)
         for (const placeholder of diff.missing) missing.add(placeholder)
         for (const placeholder of diff.extra) extra.add(placeholder)
       }
@@ -740,7 +742,9 @@ export async function translateMissing(opts: {
   }))
 
   for (const [i, { result, fallbackContext }] of localeResults.entries()) {
-    const localeCode = targets[i].code
+    const target = targets[i]
+    if (target === undefined) continue
+    const localeCode = target.code
     results[localeCode] = result
     if (fallbackContext) {
       fallbackContexts[localeCode] = fallbackContext
@@ -1002,8 +1006,9 @@ export async function translateKey(opts: {
 
     const validation = validatePlaceholders(opts.key, sourceValue, [{ locale: locale.code, value: targetValue }], config.localeFileFormat)
     placeholderValidations.push(validation)
-    if (!validation.ok) {
-      failed.push({ locale: locale.code, reason: failReasonForIssue(validation.errors[0]) })
+    const firstIssue = validation.errors[0]
+    if (firstIssue !== undefined) {
+      failed.push({ locale: locale.code, reason: failReasonForIssue(firstIssue) })
       continue
     }
 

--- a/packages/cli/src/io/json-reader.ts
+++ b/packages/cli/src/io/json-reader.ts
@@ -33,10 +33,9 @@ export function detectIndentation(content: string): string {
   let usesTabs = false
 
   for (const line of lines) {
-    const match = line.match(/^(\s+)\S/)
-    if (!match) continue
+    const indent = line.match(/^(\s+)\S/)?.[1]
+    if (!indent) continue
 
-    const indent = match[1]
     if (indent.includes('\t')) {
       usesTabs = true
       break

--- a/packages/cli/src/io/key-operations.ts
+++ b/packages/cli/src/io/key-operations.ts
@@ -21,15 +21,16 @@ export function getNestedValue(obj: Record<string, unknown>, path: string): unkn
  */
 export function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split('.')
+  const lastKey = parts.pop()
+  if (lastKey === undefined) return
   let current: Record<string, unknown> = obj
-  for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i]
+  for (const part of parts) {
     if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
       current[part] = {}
     }
     current = current[part] as Record<string, unknown>
   }
-  current[parts[parts.length - 1]] = value
+  current[lastKey] = value
 }
 
 /**
@@ -39,11 +40,12 @@ export function setNestedValue(obj: Record<string, unknown>, path: string, value
  */
 export function removeNestedValue(obj: Record<string, unknown>, path: string): boolean {
   const parts = path.split('.')
+  const lastKey = parts.pop()
+  if (lastKey === undefined) return false
   const parents: Array<{ obj: Record<string, unknown>; key: string }> = []
   let current: Record<string, unknown> = obj
 
-  for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i]
+  for (const part of parts) {
     if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
       return false
     }
@@ -51,15 +53,13 @@ export function removeNestedValue(obj: Record<string, unknown>, path: string): b
     current = current[part] as Record<string, unknown>
   }
 
-  const lastKey = parts[parts.length - 1]
   if (!(lastKey in current)) {
     return false
   }
 
   delete current[lastKey]
 
-  for (let i = parents.length - 1; i >= 0; i--) {
-    const { obj: parentObj, key } = parents[i]
+  for (const { obj: parentObj, key } of [...parents].reverse()) {
     const child = parentObj[key] as Record<string, unknown>
     if (Object.keys(child).length === 0) {
       delete parentObj[key]
@@ -131,7 +131,8 @@ export function orderKeysPreserving(
   for (const key of newKeys) {
     let insertAt = 0
     for (let i = orderedKeys.length - 1; i >= 0; i--) {
-      if (orderedKeys[i] <= key) {
+      const existingKey = orderedKeys[i]
+      if (existingKey !== undefined && existingKey <= key) {
         insertAt = i + 1
         break
       }

--- a/packages/cli/src/io/locale-data.ts
+++ b/packages/cli/src/io/locale-data.ts
@@ -142,8 +142,9 @@ export async function mutateLocaleData(
     if (!localeDir) return filesWritten
 
     const localePath = join(localeDir, locale.code)
-    const fileExt = entries.length > 0
-      ? extname(entries[0].path) // '.php' or '.json'
+    const firstEntry = entries[0]
+    const fileExt = firstEntry
+      ? extname(firstEntry.path) // '.php' or '.json'
       : config.localeFileFormat === 'php-array' ? '.php' : '.json'
 
     const preSnapshots = new Map<string, string>()
@@ -174,8 +175,9 @@ export async function mutateLocaleData(
       return filesWritten
     }
 
-    if (entries.length === 0) return filesWritten
-    const filePath = entries[0].path
+    const firstEntry = entries[0]
+    if (!firstEntry) return filesWritten
+    const filePath = firstEntry.path
     await writeLocaleEntryFile(filePath, data)
     filesWritten.add(filePath)
   }

--- a/packages/cli/src/io/php-writer.ts
+++ b/packages/cli/src/io/php-writer.ts
@@ -161,8 +161,7 @@ export function detectPhpStyle(content: string): { quoteStyle: 'single' | 'doubl
   }
   const quoteStyle: 'single' | 'double' = singleCount > doubleCount ? 'single' : 'double'
 
-  const indentMatch = content.match(/^([ \t]+)['"]/m)
-  const indent = indentMatch ? indentMatch[1] : '    '
+  const indent = content.match(/^([ \t]+)['"]/m)?.[1] ?? '    '
 
   return { quoteStyle, indent }
 }

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -55,14 +55,13 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
 
   const lines = content.split('\n')
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
+  for (const [i, line] of lines.entries()) {
     const lineNumber = i + 1
 
     for (const regex of pat.staticKeyPatterns) {
       regex.lastIndex = 0
       for (const match of line.matchAll(regex)) {
-        const callee = match[1]
+        const callee = match[1] ?? ''
         const key = match[3]
         if (!key) continue
         if (key.includes('{$')) continue
@@ -74,8 +73,9 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
     for (const regex of pat.dynamicKeyPatterns) {
       regex.lastIndex = 0
       for (const match of line.matchAll(regex)) {
-        const callee = match[1]
+        const callee = match[1] ?? ''
         const expression = match[2]
+        if (!expression) continue
         const hasDollarBrace = expression.includes('${')
         const hasBraceDollar = expression.includes('{$')
         const hasBarePHP = !hasDollarBrace && !hasBraceDollar && /\$[a-zA-Z_]/.test(expression)
@@ -93,14 +93,14 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
           : hasBarePHP
             ? expression.replace(/\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*/g, '${_}')
             : expression
-        dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee: match[1] })
+        dynamicKeys.push({ expression: `\`${normalized}\``, file: filePath, line: lineNumber, callee })
       }
     }
 
     for (const regex of pat.concatKeyPatterns) {
       regex.lastIndex = 0
       for (const match of line.matchAll(regex)) {
-        const callee = match[1]
+        const callee = match[1] ?? ''
         const prefix = match[3]
         if (!prefix) continue
         if (pat.requiresDotForCallee?.(callee) && !prefix.includes('.')) continue
@@ -261,13 +261,14 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
 
     BARE_DOTTED_STRING.lastIndex = 0
     for (const match of content.matchAll(BARE_DOTTED_STRING)) {
-      bareStringCandidates.add(match[2])
+      const candidate = match[2]
+      if (candidate) bareStringCandidates.add(candidate)
     }
 
     BARE_DYNAMIC_TEMPLATE.lastIndex = 0
     for (const match of content.matchAll(BARE_DYNAMIC_TEMPLATE)) {
       const expr = match[1]
-      if (!expr.includes('.')) continue
+      if (!expr?.includes('.')) continue
       const normalized = expr.replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '${_}')
       bareDynamicCandidates.add(`\`${normalized}\``)
     }
@@ -275,7 +276,7 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     BARE_PHP_DYNAMIC.lastIndex = 0
     for (const match of content.matchAll(BARE_PHP_DYNAMIC)) {
       const expr = match[1]
-      if (!expr.includes('.')) continue
+      if (!expr?.includes('.')) continue
       const normalized = expr
         .replace(/\{\$[^}]+\}/g, '${_}')
         .replace(/\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*/g, '${_}')
@@ -314,17 +315,18 @@ export function buildIgnorePatternRegexes(patterns: string[]): RegExp[] {
     let regexStr = ''
     let i = 0
     while (i < pattern.length) {
-      if (pattern[i] === '*' && pattern[i + 1] === '*') {
+      const ch = pattern.charAt(i)
+      if (ch === '*' && pattern[i + 1] === '*') {
         regexStr += '.*'
         i += 2
-      } else if (pattern[i] === '*') {
+      } else if (ch === '*') {
         regexStr += '[^.]*'
         i += 1
-      } else if ('.+?^${}()|[]\\'.includes(pattern[i])) {
-        regexStr += '\\' + pattern[i]
+      } else if ('.+?^${}()|[]\\'.includes(ch)) {
+        regexStr += '\\' + ch
         i += 1
       } else {
-        regexStr += pattern[i]
+        regexStr += ch
         i += 1
       }
     }

--- a/packages/cli/src/tools/scaffold-locale.ts
+++ b/packages/cli/src/tools/scaffold-locale.ts
@@ -120,7 +120,7 @@ async function scaffoldJsonLayer(
 
   for (const target of targets) {
     const entries = await resolveLocaleEntries(config, dir.layer, target)
-    const targetPath = entries.length > 0 ? entries[0].path : join(dir.path, target.file ?? `${target.code}.json`)
+    const targetPath = entries[0]?.path ?? join(dir.path, target.file ?? `${target.code}.json`)
 
     if (existsSync(targetPath)) {
       skipped.push({ locale: target.code, layer: dir.layer, file: targetPath, keys: keyCount })

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

Enables `noUncheckedIndexedAccess: true` in `tsconfig.base.json` (shared by both packages) and fixes all resulting type errors. The issue's original count of 67 predates the core/ops-* restructuring — re-measuring on current `main` surfaced **73 errors across 17 CLI source files** (the mcp package needed no changes; its initial errors were all cascades from the unbuilt CLI dist).

## Fix pattern breakdown

| Pattern | Errors | Examples |
|---|---|---|
| Regex match-group narrowing (`?.[1]` + guard, `?? null`/`?? ''` defaults) | ~24 | `code-scanner.ts` callees/expressions, `laravel`, `react`, `vue`, `php-writer`, `json-reader` |
| First-element access via destructuring with guard (`const [x] = arr; if (x === undefined) throw/return`) | ~10 | `react`, `vue`, `nuxt` adapters, `locale-data.ts`, `ops-read.ts` |
| Path-segment handling via `parts.pop()` + guard instead of `parts[parts.length - 1]` | ~20 | `key-operations.ts` (set/remove nested value), `discovery.ts` (layer naming) |
| Index-loop → `for...of` / `.entries()` / `.slice()` iteration | ~12 | `code-scanner.ts` line loop, `ops-duplicates.ts` pair derivation, `ops-translate.ts` |
| Grouped-record init with `??=` (`(rec[k] ??= []).push(...)`) | 4 | `ops-orphans.ts`, `ops-read.ts` |
| Provable-invariant guards (length-checked sibling arrays) | 4 | `ops-translate.ts` plural variants / locale results, `orderKeysPreserving` |
| Non-null assertion with invariant comment | 1 | `generic/index.ts` (localeDirs emptiness guarded at method top) |

No runtime behavior changes: every guard is either a restructured existing check or covers a branch that is unreachable by construction (e.g. mandatory regex capture groups, `String.split` never returning an empty array).

One extraction to keep the complexity gate green: `firstMatchGroup()` helper in `vue/index.ts`, since the added optional chains pushed `tryExtractFromConfig` over the CRAP threshold.

## Validation

- `pnpm --filter the-i18n-cli build` — pass
- `pnpm -r --filter='./packages/*' typecheck` — pass (cli + mcp)
- `pnpm -r test` — 699 cli + 17 mcp tests pass
- `pnpm lint` — 0 errors (3 pre-existing warnings, unchanged from main)
- `npx fallow audit --base origin/main` — exit 0, no new findings

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)