### PR TITLE
fix(cli): deterministic orphan reports and orphanScan layer-key validation

### DIFF
--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -16,6 +16,8 @@ import type { OrphanScanPlan, OrphanScanResult } from '../scanner/code-scanner.j
 import { getPatternSet } from '../scanner/patterns.js'
 import { ToolError } from '../utils/errors.js'
 
+import { log } from '../utils/logger.js'
+
 import { findLayerOrThrow, resolveReferenceLocale } from './shared.js'
 import { validateReportPath, resolveReportFilePath } from './report.js'
 
@@ -92,6 +94,21 @@ export function buildOrphanScanPlan(config: I18nConfig, projectDir: string): Orp
   return { units, scopeByLayer }
 }
 
+/**
+ * Report shape for a dynamic-key entry. Bare candidates are synthesized
+ * without a source location (file: '', line: 0) — relativizing '' would
+ * resolve against the process cwd and make reports cwd-dependent, so
+ * file/line are omitted entirely for them.
+ */
+function toDynamicKeyEntries(
+  dynamicKeys: OrphanScanResult['allDynamicKeys'],
+  projectDir: string,
+): Array<{ expression: string; file?: string; line?: number }> {
+  return dynamicKeys.map(dk => dk.file
+    ? { expression: dk.expression, file: toRelativePath(dk.file, projectDir), line: dk.line }
+    : { expression: dk.expression })
+}
+
 /** Relativize each layer's scan-scope dirs against the project dir for reporting. */
 function relativeScanScope(result: OrphanScanResult, projectDir: string): Record<string, string[]> {
   const scanScope: Record<string, string[]> = {}
@@ -111,6 +128,7 @@ async function runOrphanScan(
   keysByLayer: Map<string, { keys: string[]; localeDir: LocaleDir }>,
   opts: { scanDirs?: string[]; excludeDirs?: string[]; dir: string },
 ): Promise<OrphanScanResult> {
+  warnUnknownOrphanScanLayers(config)
   return findOrphanKeysForConfig({
     keysByLayer,
     // an empty scanDirs array means "not provided" (matches excludeDirs)
@@ -119,6 +137,22 @@ async function runOrphanScan(
     resolveIgnorePatterns: layerName => resolveOrphanIgnorePatterns(config, layerName),
     patterns: getPatternSet(config.localeFileFormat),
   })
+}
+
+/**
+ * `orphanScan` keys are matched against detected layer names — an unknown key
+ * (e.g. keyed "lang" when the adapter names the layer "root") silently drops
+ * its ignorePatterns, so warn on stderr listing the valid names (#265).
+ */
+export function warnUnknownOrphanScanLayers(config: I18nConfig): void {
+  const orphanScan = config.projectConfig?.orphanScan
+  if (!orphanScan) return
+  const layerNames = config.localeDirs.map(d => d.layer)
+  const known = new Set(layerNames)
+  for (const key of Object.keys(orphanScan)) {
+    if (known.has(key)) continue
+    log.warn(`orphanScan config key "${key}" matches no detected layer — its ignorePatterns are not applied. Detected layers: ${layerNames.join(', ')}`)
+  }
 }
 
 export function resolveOrphanIgnorePatterns(
@@ -263,11 +297,7 @@ export async function findOrphanKeys(opts: {
       ? `${orphanResult.allDynamicKeys.length} dynamic key reference(s) found (template literals with interpolation). Some "orphan" keys may actually be used via dynamic keys. Review before removing. Note: string concatenation patterns (e.g. 'prefix.' + var) are not detected — use template literals for full coverage.`
       : undefined,
     dynamicKeys: orphanResult.allDynamicKeys.length > 0
-      ? orphanResult.allDynamicKeys.map(dk => ({
-          expression: dk.expression,
-          file: toRelativePath(dk.file, dir),
-          line: dk.line,
-        }))
+      ? toDynamicKeyEntries(orphanResult.allDynamicKeys, dir)
       : undefined,
     unresolvedKeyWarnings: orphanResult.unresolvedKeyWarnings.length > 0
       ? orphanResult.unresolvedKeyWarnings.map(w => ({
@@ -424,11 +454,7 @@ export async function removeOrphanKeys(opts: {
   const misplacedUsages = misplacedCount > 0 ? orphanResult.misplacedUsages : undefined
   const misplacedUsageNote = misplacedCount > 0 ? MISPLACED_USAGE_NOTE : undefined
   const scanScope = relativeScanScope(orphanResult, dir)
-  const allDynamicKeys = orphanResult.allDynamicKeys.map(dk => ({
-    expression: dk.expression,
-    file: toRelativePath(dk.file, dir),
-    line: dk.line,
-  }))
+  const allDynamicKeys = toDynamicKeyEntries(orphanResult.allDynamicKeys, dir)
 
   if (orphanCount === 0) {
     const messageParts: string[] = ['No orphan keys found.']

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -128,7 +128,6 @@ async function runOrphanScan(
   keysByLayer: Map<string, { keys: string[]; localeDir: LocaleDir }>,
   opts: { scanDirs?: string[]; excludeDirs?: string[]; dir: string },
 ): Promise<OrphanScanResult> {
-  warnUnknownOrphanScanLayers(config)
   return findOrphanKeysForConfig({
     keysByLayer,
     // an empty scanDirs array means "not provided" (matches excludeDirs)
@@ -238,6 +237,7 @@ export async function findOrphanKeys(opts: {
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
+  warnUnknownOrphanScanLayers(config)
 
   const { layersToCheck, keysByLayer, totalKeys, localeCode } = await resolveOrphanScanContext(config, {
     layer,
@@ -421,6 +421,7 @@ export async function removeOrphanKeys(opts: {
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
+  warnUnknownOrphanScanLayers(config)
   const isDryRun = opts.dryRun ?? true
 
   const { keysByLayer, totalKeys } = await resolveOrphanScanContext(config, {

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -186,10 +186,15 @@ function suggestIgnorePattern(expression: string): string | undefined {
 }
 
 function buildUnresolvedWarnings(dynamicKeys: DynamicKeyUsage[]): UnresolvedKeyWarning[] {
+  // Glob order varies between runs; dedupe keeps the first entry per pattern,
+  // so sort first to make the surviving representative the lexicographically
+  // smallest location — report output must be byte-deterministic (CI diffing).
+  const sorted = [...dynamicKeys].sort((a, b) =>
+    a.file.localeCompare(b.file) || a.line - b.line || a.expression.localeCompare(b.expression))
   const seen = new Set<string>()
   const seenPatterns = new Set<string>()
   const warnings: UnresolvedKeyWarning[] = []
-  for (const dk of dynamicKeys) {
+  for (const dk of sorted) {
     if (!dk.file || !dk.line) continue
     const pattern = suggestIgnorePattern(dk.expression)
     if (!pattern) continue

--- a/packages/cli/tests/scanner/orphan-report-determinism.test.ts
+++ b/packages/cli/tests/scanner/orphan-report-determinism.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Byte-determinism of orphan-scan diagnostics (#263): when several files
+ * produce the same suggestedIgnorePattern, the surviving representative in
+ * unresolvedKeyWarnings must not depend on file discovery order — CI artifact
+ * diffing relies on two consecutive runs being byte-identical.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdir, writeFile, rm, mkdtemp } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { findOrphanKeysForConfig } from '../../src/scanner/code-scanner.js'
+
+let baseDir: string
+let dirA: string
+let dirB: string
+
+beforeAll(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'i18n-determinism-'))
+  dirA = join(baseDir, 'unit-a')
+  dirB = join(baseDir, 'unit-b')
+  await mkdir(dirA, { recursive: true })
+  await mkdir(dirB, { recursive: true })
+
+  // Three files whose dynamic expressions all suggest `common.pay.**`.
+  // The lexicographically-latest file is written FIRST so plain creation
+  // order differs from the expected lexicographic representative.
+  await writeFile(join(dirB, 'zz-late.vue'), 'const c = t(`common.pay.${mode}.title`)\n')
+  await writeFile(join(dirA, 'zz-intra.vue'), 'const b = t(`common.pay.${type}.title`)\n')
+  await writeFile(join(dirA, 'aa-early.vue'), '\n\nconst a = t(`common.pay.${kind}.title`)\n')
+})
+
+afterAll(async () => {
+  await rm(baseDir, { recursive: true, force: true })
+})
+
+const run = (scanDirs: string[]) => findOrphanKeysForConfig({
+  keysByLayer: new Map([
+    ['root', { keys: ['common.pay.card.title', 'some.orphan'], localeDir: { layer: 'root' } }],
+  ]),
+  scanDirs,
+  resolveIgnorePatterns: () => undefined,
+})
+
+describe('unresolvedKeyWarnings determinism (#263)', () => {
+  it('two consecutive runs produce byte-identical results', async () => {
+    const first = await run([dirA, dirB])
+    const second = await run([dirA, dirB])
+
+    expect(second).toEqual(first)
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+  })
+
+  it('representative location survives scan-order perturbation and is the lexicographically smallest', async () => {
+    // Reversing the unit order reverses raw dynamic-key accumulation order —
+    // the pre-sort dedupe would have picked a different representative.
+    const forward = await run([dirA, dirB])
+    const reversed = await run([dirB, dirA])
+
+    expect(reversed.unresolvedKeyWarnings).toEqual(forward.unresolvedKeyWarnings)
+    expect(reversed.allDynamicKeys).toEqual(forward.allDynamicKeys)
+
+    expect(forward.unresolvedKeyWarnings).toHaveLength(1)
+    const warning = forward.unresolvedKeyWarnings[0]!
+    expect(warning.suggestedIgnorePattern).toBe('common.pay.**')
+    expect(warning.file).toBe(join(dirA, 'aa-early.vue'))
+    expect(warning.line).toBe(3)
+  })
+})

--- a/packages/cli/tests/tools/orphan-report-shape.test.ts
+++ b/packages/cli/tests/tools/orphan-report-shape.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Orphan report shape and config validation (#263, #265):
+ * - dynamicKeys entries synthesized from bare candidates carry NO file/line
+ *   (relativizing their empty file path would embed the process cwd);
+ * - unknown `orphanScan` layer keys warn on stderr instead of silently
+ *   no-op'ing, while valid keys keep applying their ignorePatterns.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdir, writeFile, rm, mkdtemp } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { log } from '../../src/utils/logger.js'
+import type { I18nConfig } from '../../src/config/types.js'
+
+const holder = vi.hoisted(() => ({ config: undefined as unknown }))
+vi.mock('../../src/config/detector.js', async importOriginal =>
+  (await import('../fixtures/holder-detector.js')).holderDetectorMock(holder, importOriginal))
+
+const { findOrphanKeys } = await import('../../src/core/operations.js')
+
+let projectDir: string
+
+beforeAll(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'i18n-report-shape-'))
+
+  await mkdir(join(projectDir, 'pages'), { recursive: true })
+  await writeFile(join(projectDir, 'pages/index.vue'), [
+    `{{ $t('home.title') }}`,
+    'const label = t(`dyn.stuff.${x}`)',
+    // Bare dynamic template outside any i18n call — collected as a bare
+    // candidate with no source location.
+    'const p = `bare.path.${id}`',
+  ].join('\n'))
+
+  await mkdir(join(projectDir, 'i18n/locales'), { recursive: true })
+  await writeFile(join(projectDir, 'i18n/locales/de-DE.json'), JSON.stringify({
+    home: { title: 'a' },
+    legal: { terms: 'b' },
+    validation: { custom: 'c' },
+  }))
+
+  const config: I18nConfig = {
+    rootDir: projectDir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['en'] },
+    locales: [{ code: 'de', language: 'de-DE', file: 'de-DE.json' }],
+    localeDirs: [
+      { path: join(projectDir, 'i18n/locales'), layer: 'root', layerRootDir: projectDir },
+    ],
+    layerRootDirs: [projectDir],
+    apps: [{ name: 'root', rootDir: projectDir, layers: ['root'] }],
+    projectConfig: {
+      orphanScan: {
+        // Unknown layer name (#265) — the adapter names the layer "root".
+        lang: { ignorePatterns: ['validation.**'] },
+        root: { ignorePatterns: ['legal.**'] },
+      },
+    },
+  }
+  holder.config = config
+})
+
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true })
+})
+
+describe('dynamicKeys report shape (#263)', () => {
+  it('bare-candidate entries omit file/line; located entries stay relative', async () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    try {
+      const result = await findOrphanKeys({ projectDir })
+      const dynamicKeys = result.dynamicKeys as Array<Record<string, unknown>>
+
+      const bare = dynamicKeys.find(dk => dk.expression === '`bare.path.${_}`')
+      expect(bare).toBeDefined()
+      expect(bare).not.toHaveProperty('file')
+      expect(bare).not.toHaveProperty('line')
+
+      const located = dynamicKeys.find(dk => dk.expression === '`dyn.stuff.${x}`')
+      expect(located?.file).toBe(join('pages', 'index.vue'))
+      expect(located?.line).toBe(2)
+
+      // No cwd-dependent paths anywhere in the report.
+      for (const dk of dynamicKeys) {
+        expect(String(dk.file ?? '')).not.toContain('..')
+      }
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})
+
+describe('orphanScan layer-key validation (#265)', () => {
+  it('warns for unknown layer keys and still applies valid ones', async () => {
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {})
+    try {
+      const result = await findOrphanKeys({ projectDir })
+      const messages = warnSpy.mock.calls.map(args => args.join(' '))
+
+      const unknownWarning = messages.find(m => m.includes('"lang"'))
+      expect(unknownWarning).toBeDefined()
+      expect(unknownWarning).toContain('Detected layers: root')
+      // The known key must not be warned about.
+      expect(messages.some(m => m.includes('orphanScan config key "root"'))).toBe(false)
+
+      // Valid key applied: legal.** ignored. Unknown key no-op'd (no magic
+      // single-layer aliasing): validation.custom stays an orphan.
+      const summary = result.summary as Record<string, unknown>
+      expect(summary.ignoredCount).toBe(1)
+      expect((result.orphanKeys as Record<string, string[]>).root).toEqual(['validation.custom'])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
Fixes two report-generation defects (#263) and a silent config no-op (#265) in the orphan-scan tools.

## #263 — byte-determinism and cwd-dependent `file` fields

**1. Non-deterministic `unresolvedKeyWarnings` representative.** `buildUnresolvedWarnings` dedupes by `suggestedIgnorePattern` keeping the first-seen entry, and ran on raw glob-accumulation order — *before* the stabilizing `byLocation` sort. When several files produce the same pattern, the surviving representative flipped between runs. Fix (`packages/cli/src/scanner/code-scanner.ts`): sort candidates by `(file, line, expression)` before the dedupe, so the representative is always the lexicographically smallest location. The later output sort is unchanged.

**2. Bogus `file` on bare-dynamic entries.** Bare candidates are synthesized with `file: ''`; `toRelativePath('', dir)` resolved `''` against the process cwd, producing `file: "../../Users/...", line: 0` entries (3,427 of 3,628 dynamicKeys on anny-ui) and making reports cwd-dependent. Fix (`packages/cli/src/core/ops-orphans.ts`): a shared `toDynamicKeyEntries` mapper **omits `file`/`line` entirely** for entries without a source location (omission chosen over a sentinel — the report output type is structural, so no schema change was needed).

## #265 — unknown `orphanScan` layer keys silently no-op

`orphanScan` project-config keys are matched against detected layer names; a mismatched key (bookings-api keyed `"lang"`, the Laravel adapter names the layer `"root"`) silently dropped its `ignorePatterns`. Fix: `warnUnknownOrphanScanLayers` runs once per orphan scan and warns **on stderr** (stdout stays pure JSON) for each `orphanScan` key that matches no detected layer, listing the valid layer names:

```
[warn] [the-i18n-cli] orphanScan config key "lang" matches no detected layer — its ignorePatterns are not applied. Detected layers: root
```

**Decision — no single-layer aliasing magic.** Considered treating any single `orphanScan` entry as applying to a single-layer project's sole layer, and decided against it: implicit remapping would make behavior depend on layer count (adding a second layer would silently change semantics), and the warning already tells the user exactly what to rename the key to. Predictable > convenient.

## Verification against anny-ui (read-only)

`node packages/cli/dist/bin.js remove-orphans --json -d ~/code/anny/anny-ui`, run twice and diffed:

- Two consecutive runs: **byte-identical** (3,353,119 bytes each, `diff` clean).
- A third run from a different cwd (`/tmp`): **also byte-identical** to the first — reports are now cwd-independent.
- `jq`: **0** dynamicKeys entries contain `..` paths; 3,427 bare-candidate entries carry no `file`/`line`; counts unchanged (totalKeys 8596, orphanCount 1514, uncertainCount 31, ignoredCount 86, dynamicMatchedCount 560).

## Tests

- `packages/cli/tests/scanner/orphan-report-determinism.test.ts` — double-run byte-identity (`JSON.stringify` equality) over a fixture with three files sharing one dynamic pattern, plus a real order-perturbation test: reversing the `scanDirs` unit order reverses raw accumulation order, and the warnings must still be deep-equal with the lexicographically-smallest file/line as representative (fails on pre-fix code).
- `packages/cli/tests/tools/orphan-report-shape.test.ts` — bare-candidate `dynamicKeys` entries carry no `file`/`line` while located entries keep relative `file` + `line`, and no `..` appears anywhere; #265 warning fires for the unknown `"lang"` key (naming the valid layers), does not fire for the valid `"root"` key, and `"root"`'s `ignorePatterns` still apply (`ignoredCount: 1`, no-op'd key's target stays an orphan).

## Validation

- `pnpm --filter the-i18n-cli build` ✓
- `pnpm -r test` ✓ (727 passed: 703 cli + 24 mcp)
- `pnpm -r --filter='./packages/*' typecheck` ✓
- `pnpm lint` ✓ (0 errors; 3 pre-existing warnings in untouched files)
- `npx fallow audit --base origin/main` ✓ exit 0

Closes #263
Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan-scan reports for dynamic translation keys by showing file and line details only when available.
  * Made orphan diagnostics consistent across repeated scans and directory order changes.
  * Added warnings for unrecognized orphan-scan layer names while continuing to process valid settings.
  * Preserved ignore-pattern behavior and accurate reporting of unignored orphan keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->