### PR TITLE
fix(cli): never classify indirectly-consumed or Laravel-idiom keys as hard findings

### DIFF
--- a/packages/cli/src/core/ops-check.ts
+++ b/packages/cli/src/core/ops-check.ts
@@ -78,6 +78,15 @@ const UNCERTAIN_DYNAMIC_OVERLAP
   = 'matches a dynamic key pattern used in this app — may be a partial extraction of that expression'
 const UNCERTAIN_EXISTENCE_CHECK
   = 'referenced only via existence checks ($te) — likely a deliberately optional key'
+const UNCERTAIN_NAMESPACED_KEY
+  = 'package-namespaced key (namespace::group.key) — vendor language files outside the project cannot be resolved'
+const UNCERTAIN_STRING_KEY
+  = 'string-key (no dot-separated key-path shape) — Laravel/JSON-style translations render these as-is when unresolved'
+
+/** Dot-separated identifier path; anything else is a JSON-style string-key. */
+const KEY_PATH_SHAPE = /^[\w-]+(?:\.[\w-]+)+$/
+/** Laravel package-namespace syntax: accounting::messages.invoice.total */
+const NAMESPACED_KEY = /^[\w-]+::/
 
 /** Existence-check callees probe whether a key is defined; a miss is handled by the caller. */
 function isExistenceCheckCallee(callee: string): boolean {
@@ -220,6 +229,17 @@ function classifyStaticKeys(
     }
     if (keyUsages.every(u => isExistenceCheckCallee(u.callee))) {
       pushUncertain(outcome, ctx, key, keyUsages, UNCERTAIN_EXISTENCE_CHECK)
+      continue
+    }
+    // Two Laravel idioms are never hard findings: namespaced keys resolve in
+    // vendor lang dirs this scan cannot see, and string-keys (JSON-style
+    // full-sentence translations) legitimately render as-is when undefined.
+    if (NAMESPACED_KEY.test(key)) {
+      pushUncertain(outcome, ctx, key, keyUsages, UNCERTAIN_NAMESPACED_KEY)
+      continue
+    }
+    if (!KEY_PATH_SHAPE.test(key)) {
+      pushUncertain(outcome, ctx, key, keyUsages, UNCERTAIN_STRING_KEY)
       continue
     }
     outcome.undefinedKeys.push({

--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -235,15 +235,25 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
   const BARE_DYNAMIC_TEMPLATE = /`([^`\\\n]{0,200}\$\{[^`\\\n]{0,200})`/g
-  /** Matches PHP double-quoted strings containing $var or {$var} interpolation with at least one dot */
-  const BARE_PHP_DYNAMIC = /"((?:[^"\\]|\\.)*(?:\{\$|\$[a-zA-Z_])(?:[^"\\]|\\.)*)"/g
   /**
-   * Matches string concat prefixes ending with a dot: 'some.key.' + var —
-   * including single-segment prefixes like 'menu.' + var.
-   * Catches multiline t() calls where the prefix is on a separate line from t(.
-   * Group 2: the prefix without trailing dot.
+   * Matches PHP double-quoted interpolated strings with i18n-key shape,
+   * regardless of call context — `$transKey = "api.x.{$key}"` assigned first
+   * and passed to Lang::get() later must still suppress api.x.* orphans.
+   * Content is restricted to key-like chars plus {$expr} / $var->prop
+   * interpolations: a permissive "any double-quoted string containing $"
+   * match swallows the code BETWEEN quoted strings (PHP code is full of $),
+   * shifting quote parity past the real candidates.
    */
-  const BARE_CONCAT_PREFIX = /['"](([\w-]+(?:\.[\w-]+)*)\.)['"]\s*\+/g
+  const BARE_PHP_DYNAMIC = /"((?:[\w.-]|\{\$[^}]+\}|\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*)+)"/g
+  /**
+   * Matches prefix-shaped string literals (≥1 key-like segment, trailing dot,
+   * closing quote right after the dot) regardless of call context: concat
+   * prefixes ('menu.' + var, __('a.b.' . $x) — incl. multiline t() calls where
+   * the prefix sits on its own line) and prefixes passed as plain arguments
+   * (->translationPrefix('api.invoices.status.')) concatenated in a helper.
+   * Group 2: the prefix including the trailing dot.
+   */
+  const BARE_PREFIX_LITERAL = /(['"])((?:[\w-]+\.)+)\1/g
 
   for (const relPath of relativePaths) {
     const filePath = join(rootDir, relPath)
@@ -276,16 +286,20 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     BARE_PHP_DYNAMIC.lastIndex = 0
     for (const match of content.matchAll(BARE_PHP_DYNAMIC)) {
       const expr = match[1]
-      if (!expr?.includes('.')) continue
+      // The $-check keeps plain dotted strings out (BARE_DOTTED_STRING's job);
+      // the dot must survive interpolation stripping so `{$a}$b` (no literal
+      // key segment) does not become an everything-matches candidate.
+      if (!expr?.includes('$')) continue
       const normalized = expr
         .replace(/\{\$[^}]+\}/g, '${_}')
         .replace(/\$[a-zA-Z_][a-zA-Z0-9_]*(?:->[a-zA-Z_][a-zA-Z0-9_]*)*/g, '${_}')
+      if (!normalized.replace(/\$\{_\}/g, '').includes('.')) continue
       bareDynamicCandidates.add(`\`${normalized}\``)
     }
 
-    BARE_CONCAT_PREFIX.lastIndex = 0
-    for (const match of content.matchAll(BARE_CONCAT_PREFIX)) {
-      bareDynamicCandidates.add(`\`${match[2]}.\${_}\``)
+    BARE_PREFIX_LITERAL.lastIndex = 0
+    for (const match of content.matchAll(BARE_PREFIX_LITERAL)) {
+      bareDynamicCandidates.add(`\`${match[2]}\${_}\``)
     }
 
     filesScanned++

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -641,6 +641,19 @@ describe('scanSourceFiles', () => {
     expect(result.bareDynamicCandidates.size).toBe(1)
     expect(result.bareDynamicCandidates.has('`prefix.${_}.suffix`')).toBe(true)
   })
+
+  // #262 — prefix-shaped literals count as dynamic candidates in any context,
+  // not only directly left of a concat operator.
+  it('collects prefix-shaped string literals passed as plain arguments', async () => {
+    await writeFile(join(tmpDir, 'columns.ts'), [
+      `columns.push(translatedColumn('status', 'api.orders.status.'))`,
+    ].join('\n'))
+
+    const result = await scanSourceFiles(tmpDir)
+    expect(result.bareDynamicCandidates.has('`api.orders.status.${_}`')).toBe(true)
+    const regexes = buildDynamicKeyRegexes([...result.bareDynamicCandidates].map(e => ({ expression: e })))
+    expect(regexes.some(re => re.test('api.orders.status.open'))).toBe(true)
+  })
 })
 
 describe('toRelativePath', () => {

--- a/packages/cli/tests/scanner/laravel-patterns.test.ts
+++ b/packages/cli/tests/scanner/laravel-patterns.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles } from '../../src/scanner/code-scanner.js'
+import { buildDynamicKeyRegexes, extractKeys, findOrphanKeysForConfig, scanSourceFiles } from '../../src/scanner/code-scanner.js'
 import { LARAVEL_PATTERNS, getPatternSet } from '../../src/scanner/patterns.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/laravel-scanner')
@@ -341,5 +341,79 @@ describe('Laravel scanSourceFiles', () => {
     expect(result.filesScanned).toBe(2)
     expect(result.usages).toHaveLength(2)
     expect(result.uniqueKeys.size).toBe(1)
+  })
+
+  // #262 — keys constructed away from the translation call must still become
+  // bare dynamic candidates, or a remove-orphans run deletes live keys.
+  describe('indirectly-constructed key candidates (#262)', () => {
+    it('collects variable-assigned interpolated strings amid $-heavy PHP code', async () => {
+      // Mimics bookings-api FormatsBookingChanges.php: the interpolated key is
+      // assigned to a variable first; surrounding code is full of $vars and
+      // other double-quoted strings that must not shift quote parity past it.
+      await writeFile(join(tmpDir, 'FormatsBookingChanges.php'), [
+        '<?php',
+        'foreach ($changedAttributes as $key => $value) {',
+        '    $original = isset($originalAttributes[$key]) ? $originalAttributes[$key] : null;',
+        '    $transKey = "api.bookings.attributes.{$key}";',
+        '    $translatedAttribute = Lang::has($transKey) ? Lang::get($transKey) : $key;',
+        '    $list .= "<li>" . $translatedAttribute . "</li>";',
+        '}',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+      expect(result.bareDynamicCandidates.has('`api.bookings.attributes.${_}`')).toBe(true)
+      const regexes = buildDynamicKeyRegexes([...result.bareDynamicCandidates].map(e => ({ expression: e })))
+      expect(regexes.some(re => re.test('api.bookings.attributes.start_date'))).toBe(true)
+    })
+
+    it('collects prefix-shaped string literals passed as plain arguments', async () => {
+      // Mimics bookings-api OrdersExport.php: the prefix is a builder argument,
+      // concatenated inside a helper (__("{$this->translationPrefix}$value")).
+      await writeFile(join(tmpDir, 'OrdersExport.php'), [
+        '<?php',
+        "TranslatedColumn::make('status', __('exports.orders.status'), 'status')",
+        "    ->translationPrefix('api.orders.status.'),",
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+      expect(result.bareDynamicCandidates.has('`api.orders.status.${_}`')).toBe(true)
+    })
+
+    it('does not build candidates from interpolation-only or dotless strings', async () => {
+      await writeFile(join(tmpDir, 'Helper.php'), [
+        '<?php',
+        'return $value ? __("{$this->translationPrefix}$value") : $this->defaultValue;',
+        '$greeting = "hello_$name";',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+      expect(result.bareDynamicCandidates.size).toBe(0)
+    })
+
+    it('ground truth: indirectly-consumed keys are never safe orphans', async () => {
+      await writeFile(join(tmpDir, 'FormatsBookingChanges.php'), [
+        '<?php',
+        '$transKey = "api.bookings.attributes.{$key}";',
+        '$label = Lang::has($transKey) ? Lang::get($transKey) : $key;',
+      ].join('\n'))
+      await writeFile(join(tmpDir, 'InvoiceItemsExport.php'), [
+        '<?php',
+        "TranslatedColumn::make('invoice.status', __('exports.invoices.status'), 'document.status')",
+        "    ->translationPrefix('api.invoices.status.'),",
+      ].join('\n'))
+
+      const result = await findOrphanKeysForConfig({
+        keysByLayer: new Map([['root', {
+          keys: ['api.bookings.attributes.start_date', 'api.invoices.status.paid', 'api.truly.unused'],
+          localeDir: { layer: 'root' },
+        }]]),
+        resolveIgnorePatterns: () => undefined,
+        patterns: LARAVEL_PATTERNS,
+        scanDirs: [tmpDir],
+      })
+
+      expect(result.orphansByLayer.root ?? []).toEqual(['api.truly.unused'])
+      expect(result.dynamicMatchedCount).toBe(2)
+    })
   })
 })

--- a/packages/cli/tests/tools/check-undefined.test.ts
+++ b/packages/cli/tests/tools/check-undefined.test.ts
@@ -77,6 +77,28 @@ async function runCheck(): Promise<CheckUndefinedKeysResult> {
   return result
 }
 
+/**
+ * Run one check against a throwaway multi-app project built from `files`,
+ * restoring the shared holder config afterwards (tests in this file share it).
+ */
+async function checkTempProject(prefix: string, files: Record<string, string>): Promise<CheckUndefinedKeysResult> {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  try {
+    for (const [rel, content] of Object.entries(files)) {
+      const path = join(dir, rel)
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, content)
+    }
+    holder.config = createTempMultiAppConfig(dir)
+    const result = await checkUndefinedKeys({ projectDir: dir })
+    if ('reportFile' in result) throw new Error('Expected inline result')
+    return result
+  } finally {
+    holder.config = config
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
 describe('checkUndefinedKeys — scope-aware', () => {
   it('keys defined in a consumed layer (own, shared, or parent node) are clean', async () => {
     const result = await runCheck()
@@ -193,41 +215,61 @@ describe('checkUndefinedKeys — scope-aware', () => {
 
   it('multiline single-segment concat: the bare fallback downgrades matching static keys', async () => {
     // `t(` and the 'menu.' + suffix prefix on separate lines: only the
-    // BARE_CONCAT_PREFIX fallback sees this usage. Its `menu.${_}` candidate
+    // BARE_PREFIX_LITERAL fallback sees this usage. Its `menu.${_}` candidate
     // must downgrade the statically used, nowhere-defined menu.ghost from a
     // hard undefined finding to uncertain.
-    const dir = await mkdtemp(join(tmpdir(), 'i18n-check-concat-'))
-    try {
-      const write = async (rel: string, content: string): Promise<void> => {
-        const path = join(dir, rel)
-        await mkdir(dirname(path), { recursive: true })
-        await writeFile(path, content)
-      }
-      await write('i18n/locales/de-DE.json', JSON.stringify({ root: { used: 'a' } }))
-      await write('app-admin/i18n/locales/de-DE.json', '{}')
-      await write('app-shop/i18n/locales/de-DE.json', '{}')
-      await write('components/Menu.vue', [
+    const result = await checkTempProject('i18n-check-concat-', {
+      'i18n/locales/de-DE.json': JSON.stringify({ root: { used: 'a' } }),
+      'app-admin/i18n/locales/de-DE.json': '{}',
+      'app-shop/i18n/locales/de-DE.json': '{}',
+      'components/Menu.vue': [
         'const menuLabel = t(',
         `  'menu.' + suffix,`,
         ')',
         `{{ $t('menu.ghost') }}`,
-      ].join('\n'))
-      holder.config = createTempMultiAppConfig(dir)
+      ].join('\n'),
+    })
 
-      const result = await checkUndefinedKeys({ projectDir: dir })
-      if ('reportFile' in result) throw new Error('Expected inline result')
+    expect(result.undefinedKeys).toEqual([])
+    expect(result.uncertainKeys).toContainEqual(
+      expect.objectContaining({
+        key: 'menu.ghost',
+        reason: expect.stringContaining('dynamic key pattern'),
+      }),
+    )
+  })
 
-      expect(result.undefinedKeys).toEqual([])
+  it('string-keys and package-namespaced keys are uncertain, never hard findings (#267)', async () => {
+    // Mimics the bookings-api Laravel idioms: full-sentence JSON-style keys
+    // (Nova labels, `__('Server Error')`) render as-is when unresolved, and
+    // `namespace::group.key` resolves in vendor lang dirs this scan cannot
+    // see. Both must land in uncertainKeys with distinct reasons.
+    const result = await checkTempProject('i18n-check-stringkey-', {
+      'i18n/locales/de-DE.json': JSON.stringify({ root: { used: 'a' } }),
+      'app-admin/i18n/locales/de-DE.json': '{}',
+      'app-shop/i18n/locales/de-DE.json': '{}',
+      'components/Nova.vue': [
+        `{{ $t('Server Error') }}`,
+        `{{ $t('30 Days') }}`,
+        `{{ $t('Logout') }}`,
+        `{{ $t('accounting::messages.invoice.table.total') }}`,
+        `{{ $t('admin.truly.missing') }}`,
+      ].join('\n'),
+    })
+
+    // Only the well-shaped, nowhere-defined key stays a hard finding.
+    expect(result.undefinedKeys.map(f => f.key)).toEqual(['admin.truly.missing'])
+    for (const key of ['Server Error', '30 Days', 'Logout']) {
       expect(result.uncertainKeys).toContainEqual(
-        expect.objectContaining({
-          key: 'menu.ghost',
-          reason: expect.stringContaining('dynamic key pattern'),
-        }),
+        expect.objectContaining({ key, reason: expect.stringContaining('string-key') }),
       )
-    } finally {
-      holder.config = config
-      await rm(dir, { recursive: true, force: true })
     }
+    expect(result.uncertainKeys).toContainEqual(
+      expect.objectContaining({
+        key: 'accounting::messages.invoice.table.total',
+        reason: expect.stringContaining('package-namespaced'),
+      }),
+    )
   })
 
   it('honors outputFile: writes the full report and returns only the summary', async () => {


### PR DESCRIPTION
Fixes two battle-test findings against bookings-api (Laravel).

## #262 — orphan scanner: indirectly-constructed keys were SAFE orphans (data-loss risk)

Two root causes in `scanSourceFiles` (`packages/cli/src/scanner/code-scanner.ts`):

1. **`BARE_PHP_DYNAMIC` quote-parity poisoning.** The old regex matched *any* double-quoted string containing `$`. PHP code between string literals is full of `$vars`, so the regex matched the spans BETWEEN quoted strings (e.g. `"; $translatedAttribute = Lang::has($transKey) ? Lang::get($trans"`), consuming the opening quotes of the real candidates. `$transKey = "api.bookings.attributes.{$key}"` was never collected. The regex now only matches strings with i18n-key shape (key-like chars + `{$expr}` / `$var->prop` interpolations), and the dot must survive interpolation stripping.
2. **No collector for prefix-shaped literals outside concat.** `->translationPrefix('api.invoices.status.')` (concatenated later inside a helper via `__("{$this->translationPrefix}$value")`) was invisible — `BARE_CONCAT_PREFIX` required a trailing `+`. It is generalized to `BARE_PREFIX_LITERAL`: any string literal of ≥1 `[\w-]+` segment with a trailing dot, in any call context (strictly subsumes the old concat case, JS and PHP alike; the JS bare-template case was already covered by `BARE_DYNAMIC_TEMPLATE`).

Both mechanisms only *downgrade* orphans to dynamic-matched/uncertain — they never delete, so over-matching costs report precision, not correctness.

## #267 — check: Laravel string-keys and namespaced keys were hard undefined findings

In `classifyStaticKeys` (`packages/cli/src/core/ops-check.ts`), two new uncertain classifications, checked after all existing downgrades so only previously-hard-undefined keys change bucket:

- `namespace::group.key` → uncertain, reason "package-namespaced key (namespace::group.key) — vendor language files outside the project cannot be resolved"
- keys without dot-separated key-path shape (`__('Server Error')`, `'30 Days'`, `'Logout'`) → uncertain, reason "string-key (no dot-separated key-path shape) — Laravel/JSON-style translations render these as-is when unresolved"

Orphan side checked: neither shape can appear in project locale keys nor produce bare-string candidates (`::` breaks the `BARE_DOTTED_STRING` shape), so no noise there.

## Real-repo verification (bookings-api, read-only dry runs)

`remove-orphans --json`:
| | before | after |
|---|---|---|
| safe orphans | 111 | **82** |
| dynamic-matched | 892 | **921** |
| uncertain | 270 | 270 |

All 22 affected keys (`api.bookings.attributes.*`, `api.invoices.status.*`, `api.orders.status.*`, plus `api.bookings.status.*` from the same idiom) are gone from `orphanKeys` — zero matches for the affected families in the safe list.

`check --json`:
| | before | after |
|---|---|---|
| hard undefined | 59 | **4** |
| uncertain | 44 | **99** |

The 4 remaining hard findings are the genuine dotted keys; 42 string-keys and 13 `accounting::*` keys moved to uncertain with the new distinct reasons. No genuine finding was lost (before: 59 = 42 string + 13 namespaced + 4 genuine).

## Tests

- `tests/scanner/laravel-patterns.test.ts`: variable-assigned interpolation amid $-heavy PHP code (mimics `FormatsBookingChanges.php`), prefix literal as builder argument (mimics `OrdersExport.php`), negative case (interpolation-only / dotless strings produce no candidates), and a ground-truth `findOrphanKeysForConfig` fixture asserting the affected keys are dynamic-matched and only the truly-unused key remains a safe orphan.
- `tests/scanner/code-scanner.test.ts`: JS prefix literal passed as plain argument.
- `tests/tools/check-undefined.test.ts`: bookings-api-idiom fixture — string-keys and namespaced keys land in uncertainKeys with distinct reasons, the well-shaped nowhere-defined key stays a hard finding (shared temp-project helper extracted to keep fallow's duplication gate clean).

Validation: cli build ✓, `pnpm -r test` 705+24 pass ✓, typecheck ✓, lint 0 errors ✓, `npx fallow audit --base origin/main` exit 0, no issues in changed files ✓.

Closes #262
Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)