### PR TITLE
feat(cli): GitLab Code Quality output for check and remove-orphans

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Outputs: `translated_count`, `failed_count`, `pr_url`.
 
 ### GitLab CI
 
-Two reusable jobs: `.i18n-translate` and `.i18n-cleanup`.
+Three reusable jobs: `.i18n-translate`, `.i18n-cleanup`, and `.i18n-check`.
 
 ```yaml
 # .gitlab-ci.yml
@@ -238,11 +238,19 @@ i18n-cleanup:
       changes:
         - components/**/*.vue
         - i18n/locales/*.json
+    # Default-branch baseline — required for the MR Code Quality widget
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+i18n-check:
+  extends: .i18n-check
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
-Translations are pushed to the MR branch. Orphan findings are posted as an MR comment with expandable details (requires `I18N_PUSH_TOKEN`). Artifacts (`.i18n-reports/`) are retained for 7 days. The translate job fails when every key failed to translate.
+Translations are pushed to the MR branch. Orphan and undefined-key findings are emitted as a `gl-codequality.json` Code Quality artifact and surface in the MR's Code Quality widget. The widget diffs the MR report against the latest default-branch report — without a default-branch rule (no `changes:` filter) the widget stays blank. Artifacts (`.i18n-reports/`, `gl-codequality.json`) are retained for 7 days. The translate job fails when every key failed to translate; `.i18n-check` fails on findings but has `allow_failure: true` by default (remove it to make it a gate).
 
-Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *"Allow Git push requests to the repository"* (job token) or a project access token with `write_repository` + `api` scope in `I18N_PUSH_TOKEN`. MR comments always require `I18N_PUSH_TOKEN`.
+Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *"Allow Git push requests to the repository"* (job token) or a project access token with `write_repository` scope in `I18N_PUSH_TOKEN`.
 
 **`.i18n-translate` variables:**
 
@@ -259,10 +267,9 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 | `I18N_DRY_RUN` | — | `false` | Preview without writing |
 | `I18N_CLI_VERSION` | — | `latest` | Pin the-i18n-cli (npm version or dist-tag) |
 | `I18N_INSTALL_PEER_DEPS` | — | — | Extra npm packages installed alongside the CLI |
-| `I18N_PUSH_TOKEN` | — | — | Project access token (`write_repository` + `api`) for push + MR comments |
+| `I18N_PUSH_TOKEN` | — | — | Project access token (`write_repository`) — push alternative to the job token |
 | `I18N_LOCALE_PATHS` | — | `i18n/locales/` | Space-separated globs for locale directories |
 | `I18N_COMMIT_MESSAGE` | — | auto-generated | Custom commit message |
-| `I18N_MR_COMMENT` | — | `true` | Post summary comment on MR (requires `I18N_PUSH_TOKEN`) |
 
 **`.i18n-cleanup` variables:**
 
@@ -271,7 +278,13 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 | `I18N_LAYER` | ✅ | — | Layer name |
 | `I18N_CLI_VERSION` | — | `latest` | Pin the-i18n-cli (npm version or dist-tag) |
 | `I18N_INSTALL_PEER_DEPS` | — | — | Extra npm packages installed alongside the CLI |
-| `I18N_PUSH_TOKEN` | — | — | Project access token (`api` scope) for MR comments |
+
+**`.i18n-check` variables:**
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `I18N_CLI_VERSION` | — | `latest` | Pin the-i18n-cli (npm version or dist-tag) |
+| `I18N_INSTALL_PEER_DEPS` | — | — | Extra npm packages installed alongside the CLI |
 
 > **Enterprise setups** (private registries, yarn, custom images): override `before_script` on the extending job. The template's `image`, `before_script`, `tags`, and `cache` are all overridable.
 

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -1,8 +1,10 @@
 # the-i18n-kit — GitLab CI template
 #
-# Provides two reusable jobs:
+# Provides three reusable jobs:
 #   .i18n-translate  – find missing keys and auto-translate via LLM
-#   .i18n-cleanup    – find orphan keys and report findings on the MR
+#   .i18n-cleanup    – find orphan keys, report them as a Code Quality artifact
+#   .i18n-check      – find used-but-undefined keys (render as raw keys),
+#                      report them as a Code Quality artifact
 #
 # Usage in your .gitlab-ci.yml:
 #
@@ -30,17 +32,43 @@
 #         changes:
 #           - components/**/*.vue
 #           - i18n/locales/*.json
+#       # Default-branch baseline — REQUIRED for the MR widget, see below.
+#       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 #
-# Pushing translations back to the branch requires ONE of:
+#   i18n-check:
+#     extends: .i18n-check
+#     rules:
+#       - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+#       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+#
+# ── Code Quality widget (MR findings) ────────────────────────────────────────
+# .i18n-cleanup and .i18n-check emit `gl-codequality.json` declared as
+# artifacts:reports:codequality. GitLab's MR widget shows the DIFF between the
+# MR pipeline's report and the report of the latest default-branch pipeline.
+# WITHOUT A DEFAULT-BRANCH BASELINE THE WIDGET STAYS BLANK — by design:
+# there is nothing to diff against. So every job you adopt needs a rule that
+# also runs it on the default branch, WITHOUT a `changes:` filter (a filtered
+# rule would skip the baseline whenever the MR that just merged didn't touch
+# those paths, leaving the widget blank for the next MRs):
+#
+#   rules:
+#     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+#
+# Artifact expiry: the widget reads the newest default-branch report; when it
+# has expired (expire_in below is 7 days), the widget is blank again until the
+# next default-branch pipeline refreshes the baseline. Raise expire_in on the
+# extending job if your default branch is quieter than that.
+#
+# ── Pushing translations back to the branch ──────────────────────────────────
+# Requires ONE of:
 #   a) Project setting: Settings → CI/CD → Job token permissions →
 #      "Allow Git push requests to the repository" (GitLab ≥ 17.2).
 #      Then the default CI_JOB_TOKEN push just works.
-#   b) A project access token with `write_repository` + `api` scope in the
-#      I18N_PUSH_TOKEN CI variable (also used to post MR comments).
-# MR comments always require I18N_PUSH_TOKEN (a job token cannot call the
-# notes API) — without it, comment posting is skipped with a warning.
+#   b) A project access token with `write_repository` scope in the
+#      I18N_PUSH_TOKEN CI variable — the push alternative when (a) is not
+#      available.
 
-# ─── Base image used by both jobs ────────────────────────────────────────────
+# ─── Base image used by all jobs ─────────────────────────────────────────────
 .i18n-base:
   image: node:22-alpine
 
@@ -61,14 +89,13 @@
     I18N_CLI_VERSION: "latest"  # pin the-i18n-cli (npm version or dist-tag)
     I18N_INSTALL_PEER_DEPS: ""  # extra npm packages to install globally alongside the CLI
 
-    # Optional — push/MR behaviour
-    I18N_PUSH_TOKEN: ""       # project access token (write_repository + api). See header comment.
+    # Optional — push behaviour
+    I18N_PUSH_TOKEN: ""       # project access token (write_repository) — push alternative to the job token. See header comment.
     I18N_LOCALE_PATHS: "i18n/locales/"  # space-separated globs for locale directories (e.g. "i18n/locales/ app-*/i18n/locales/")
     I18N_COMMIT_MESSAGE: ""   # custom commit message (include [skip ci] to avoid pipeline loops)
-    I18N_MR_COMMENT: "true"   # post a summary comment on the MR (requires I18N_PUSH_TOKEN)
 
   before_script:
-    - if command -v apk >/dev/null; then apk add --no-cache git curl jq; fi
+    - if command -v apk >/dev/null; then apk add --no-cache git jq; fi
     - |
       # Install the CLI plus the SDK for the chosen provider (optional peer dep)
       case "${I18N_PROVIDER:-}" in
@@ -170,21 +197,6 @@
 
       echo "Pushed ${CHANGED_FILES} locale file(s) to ${CI_COMMIT_REF_NAME}"
 
-      # Post MR comment (only in MR context; requires an API-capable token)
-      if [ "$I18N_MR_COMMENT" = "true" ] && [ -n "${CI_MERGE_REQUEST_IID:-}" ]; then
-        if [ -z "${I18N_PUSH_TOKEN:-}" ]; then
-          echo "WARNING: skipping MR comment — set I18N_PUSH_TOKEN (api scope) to enable it."
-        else
-          BODY="## i18n Auto-Translate 🌐\n\nAuto-translated missing keys from source locale to target locales.\n\n| | |\n|---|---|\n| Provider | ${I18N_PROVIDER} |\n| Model | ${I18N_MODEL} |\n| Layer | ${I18N_LAYER} |\n| Keys translated | ${TRANSLATED} |\n| Files changed | ${CHANGED_FILES} |\n\nTranslations pushed to this branch."
-          curl --fail --silent --show-error --request POST \
-            --header "PRIVATE-TOKEN: ${I18N_PUSH_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "{\"body\": \"${BODY}\"}" \
-            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes" \
-            || echo "WARNING: failed to post MR comment."
-        fi
-      fi
-
   artifacts:
     paths:
       - .i18n-reports/translate-output.json
@@ -203,10 +215,9 @@
     # Optional
     I18N_CLI_VERSION: "latest"
     I18N_INSTALL_PEER_DEPS: ""
-    I18N_PUSH_TOKEN: ""       # project access token (api scope) for MR comments
 
   before_script:
-    - if command -v apk >/dev/null; then apk add --no-cache git curl jq; fi
+    - if command -v apk >/dev/null; then apk add --no-cache jq; fi
     - npm install -g --legacy-peer-deps "the-i18n-cli@${I18N_CLI_VERSION}" $I18N_INSTALL_PEER_DEPS
 
   script:
@@ -215,56 +226,63 @@
 
       mkdir -p .i18n-reports
 
-      # remove-orphans is a dry run by default — it only reports
+      # remove-orphans is a dry run by default — it only reports.
+      # --codequality-output feeds the MR Code Quality widget (needs the
+      # default-branch baseline rule, see header comment).
       the-i18n-cli remove-orphans \
         --layer "$I18N_LAYER" \
+        --codequality-output gl-codequality.json \
         > .i18n-reports/orphans.json
 
       ORPHAN_COUNT=$(jq '.summary.orphanCount // 0' .i18n-reports/orphans.json)
 
-      if [ "$ORPHAN_COUNT" -eq 0 ]; then
-        COMMENT="## i18n Cleanup ✅
-
-      No orphan keys found in layer \`${I18N_LAYER}\`. All translation keys are referenced in source code."
-      else
-        ORPHAN_LIST=$(jq -r '[.orphanKeys | to_entries[] | .value[] | "- `\(.)`"] | join("\n")' .i18n-reports/orphans.json)
-        COMMENT="## i18n Cleanup ⚠️
-
-      **${ORPHAN_COUNT} orphan key(s) found** in layer \`${I18N_LAYER}\` — keys in locale files with no source code references.
-
-      <details><summary>Click to expand</summary>
-
-      ${ORPHAN_LIST}
-
-      </details>
-
-      > ⚠️ Do not blindly delete all orphans. Some may be dynamically constructed. Review manually.
-      > Full report: [job artifacts](${CI_JOB_URL}/artifacts/browse/.i18n-reports/)"
-      fi
-
-      # Print summary to job log
       echo ""
       echo "============================================"
       echo "  i18n Cleanup Report — layer: ${I18N_LAYER}"
       echo "  Orphan keys found: ${ORPHAN_COUNT}"
       echo "============================================"
-
-      # Post MR comment (only in MR context; requires an API-capable token)
-      if [ -n "${CI_MERGE_REQUEST_IID:-}" ]; then
-        if [ -z "${I18N_PUSH_TOKEN:-}" ]; then
-          echo "WARNING: skipping MR comment — set I18N_PUSH_TOKEN (api scope) to enable it."
-        else
-          curl --fail --silent --show-error --request POST \
-            --header "PRIVATE-TOKEN: ${I18N_PUSH_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "$(echo "$COMMENT" | jq -Rs '{body: .}')" \
-            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes" \
-            || echo "WARNING: failed to post MR comment."
-        fi
-      fi
+      echo "Findings appear in the MR Code Quality widget."
+      echo "Full report: ${CI_JOB_URL}/artifacts/browse/.i18n-reports/"
 
   artifacts:
     paths:
       - .i18n-reports/orphans.json
+      - gl-codequality.json
+    reports:
+      codequality: gl-codequality.json
+    expire_in: 7 days
+    when: always
+
+# ─── Check for used-but-undefined keys ──────────────────────────────────────
+.i18n-check:
+  extends: .i18n-base
+  stage: lint
+  # `check` exits non-zero when any key is used but defined nowhere.
+  # allow_failure keeps that informational (findings still reach the MR
+  # widget) — remove allow_failure on the extending job to make it a gate.
+  allow_failure: true
+  variables:
+    I18N_CLI_VERSION: "latest"
+    I18N_INSTALL_PEER_DEPS: ""
+
+  before_script:
+    - npm install -g --legacy-peer-deps "the-i18n-cli@${I18N_CLI_VERSION}" $I18N_INSTALL_PEER_DEPS
+
+  script:
+    - |
+      set -euo pipefail
+
+      mkdir -p .i18n-reports
+
+      the-i18n-cli check \
+        --codequality-output gl-codequality.json \
+        > .i18n-reports/check.json
+
+  artifacts:
+    paths:
+      - .i18n-reports/check.json
+      - gl-codequality.json
+    reports:
+      codequality: gl-codequality.json
     expire_in: 7 days
     when: always

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -20,6 +20,7 @@ export default createCommand({
   args: {
     locale: { type: 'string', description: 'Reference locale to resolve definitions in (default: project default)' },
     outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
+    codequalityOutput: { type: 'string', description: 'Also write the findings as a GitLab Code Quality (CodeClimate) JSON report to this file path' },
   },
   failWhen: hasUndefinedKeys,
   async run(args) {
@@ -27,6 +28,7 @@ export default createCommand({
       locale: args.locale,
       projectDir: args.projectDir,
       outputFile: args.outputFile,
+      codequalityOutput: args.codequalityOutput,
     })
   },
 })

--- a/packages/cli/src/commands/remove-orphans.ts
+++ b/packages/cli/src/commands/remove-orphans.ts
@@ -9,6 +9,7 @@ export default createCommand({
     locale: { type: 'string', description: 'Locale to check (default: project default)' },
     dryRun: { type: 'boolean', description: 'Preview without removing (default: true)', default: true },
     outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
+    codequalityOutput: { type: 'string', description: 'Also write the orphan findings as a GitLab Code Quality (CodeClimate) JSON report to this file path' },
   },
   async run(args) {
     return removeOrphanKeys({
@@ -17,6 +18,7 @@ export default createCommand({
       dryRun: args.dryRun,
       projectDir: args.projectDir,
       outputFile: args.outputFile,
+      codequalityOutput: args.codequalityOutput,
     })
   },
 })

--- a/packages/cli/src/core/codequality.ts
+++ b/packages/cli/src/core/codequality.ts
@@ -1,0 +1,128 @@
+/**
+ * GitLab Code Quality (CodeClimate) mapping — pure result-shape → issue-array
+ * transforms, no I/O.
+ *
+ * Format contract (https://docs.gitlab.com/ci/testing/code_quality/):
+ * every issue needs description, check_name, fingerprint, severity, and
+ * location.path + location.lines.begin, where path is project-root-relative
+ * (no leading `./`) and lines.begin is an integer ≥ 1.
+ *
+ * Fingerprints deliberately exclude line numbers so unrelated edits that
+ * shift a usage do not churn findings as new/resolved in the MR widget.
+ */
+
+import { createHash } from 'node:crypto'
+import { join, relative } from 'node:path'
+
+import type { I18nConfig, LocaleDefinition } from '../config/types.js'
+
+import type { UndefinedKeyFinding } from './ops-check.js'
+
+export interface CodeQualityIssue {
+  description: string
+  check_name: string
+  fingerprint: string
+  severity: 'info' | 'minor' | 'major' | 'critical' | 'blocker'
+  location: {
+    path: string
+    lines: { begin: number }
+  }
+}
+
+const UNDEFINED_KEY_CHECK = 'i18n.undefined-key'
+const ORPHAN_KEY_CHECK = 'i18n.orphan-key'
+
+/** NUL-joined so no part can bleed into its neighbor (keys/paths never contain NUL). */
+function fingerprintOf(...parts: string[]): string {
+  return createHash('sha256').update(parts.join('\0')).digest('hex')
+}
+
+/** Normalize to the report's path shape: forward slashes, no leading `./`. */
+function toReportPath(path: string): string {
+  const normalized = path.replaceAll('\\', '/')
+  return normalized.startsWith('./') ? normalized.slice(2) : normalized
+}
+
+/** GitLab rejects non-positive or fractional line numbers. */
+function toLineBegin(line: number): number {
+  return Math.max(1, Math.trunc(line))
+}
+
+/**
+ * `check` findings → one issue per usage location. Uncertain findings are
+ * not mapped: the widget has no "maybe" state, and a hard-looking finding
+ * for an unverifiable key would train consumers to ignore the report.
+ */
+export function undefinedKeysToCodeQuality(undefinedKeys: UndefinedKeyFinding[]): CodeQualityIssue[] {
+  const issues: CodeQualityIssue[] = []
+  for (const finding of undefinedKeys) {
+    for (const usage of finding.usages) {
+      const path = toReportPath(usage.file)
+      issues.push({
+        description: `i18n key "${finding.key}" is referenced here but defined in no locale file of the consuming app's layers — it renders as the raw key at runtime.`,
+        check_name: UNDEFINED_KEY_CHECK,
+        fingerprint: fingerprintOf(UNDEFINED_KEY_CHECK, finding.key, path),
+        severity: 'major',
+        location: { path, lines: { begin: toLineBegin(usage.line) } },
+      })
+    }
+  }
+  return issues
+}
+
+/**
+ * Orphan findings → one issue per key, anchored at the layer's
+ * reference-locale file (line 1): orphans live in locale files, not code.
+ * The fingerprint is anchor-independent (layer + key), so locale-file
+ * renames or layout changes do not churn findings. Uncertain,
+ * dynamic-matched, and misplaced keys are not part of `orphansByLayer`
+ * and therefore never mapped.
+ */
+export function orphanKeysToCodeQuality(
+  orphansByLayer: Record<string, string[]>,
+  anchorFileByLayer: Record<string, string>,
+): CodeQualityIssue[] {
+  const issues: CodeQualityIssue[] = []
+  for (const [layer, keys] of Object.entries(orphansByLayer)) {
+    // A missing anchor (layer absent from config) degrades to the layer name
+    // as path — the fingerprint is path-independent, so findings stay stable.
+    const path = toReportPath(anchorFileByLayer[layer] ?? layer)
+    for (const key of keys) {
+      issues.push({
+        description: `Orphan i18n key "${key}" in layer "${layer}" has no source-code reference — it may be consumed dynamically; verify before deleting.`,
+        check_name: ORPHAN_KEY_CHECK,
+        fingerprint: fingerprintOf(ORPHAN_KEY_CHECK, layer, key),
+        severity: 'minor',
+        location: { path, lines: { begin: 1 } },
+      })
+    }
+  }
+  return issues
+}
+
+/**
+ * Project-root-relative reference-locale file path per layer, the anchor for
+ * orphan issues. Aliases resolve to their target layer's directory. Flat
+ * layouts anchor at the locale file; namespaced layouts (per-locale
+ * directories) have no single file and anchor at the locale's directory.
+ */
+export function referenceLocaleAnchorPaths(
+  config: I18nConfig,
+  layers: string[],
+  locale: LocaleDefinition,
+  projectDir: string,
+): Record<string, string> {
+  const anchors: Record<string, string> = {}
+  for (const layer of layers) {
+    const localeDir = config.localeDirs.find(d => d.layer === layer)
+    const resolved = localeDir?.aliasOf
+      ? config.localeDirs.find(d => d.layer === localeDir.aliasOf) ?? localeDir
+      : localeDir
+    if (!resolved) continue
+    const absPath = locale.file
+      ? join(resolved.path, locale.file)
+      : join(resolved.path, locale.code)
+    anchors[layer] = toReportPath(relative(projectDir, absPath))
+  }
+  return anchors
+}

--- a/packages/cli/src/core/ops-check.ts
+++ b/packages/cli/src/core/ops-check.ts
@@ -9,7 +9,7 @@
 
 import { detectI18nConfig } from '../config/detector.js'
 import type { I18nConfig, LocaleDefinition } from '../config/types.js'
-import { writeReportFile } from '../io/json-writer.js'
+import { writeCodequalityFile, writeReportFile } from '../io/json-writer.js'
 import { readLocaleData } from '../io/locale-data.js'
 import { getLeafKeys } from '../io/key-operations.js'
 import {
@@ -25,6 +25,7 @@ import { getPatternSet } from '../scanner/patterns.js'
 import { resolveReferenceLocale } from './shared.js'
 import { resolveReportFilePath, validateReportPath } from './report.js'
 import { buildOrphanScanPlan, resolveOrphanIgnorePatterns } from './ops-orphans.js'
+import { undefinedKeysToCodeQuality } from './codequality.js'
 
 export interface KeyUsageLocation {
   /** Source file path, relative to the project dir. */
@@ -322,6 +323,8 @@ export async function checkUndefinedKeys(opts: {
   excludeDirs?: string[]
   projectDir?: string
   outputFile?: string
+  /** Also write the findings as a GitLab Code Quality JSON array to this path. */
+  codequalityOutput?: string
 } = {}): Promise<CheckUndefinedKeysResult | { reportFile: string; summary: CheckUndefinedKeysSummary }> {
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -396,6 +399,13 @@ export async function checkUndefinedKeys(opts: {
     uncertainKeys,
     limitation: CHECK_LIMITATION,
     summary,
+  }
+
+  // Written even when clean: an empty array on the default branch is the
+  // baseline the MR widget diffs against.
+  if (opts.codequalityOutput) {
+    validateReportPath(dir, opts.codequalityOutput)
+    await writeCodequalityFile(opts.codequalityOutput, undefinedKeysToCodeQuality(undefinedKeys))
   }
 
   const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_undefined_keys')

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -7,8 +7,8 @@ import { isAbsolute, relative } from 'node:path'
 
 import { detectI18nConfig } from '../config/detector.js'
 import { buildLayerGraph } from '../config/layer-graph.js'
-import type { I18nConfig, LocaleDir } from '../config/types.js'
-import { writeReportFile } from '../io/json-writer.js'
+import type { I18nConfig, LocaleDefinition, LocaleDir } from '../config/types.js'
+import { writeCodequalityFile, writeReportFile } from '../io/json-writer.js'
 import { readLocaleData, mutateLocaleData } from '../io/locale-data.js'
 import { getLeafKeys, removeNestedValue } from '../io/key-operations.js'
 import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from '../scanner/code-scanner.js'
@@ -18,6 +18,7 @@ import { ToolError } from '../utils/errors.js'
 
 import { findLayerOrThrow, resolveReferenceLocale } from './shared.js'
 import { validateReportPath, resolveReportFilePath } from './report.js'
+import { orphanKeysToCodeQuality, referenceLocaleAnchorPaths } from './codequality.js'
 
 const MISPLACED_USAGE_NOTE
   = 'Keys referenced only from apps that do not consume their layer. '
@@ -145,6 +146,7 @@ async function resolveOrphanScanContext(
   keysByLayer: Map<string, { keys: string[]; localeDir: LocaleDir }>
   totalKeys: number
   localeCode: string
+  localeDef: LocaleDefinition
 }> {
   const { localeCode, localeDef } = resolveReferenceLocale(config, opts.locale)
 
@@ -180,7 +182,7 @@ async function resolveOrphanScanContext(
 
   const totalKeys = [...keysByLayer.values()].reduce((sum, v) => sum + v.keys.length, 0)
 
-  return { layersToCheck, keysByLayer, totalKeys, localeCode }
+  return { layersToCheck, keysByLayer, totalKeys, localeCode, localeDef }
 }
 
 /**
@@ -387,20 +389,32 @@ export async function removeOrphanKeys(opts: {
   dryRun?: boolean
   projectDir?: string
   outputFile?: string
+  /** Also write the orphan findings as a GitLab Code Quality JSON array to this path. */
+  codequalityOutput?: string
 }): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
   const isDryRun = opts.dryRun ?? true
 
-  const { keysByLayer, totalKeys } = await resolveOrphanScanContext(config, {
+  const { keysByLayer, totalKeys, localeDef } = await resolveOrphanScanContext(config, {
     layer,
     locale,
     dir,
     toolName: 'remove_orphan_keys',
   })
 
+  // Written in every branch, even without findings: an empty array on the
+  // default branch is the baseline the MR widget diffs against.
+  const writeCodequality = async (orphans: Record<string, string[]>): Promise<void> => {
+    if (!opts.codequalityOutput) return
+    validateReportPath(dir, opts.codequalityOutput)
+    const anchors = referenceLocaleAnchorPaths(config, Object.keys(orphans), localeDef, dir)
+    await writeCodequalityFile(opts.codequalityOutput, orphanKeysToCodeQuality(orphans, anchors))
+  }
+
   if (totalKeys === 0) {
+    await writeCodequality({})
     const emptyOutput = { orphanKeys: {}, removed: {}, summary: { totalKeys: 0, orphanCount: 0, message: 'No translation keys found.' } }
     const emptyReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (emptyReportPath) {
@@ -415,6 +429,7 @@ export async function removeOrphanKeys(opts: {
   }
 
   const orphanResult = await runOrphanScan(config, keysByLayer, { scanDirs, excludeDirs, dir })
+  await writeCodequality(orphanResult.orphansByLayer)
   const orphansByLayer = orphanResult.orphansByLayer
   const orphanCount = orphanResult.orphanCount
   const totalFilesScanned = orphanResult.totalFilesScanned

--- a/packages/cli/src/io/json-writer.ts
+++ b/packages/cli/src/io/json-writer.ts
@@ -64,6 +64,27 @@ export async function writeReportFile(
 }
 
 /**
+ * Write a GitLab Code Quality report: a bare JSON array — the format is
+ * externally specified, so no metadata wrapper (unlike writeReportFile).
+ */
+export async function writeCodequalityFile(
+  filePath: string,
+  issues: unknown[],
+): Promise<void> {
+  const content = JSON.stringify(issues, null, 2) + '\n'
+
+  try {
+    await atomicWrite(filePath, content)
+  } catch (error) {
+    if (error instanceof FileIOError) throw error
+    throw new FileIOError(
+      `Failed to write codequality file: ${filePath}: ${toErrorMessage(error)}`,
+      filePath,
+    )
+  }
+}
+
+/**
  * Read, mutate, and write back a single JSON locale file while preserving its
  * existing formatting:
  *

--- a/packages/cli/tests/tools/check-undefined.test.ts
+++ b/packages/cli/tests/tools/check-undefined.test.ts
@@ -243,4 +243,34 @@ describe('checkUndefinedKeys — scope-aware', () => {
     expect(report.tool).toBe('find_undefined_keys')
     expect(report.undefinedKeys).toHaveLength(2)
   })
+
+  it('honors codequalityOutput: writes a CodeClimate array alongside the normal report', async () => {
+    const reportPath = join(projectDir, 'undefined-report-cq.json')
+    const cqPath = join(projectDir, 'gl-codequality.json')
+    const result = await checkUndefinedKeys({ projectDir, outputFile: reportPath, codequalityOutput: cqPath })
+
+    // The flag is additive: the normal report behavior is unchanged.
+    expect(result).toMatchObject({ reportFile: reportPath })
+
+    const issues = JSON.parse(await readFile(cqPath, 'utf-8')) as Array<Record<string, any>>
+    // One issue per usage: admin.ghost (lines 3 + 9) and shop.only (line 4).
+    expect(issues).toHaveLength(3)
+    for (const issue of issues) {
+      expect(issue).toMatchObject({
+        description: expect.any(String),
+        check_name: 'i18n.undefined-key',
+        fingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
+        severity: 'major',
+        location: { path: adminPage, lines: { begin: expect.any(Number) } },
+      })
+    }
+    // Same key, different lines → identical line-independent fingerprint.
+    const ghosts = issues.filter(i => i.description.includes('"admin.ghost"'))
+    expect(ghosts.map(i => i.location.lines.begin)).toEqual([3, 9])
+    expect(ghosts[0]!.fingerprint).toBe(ghosts[1]!.fingerprint)
+    // Uncertain findings (dynamic, $te-only) are omitted.
+    const serialized = JSON.stringify(issues)
+    expect(serialized).not.toContain('admin.optional')
+    expect(serialized).not.toContain('admin.dyn')
+  })
 })

--- a/packages/cli/tests/tools/codequality.test.ts
+++ b/packages/cli/tests/tools/codequality.test.ts
@@ -1,0 +1,147 @@
+/**
+ * GitLab Code Quality mapping (#270) — pure transforms, no I/O.
+ *
+ * Contract under test: every issue carries the full required field set,
+ * paths are project-root-relative with no leading `./`, lines.begin is an
+ * integer ≥ 1, and fingerprints are line-independent (edits that shift a
+ * usage must not churn findings as new/resolved in the MR widget).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
+
+import type { I18nConfig } from '../../src/config/types.js'
+import type { UndefinedKeyFinding } from '../../src/core/ops-check.js'
+import {
+  undefinedKeysToCodeQuality,
+  orphanKeysToCodeQuality,
+  referenceLocaleAnchorPaths,
+} from '../../src/core/codequality.js'
+import type { CodeQualityIssue } from '../../src/core/codequality.js'
+
+const finding = (key: string, usages: Array<{ file: string; line: number }>): UndefinedKeyFinding =>
+  ({ key, app: 'app', searchedLayers: ['root'], usages })
+
+function expectValidIssue(issue: CodeQualityIssue): void {
+  expect(issue.description).toEqual(expect.any(String))
+  expect(issue.description.length).toBeGreaterThan(0)
+  expect(issue.check_name).toMatch(/^i18n\./)
+  expect(issue.fingerprint).toMatch(/^[0-9a-f]{64}$/)
+  expect(['info', 'minor', 'major', 'critical', 'blocker']).toContain(issue.severity)
+  expect(issue.location.path).toEqual(expect.any(String))
+  expect(issue.location.path).not.toMatch(/^\.\//)
+  expect(issue.location.path).not.toMatch(/^\//)
+  expect(Number.isInteger(issue.location.lines.begin)).toBe(true)
+  expect(issue.location.lines.begin).toBeGreaterThanOrEqual(1)
+}
+
+describe('undefinedKeysToCodeQuality', () => {
+  it('maps one major finding per usage location', () => {
+    const issues = undefinedKeysToCodeQuality([
+      finding('a.b', [{ file: 'src/App.vue', line: 3 }, { file: 'src/Other.vue', line: 7 }]),
+      finding('c.d', [{ file: 'src/App.vue', line: 9 }]),
+    ])
+
+    expect(issues).toHaveLength(3)
+    for (const issue of issues) expectValidIssue(issue)
+    expect(issues[0]).toMatchObject({
+      check_name: 'i18n.undefined-key',
+      severity: 'major',
+      location: { path: 'src/App.vue', lines: { begin: 3 } },
+    })
+    expect(issues[0]!.description).toContain('"a.b"')
+  })
+
+  it('fingerprints are line-independent but key- and path-sensitive', () => {
+    const at = (line: number): CodeQualityIssue[] =>
+      undefinedKeysToCodeQuality([finding('a.b', [{ file: 'src/App.vue', line }])])
+
+    // Frozen vector: sha256 over check_name, key, path — changing this hash
+    // resets every consumer's new/resolved state in the widget.
+    expect(at(3)[0]!.fingerprint).toBe('0998722d98ee09e187b0b2683a90d831966e193bb63c9782de439a8d0a559158')
+    expect(at(300)[0]!.fingerprint).toBe(at(3)[0]!.fingerprint)
+
+    const otherKey = undefinedKeysToCodeQuality([finding('a.c', [{ file: 'src/App.vue', line: 3 }])])
+    const otherFile = undefinedKeysToCodeQuality([finding('a.b', [{ file: 'src/B.vue', line: 3 }])])
+    expect(otherKey[0]!.fingerprint).not.toBe(at(3)[0]!.fingerprint)
+    expect(otherFile[0]!.fingerprint).not.toBe(at(3)[0]!.fingerprint)
+  })
+
+  it('normalizes path shape and clamps lines.begin to an integer ≥ 1', () => {
+    const issues = undefinedKeysToCodeQuality([
+      finding('a.b', [{ file: './src\\win\\App.vue', line: 0 }]),
+    ])
+
+    expect(issues[0]!.location).toEqual({ path: 'src/win/App.vue', lines: { begin: 1 } })
+  })
+
+  it('maps an empty result to an empty array (the default-branch baseline)', () => {
+    expect(undefinedKeysToCodeQuality([])).toEqual([])
+  })
+})
+
+describe('orphanKeysToCodeQuality', () => {
+  const anchors = { 'root': 'i18n/locales/de-DE.json', 'app-admin': 'app-admin/i18n/locales/de-DE.json' }
+
+  it('maps one minor finding per key, anchored at the reference-locale file, line 1', () => {
+    const issues = orphanKeysToCodeQuality(
+      { 'root': ['a.b', 'a.c'], 'app-admin': ['admin.x'] },
+      anchors,
+    )
+
+    expect(issues).toHaveLength(3)
+    for (const issue of issues) expectValidIssue(issue)
+    expect(issues[0]).toMatchObject({
+      check_name: 'i18n.orphan-key',
+      severity: 'minor',
+      location: { path: 'i18n/locales/de-DE.json', lines: { begin: 1 } },
+    })
+    expect(issues[2]!.location.path).toBe('app-admin/i18n/locales/de-DE.json')
+    expect(issues[0]!.description).toContain('"a.b"')
+    expect(issues[0]!.description).toContain('verify before deleting')
+  })
+
+  it('fingerprints depend on layer + key, not the anchor path', () => {
+    const [issue] = orphanKeysToCodeQuality({ root: ['a.b'] }, anchors)
+    const [moved] = orphanKeysToCodeQuality({ root: ['a.b'] }, { root: 'renamed/locales/en.json' })
+
+    expect(issue!.fingerprint).toBe('7b340a6a9273b1d9346c77ec83a1723b01f710da22356dfd67a963bd2d6e6557')
+    expect(moved!.fingerprint).toBe(issue!.fingerprint)
+
+    const [otherLayer] = orphanKeysToCodeQuality({ other: ['a.b'] }, { other: 'x.json' })
+    expect(otherLayer!.fingerprint).not.toBe(issue!.fingerprint)
+  })
+})
+
+describe('referenceLocaleAnchorPaths', () => {
+  const projectDir = resolve('/proj')
+  const config = {
+    localeDirs: [
+      { path: resolve('/proj/i18n/locales'), layer: 'root', layerRootDir: projectDir },
+      { path: resolve('/proj/app-shop/i18n/locales'), layer: 'app-shop', layerRootDir: resolve('/proj/app-shop') },
+      { path: resolve('/proj/app-shop/i18n/locales'), layer: 'app-outlook', layerRootDir: resolve('/proj/app-outlook'), aliasOf: 'app-shop' },
+    ],
+  } as I18nConfig
+  const locale = { code: 'de', language: 'de-DE', file: 'de-DE.json' }
+
+  it('resolves flat layouts to the locale file, relative without leading ./', () => {
+    const anchors = referenceLocaleAnchorPaths(config, ['root', 'app-shop'], locale, projectDir)
+
+    expect(anchors).toEqual({
+      'root': 'i18n/locales/de-DE.json',
+      'app-shop': 'app-shop/i18n/locales/de-DE.json',
+    })
+  })
+
+  it('aliases anchor at their target layer\'s directory', () => {
+    const anchors = referenceLocaleAnchorPaths(config, ['app-outlook'], locale, projectDir)
+
+    expect(anchors['app-outlook']).toBe('app-shop/i18n/locales/de-DE.json')
+  })
+
+  it('locales without a file (namespaced layouts) anchor at the locale directory', () => {
+    const anchors = referenceLocaleAnchorPaths(config, ['root'], { code: 'de', language: 'de-DE' }, projectDir)
+
+    expect(anchors['root']).toBe('i18n/locales/de')
+  })
+})

--- a/packages/cli/tests/tools/orphan-scope.test.ts
+++ b/packages/cli/tests/tools/orphan-scope.test.ts
@@ -138,4 +138,28 @@ describe('removeOrphanKeys — scope-aware', () => {
     expect(await readLocale(projectDir)).toEqual({ root: { shared: { used: 'a', usedByAdmin: 'b' } } })
     expect(await readLocale(shopDir)).toEqual({ shop: { used: 'a' } })
   })
+
+  it('codequalityOutput writes orphan issues anchored at each layer\'s reference-locale file', async () => {
+    const cqPath = join(projectDir, 'gl-codequality.json')
+    const result = await removeOrphanKeys({ projectDir, codequalityOutput: cqPath })
+
+    // The flag is additive: the normal dry-run result is unchanged.
+    expect(result.orphanKeys).toEqual(expectedOrphans)
+
+    const issues = JSON.parse(await readFile(cqPath, 'utf-8')) as Array<Record<string, any>>
+    expect(issues).toHaveLength(2)
+    expect(issues).toContainEqual({
+      description: expect.stringContaining('"admin.orphan"'),
+      check_name: 'i18n.orphan-key',
+      fingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
+      severity: 'minor',
+      location: { path: 'app-admin/i18n/locales/de-DE.json', lines: { begin: 1 } },
+    })
+    expect(issues).toContainEqual(expect.objectContaining({
+      description: expect.stringContaining('"root.shared.orphan"'),
+      location: { path: 'i18n/locales/de-DE.json', lines: { begin: 1 } },
+    }))
+    // Misplaced keys (admin.usedFromShop) are not orphans and never mapped.
+    expect(JSON.stringify(issues)).not.toContain('usedFromShop')
+  })
 })


### PR DESCRIPTION
## What was built

An opt-in `--codequality-output <file>` flag on `check` and `remove-orphans` that writes a CodeClimate-format JSON array **in addition to** the normal stdout/report behavior (nothing changes when unset), plus a GitLab template rework that replaces MR comments with the Code Quality widget.

- **`core/codequality.ts`** — pure mapper module (no I/O): `undefinedKeysToCodeQuality`, `orphanKeysToCodeQuality`, `referenceLocaleAnchorPaths`. The ops (`ops-check.ts`, `ops-orphans.ts`) validate the path via `validateReportPath` (same as `outputFile`) and write via a new `writeCodequalityFile` (bare array — no report metadata wrapper).
- An **empty array is written on clean runs** — that's the default-branch baseline the MR widget diffs against.
- Fingerprints are sha256 over NUL-joined parts and exclude line numbers, so edits that shift a usage don't churn findings as new/resolved.

## Mapping table

| Source | check_name | severity | location.path | lines.begin | fingerprint | omitted |
|---|---|---|---|---|---|---|
| `check` undefined key, one issue **per usage** | `i18n.undefined-key` | `major` | usage file (project-root-relative, no `./`) | usage line (int ≥ 1) | sha256(check_name, key, path) | uncertain (dynamic, `$te`-only) |
| `remove-orphans` orphan, one issue **per key** | `i18n.orphan-key` | `minor` | layer's reference-locale file (aliases resolved; namespaced layouts anchor at the locale dir) | `1` | sha256(check_name, layer, key) | uncertain / dynamic-matched / misplaced |
| missing translations | — not mapped (no sensible location; the translate job auto-fixes them) | | | | | |

Orphan descriptions carry the "may be consumed dynamically — verify before deleting" caveat.

## Template before/after

| | before | after |
|---|---|---|
| MR feedback | curl to the notes API in both jobs, `I18N_MR_COMMENT` variable, api-scope token docs | **removed entirely** — findings surface in the MR Code Quality widget |
| `I18N_PUSH_TOKEN` | push + MR comments (`write_repository` + `api`) | documented only as the push alternative to the job token (`write_repository`) |
| `.i18n-cleanup` | writes `.i18n-reports/orphans.json`, posts comment | additionally writes `gl-codequality.json`, declared as `artifacts:reports:codequality` |
| `.i18n-check` | — | new hidden job running `check --codequality-output`; `allow_failure: true` by default (check exits non-zero on findings — informational until consumers remove it) |
| header docs | comment/token instructions | prominently documents the **default-branch baseline rule** (`if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH`, no `changes:` filter) and why the widget is blank without it, plus artifact-expiry interaction |

Template YAML verified to parse. README's GitLab section updated to match (MR-comment rows dropped, `.i18n-check` documented). GitHub Action untouched.

## anny-ui smoke (read-only)

Ran both commands with the flag against `~/code/anny/anny-ui` (dry-run; scratch files deleted afterwards, repo left untouched):

- `check`: exit 1 (findings, as designed), **151 issues** = 137 undefined keys × their usages; all entries valid (description/check_name/64-hex fingerprint/severity/path without `./`/integer `lines.begin ≥ 1`), e.g. `common.actions.saved` → `app-admin/components/blockers/HolidayBlockerForm.vue:256`.
- `remove-orphans`: **1514 issues** matching `summary.orphanCount` exactly; anchored at `i18n/locales/de-DE.json` / `app-admin/i18n/locales/de-DE.json`, all `lines.begin: 1`, zero invalid entries.

## Validation

- `pnpm --filter the-i18n-cli build` OK
- `pnpm -r test` OK (CLI 710, MCP 24)
- `pnpm -r --filter='./packages/*' typecheck` OK
- `pnpm lint` OK (3 pre-existing warnings, none new)
- `npx fallow audit --base origin/main` exit 0, no issues

Tests added: pure mapper suite (fingerprint stability across line changes + frozen vectors, path shape, severity/check_name, orphan anchoring/line 1, required-field shape, empty baseline) and op-level tests asserting the flag writes a valid array alongside the normal report for both commands.

Note: overlaps #254 (template exit-code rewrite, not started) — the comment-removal here shrinks its surface; whoever lands second rebases. #268/#269 touch scanner/ops internals; this PR only reads their result shapes.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
