### PR TITLE
fix(ci): remove out-of-package extra-files that break release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,19 +23,7 @@
       "prerelease": false,
       "include-component-in-tag": true,
       "include-v-in-tag": false,
-      "component": "the-i18n-mcp",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "../../server.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "../../server.json",
-          "jsonpath": "$.packages[0].version"
-        }
-      ]
+      "component": "the-i18n-mcp"
     }
   }
 }


### PR DESCRIPTION
The `extra-files` entries added in #256 to keep `server.json` versions in lockstep hit release-please's path validation — it rejects any path traversing outside the package directory and **fails the entire release run** ("illegal pathing characters in path: packages/mcp/../../server.json"), exactly the risk flagged in #256's PR body. This removes the two entries so release PR generation works again, unblocking cli 4.1.0.

server.json goes back to manual bumps on the-i18n-mcp releases (currently correct at 6.2.0). If automation is wanted later: a sync step in the publish workflow or a CI consistency check — not worth blocking releases on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)