### PR TITLE
chore: bump server.json to the-i18n-mcp 7.0.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fabkho/the-i18n-kit",
     "source": "github"
   },
-  "version": "6.2.0",
+  "version": "7.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "the-i18n-mcp",
-      "version": "6.2.0",
+      "version": "7.0.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The 7.0.0 release merged before the manual server.json bump could ride the release PR (the auto-bump was removed in #272 because release-please rejects out-of-package extra-files paths). Both version fields 6.2.0 → 7.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)