### PR TITLE
fix(ci): drop [skip ci] from the translate auto-commit by default

### DIFF
--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -92,7 +92,11 @@
     # Optional — push behaviour
     I18N_PUSH_TOKEN: ""       # project access token (write_repository) — push alternative to the job token. See header comment.
     I18N_LOCALE_PATHS: "i18n/locales/"  # space-separated globs for locale directories (e.g. "i18n/locales/ app-*/i18n/locales/")
-    I18N_COMMIT_MESSAGE: ""   # custom commit message (include [skip ci] to avoid pipeline loops)
+    I18N_COMMIT_MESSAGE: ""   # custom commit message (overrides the default entirely)
+    I18N_AUTOCOMMIT_SKIP_CI: ""  # set "true" to append [skip ci] to the auto-commit. Off by default:
+                                 # [skip ci] leaves the MR head without a pipeline, which breaks the
+                                 # Code Quality widget (comparer error). A re-run is loop-safe — it
+                                 # finds nothing missing and pushes nothing.
 
   before_script:
     - if command -v apk >/dev/null; then apk add --no-cache git jq; fi
@@ -174,7 +178,10 @@
       if [ -n "${I18N_COMMIT_MESSAGE:-}" ]; then
         COMMIT_MSG="$I18N_COMMIT_MESSAGE"
       else
-        COMMIT_MSG="i18n: auto-translate missing keys ($I18N_LAYER) via $I18N_PROVIDER [skip ci]"
+        COMMIT_MSG="i18n: auto-translate missing keys ($I18N_LAYER) via $I18N_PROVIDER"
+        if [ "${I18N_AUTOCOMMIT_SKIP_CI:-}" = "true" ]; then
+          COMMIT_MSG="$COMMIT_MSG [skip ci]"
+        fi
       fi
 
       if [ -n "${I18N_PUSH_TOKEN:-}" ]; then

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -97,6 +97,9 @@
                                  # [skip ci] leaves the MR head without a pipeline, which breaks the
                                  # Code Quality widget (comparer error). A re-run is loop-safe — it
                                  # finds nothing missing and pushes nothing.
+                                 # NOTE: pushes with the plain CI_JOB_TOKEN never trigger pipelines
+                                 # (GitLab rule), so the follow-up pipeline — and the widget on
+                                 # translated MRs — additionally requires I18N_PUSH_TOKEN.
 
   before_script:
     - if command -v apk >/dev/null; then apk add --no-cache git jq; fi


### PR DESCRIPTION
Fixes the live finding from anny-ui !2013 (first widget rollout): when the translate job pushes its `[skip ci]` auto-commit, the MR `head_sha` moves past the pipeline that produced the codequality report — GitLab's comparer then needs a head report for a sha that can never have a pipeline, returns `ERROR`, and the widget never renders on any MR where translation ran. Verified live via GraphQL (`codequalityReportsComparer.status: ERROR` with both reports ingested; recovers when a pipeline runs on the moved head).

Change: the default auto-commit message no longer carries `[skip ci]`. Loop safety holds without it — the follow-up pipeline's translate finds zero missing keys and pushes nothing, so the sequence terminates after one extra (cheap, rules-gated) pipeline that also re-validates the pushed translations and regenerates the codequality report on the final head. `I18N_AUTOCOMMIT_SKIP_CI: "true"` restores the old behavior; `I18N_COMMIT_MESSAGE` still overrides wholesale.

Template-only change — consumers on the remote include pick it up on merge, no release needed.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether automatic translation commits include the `[skip ci]` suffix.

* **Changes**
  * Automatic translation commits no longer skip CI by default; this behavior can be enabled through the new configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->