### PR TITLE
fix(cli): resolve relative --output-file against project dir, emit JSON error on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,18 +402,18 @@ The `add-feature-translations` MCP prompt codifies this as a reusable workflow. 
 
 ## Handling Large Outputs
 
-Tools like `find_orphan_keys` and `get_missing_translations` can return large payloads. Pass `--output-file` (CLI) or `outputFile` (MCP) to write the full report to disk and get only a compact summary back:
+Tools like `find_orphan_keys` and `get_missing_translations` can return large payloads. Pass `--output-file` (CLI) or `outputFile` (MCP) to write the full report to disk and get only a compact summary back. Relative paths resolve against the project dir; the path must stay within it:
 
 ```bash
-the-i18n-cli remove-orphans --output-file /tmp/orphans.json
-# → Wrote report to: /tmp/orphans.json
+the-i18n-cli remove-orphans --output-file reports/orphans.json
+# → Wrote report to: <project-dir>/reports/orphans.json
 # → { orphanCount: 1103, filesScanned: 2526, ... }
 ```
 
 ```json
 // MCP call
-{ "tool": "find_orphan_keys", "arguments": { "outputFile": "/tmp/orphans.json" } }
-// → { "reportFile": "/tmp/orphans.json", "summary": { ... } }
+{ "tool": "find_orphan_keys", "arguments": { "outputFile": "reports/orphans.json" } }
+// → { "reportFile": "<project-dir>/reports/orphans.json", "summary": { ... } }
 ```
 
 Alternatively, set `reportOutput: true` in `.i18n-mcp.json` to always write reports to `.i18n-reports/` in the project root.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import { defineCommand, runCommand, runMain } from 'citty'
-import { log } from './utils/logger.js'
 import { commands as allCommands } from './commands/index.js'
+import { emitErrorResult } from './commands/_shared.js'
 
 // Diagnostic commands kept out of the public CLI surface
 const hiddenCommands = new Set(['detect', 'list-dirs', 'empty', 'scan'])
@@ -31,11 +31,14 @@ export async function runCli(): Promise<void> {
     return
   }
 
-  // For normal execution, use runCommand so we control error output
+  // For normal execution, use runCommand so we control error output.
+  // Command run() errors are handled inside createCommand; this catch only
+  // sees pre-run failures (unknown command, argument parsing) — those must
+  // also keep stdout parseable in JSON mode.
   try {
     await runCommand(main, { rawArgs })
   } catch (error: unknown) {
-    log.error(error)
+    emitErrorResult(error, { json: rawArgs.includes('--json') })
     process.exitCode = 1
   }
 }

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty'
 import type { CommandDef } from 'citty'
 import { log } from '../utils/logger.js'
+import { toErrorMessage } from '../utils/errors.js'
 import { writeResult } from '../utils/stdout-guard.js'
 
 /** Factory for commands that call an operation and output its result. */
@@ -21,9 +22,14 @@ export function createCommand(opts: {
     meta: { name: opts.name, description: opts.description },
     args: { ...sharedArgs, ...(opts.args ?? {}) },
     async run({ args }) {
-      const result = await opts.run(args)
-      outputResult(result, args)
-      if (isTotalFailure(result) || opts.failWhen?.(result)) {
+      try {
+        const result = await opts.run(args)
+        outputResult(result, args)
+        if (isTotalFailure(result) || opts.failWhen?.(result)) {
+          process.exitCode = 1
+        }
+      } catch (error) {
+        emitErrorResult(error, args)
         process.exitCode = 1
       }
     },
@@ -85,6 +91,31 @@ function outputResult(data: unknown, args: { json?: boolean }): void {
   }
   // JSON mode emits the full result (including reportFile when present) as pure JSON
   writeResult(JSON.stringify(data, null, 2) + '\n')
+}
+
+/**
+ * Failure output. In JSON mode stdout must still carry parseable JSON —
+ * consumers pipe it into jq, and zero bytes is a parse error — so the
+ * structured error object IS the result on stdout; the human-readable
+ * message goes to stderr in every mode. Exit code stays non-zero (callers
+ * set it).
+ */
+export function emitErrorResult(error: unknown, args: { json?: boolean }): void {
+  log.error(toErrorMessage(error))
+  const jsonMode = args.json || !process.stdout.isTTY
+  if (!jsonMode) return
+  const payload = { error: { code: errorCode(error), message: toErrorMessage(error) } }
+  writeResult(JSON.stringify(payload, null, 2) + '\n')
+}
+
+/** ToolError/FileIOError carry codes; Node errors expose e.g. ENOENT. */
+function errorCode(error: unknown): string {
+  if (error instanceof Error) {
+    const code = (error as { code?: unknown }).code
+    if (typeof code === 'string') return code
+    if (error.name === 'ConfigError') return 'CONFIG_ERROR'
+  }
+  return 'UNKNOWN_ERROR'
 }
 
 /** Split a comma-separated string into a trimmed array, or return undefined */

--- a/packages/cli/src/core/ops-check.ts
+++ b/packages/cli/src/core/ops-check.ts
@@ -23,7 +23,7 @@ import type { DynamicKeyUsage, KeyUsage, ScanResult, ScanUnit } from '../scanner
 import { getPatternSet } from '../scanner/patterns.js'
 
 import { resolveReferenceLocale } from './shared.js'
-import { resolveReportFilePath, validateReportPath } from './report.js'
+import { resolveOutputFile, resolveReportFilePath, validateReportPath } from './report.js'
 import { buildOrphanScanPlan, resolveOrphanIgnorePatterns } from './ops-orphans.js'
 import { undefinedKeysToCodeQuality } from './codequality.js'
 
@@ -408,10 +408,8 @@ export async function checkUndefinedKeys(opts: {
     await writeCodequalityFile(opts.codequalityOutput, undefinedKeysToCodeQuality(undefinedKeys))
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_undefined_keys')
-  if (reportPath) {
-    validateReportPath(dir, reportPath)
-  }
+  const reportPath = resolveOutputFile(dir, opts.outputFile)
+    ?? resolveReportFilePath(config, dir, 'find_undefined_keys')
   if (reportPath) {
     await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
       tool: 'find_undefined_keys',

--- a/packages/cli/src/core/ops-duplicates.ts
+++ b/packages/cli/src/core/ops-duplicates.ts
@@ -12,7 +12,7 @@ import { getNestedValue, getLeafKeys } from '../io/key-operations.js'
 import { ToolError } from '../utils/errors.js'
 
 import { findLocaleImpl, findLocaleOrThrow } from './shared.js'
-import { resolveReportFilePath } from './report.js'
+import { resolveOutputFile, resolveReportFilePath } from './report.js'
 
 export interface DuplicateKeyCollision {
   key: string
@@ -185,7 +185,7 @@ export async function findDuplicateKeys(opts: {
     summary,
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_duplicate_keys')
+  const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'find_duplicate_keys')
   if (reportPath) {
     await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
       tool: 'find_duplicate_keys',

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -17,7 +17,7 @@ import { getPatternSet } from '../scanner/patterns.js'
 import { ToolError } from '../utils/errors.js'
 
 import { findLayerOrThrow, resolveReferenceLocale } from './shared.js'
-import { validateReportPath, resolveReportFilePath } from './report.js'
+import { validateReportPath, resolveOutputFile, resolveReportFilePath } from './report.js'
 import { orphanKeysToCodeQuality, referenceLocaleAnchorPaths } from './codequality.js'
 
 const MISPLACED_USAGE_NOTE
@@ -216,7 +216,7 @@ export async function findOrphanKeys(opts: {
 
   if (totalKeys === 0) {
     const emptyOutput = { orphanKeys: {} as Record<string, string[]>, summary: { totalKeys: 0, orphanCount: 0, filesScanned: 0, message: 'No translation keys found in locale files.' } }
-    const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
+    const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
     if (reportPath) {
       await writeReportFile(reportPath, emptyOutput, {
         tool: 'find_orphan_keys',
@@ -282,7 +282,7 @@ export async function findOrphanKeys(opts: {
       : undefined,
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
+  const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'find_orphan_keys',
@@ -365,7 +365,7 @@ export async function scanCodeUsage(opts: {
     }))
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'scan_code_usage')
+  const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'scan_code_usage')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'scan_code_usage',
@@ -416,9 +416,8 @@ export async function removeOrphanKeys(opts: {
   if (totalKeys === 0) {
     await writeCodequality({})
     const emptyOutput = { orphanKeys: {}, removed: {}, summary: { totalKeys: 0, orphanCount: 0, message: 'No translation keys found.' } }
-    const emptyReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
+    const emptyReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (emptyReportPath) {
-      validateReportPath(dir, emptyReportPath)
       await writeReportFile(emptyReportPath, emptyOutput, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
@@ -459,9 +458,8 @@ export async function removeOrphanKeys(opts: {
       misplacedUsageNote,
       summary: { totalKeys, orphanCount: 0, uncertainCount: orphanResult.uncertainCount, misplacedCount, dynamicMatchedCount, ignoredCount, filesScanned: totalFilesScanned, scanScope, message: messageParts.join(' ') },
     }
-    const zeroReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
+    const zeroReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (zeroReportPath) {
-      validateReportPath(dir, zeroReportPath)
       await writeReportFile(zeroReportPath, zeroOutput, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
@@ -505,9 +503,8 @@ export async function removeOrphanKeys(opts: {
         suggestedIgnorePattern: w.suggestedIgnorePattern,
       }))
     }
-    const dryRunReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
+    const dryRunReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (dryRunReportPath) {
-      validateReportPath(dir, dryRunReportPath)
       await writeReportFile(dryRunReportPath, output, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
@@ -561,9 +558,8 @@ export async function removeOrphanKeys(opts: {
     },
   }
 
-  const removalReportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
+  const removalReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
   if (removalReportPath) {
-    validateReportPath(dir, removalReportPath)
     await writeReportFile(removalReportPath, removalOutput, {
       tool: 'remove_orphan_keys',
       args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },

--- a/packages/cli/src/core/ops-read.ts
+++ b/packages/cli/src/core/ops-read.ts
@@ -14,7 +14,7 @@ import { ToolError } from '../utils/errors.js'
 
 import type { LocaleDirInfo, SearchMatch } from './types.js'
 import { findLayerOrThrow, findReferenceLocaleOrThrow, findLocaleImpl, localeRefInfo } from './shared.js'
-import { resolveReportFilePath } from './report.js'
+import { resolveOutputFile, resolveReportFilePath } from './report.js'
 
 /**
  * Detect the i18n configuration from the project, always bypassing the
@@ -237,7 +237,7 @@ export async function getMissingTranslations(opts: {
     },
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'get_missing_translations')
+  const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'get_missing_translations')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'get_missing_translations',
@@ -313,7 +313,7 @@ export async function findEmptyTranslations(opts: {
     },
   }
 
-  const reportPath = opts.outputFile ?? resolveReportFilePath(config, dir, 'find_empty_translations')
+  const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'find_empty_translations')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'find_empty_translations',
@@ -398,7 +398,7 @@ export async function searchTranslations(opts: {
 
   const output = { matches, totalMatches: matches.length }
 
-  const reportPath = outputFile ?? resolveReportFilePath(config, dir, 'search_translations')
+  const reportPath = resolveOutputFile(dir, outputFile) ?? resolveReportFilePath(config, dir, 'search_translations')
   if (reportPath) {
     await writeReportFile(reportPath, output, {
       tool: 'search_translations',

--- a/packages/cli/src/core/report.ts
+++ b/packages/cli/src/core/report.ts
@@ -22,6 +22,23 @@ export function validateReportPath(baseDir: string, absPath: string): void {
   }
 }
 
+/**
+ * Resolve a caller-supplied outputFile against the project dir. Relative
+ * paths must anchor to `dir`, not the process cwd — otherwise
+ * `--output-file report.json --project-dir /x` run from elsewhere can never
+ * pass the in-project guard. Absolute paths pass through unchanged; either
+ * way the result must stay within the project dir.
+ */
+export function resolveOutputFile(
+  dir: string,
+  outputFile: string | undefined,
+): string | undefined {
+  if (!outputFile) return undefined
+  const absPath = resolve(dir, outputFile)
+  validateReportPath(dir, absPath)
+  return absPath
+}
+
 export function resolveReportFilePath(
   config: I18nConfig,
   dir: string,

--- a/packages/cli/tests/cli/bin-streams.test.ts
+++ b/packages/cli/tests/cli/bin-streams.test.ts
@@ -64,10 +64,17 @@ describe('bin stream routing', () => {
       await rm(emptyDir, { recursive: true, force: true })
     })
 
-    it('keeps stdout empty when a command fails — diagnostics go to stderr', async () => {
+    // Failures must keep stdout parseable (#266): a JSON consumer piping
+    // stdout into jq must never receive zero bytes.
+    it('emits a structured JSON error on stdout when a command fails — diagnostics go to stderr', async () => {
       const { stdout, stderr, code } = await runBin(['missing', '--layer', 'root'], emptyDir)
       expect(code).toBe(1)
-      expect(stdout).toBe('')
+      expect(JSON.parse(stdout)).toMatchObject({
+        error: {
+          code: 'CONFIG_ERROR',
+          message: expect.stringContaining('No framework detected'),
+        },
+      })
       expect(stderr).not.toBe('')
     })
   })

--- a/packages/cli/tests/cli/json-error-output.test.ts
+++ b/packages/cli/tests/cli/json-error-output.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+/**
+ * JSON-mode failure output (#266): when a command run throws, stdout must
+ * still carry parseable JSON — consumers pipe it into jq, and zero bytes is
+ * a parse error. The structured `{ error: { code, message } }` object is the
+ * result; the exit code stays non-zero.
+ */
+
+// writeResult bypasses stdout spies via a bound reference captured at module
+// load — mock the guard so command output stays out of the test stream.
+vi.mock('../../src/utils/stdout-guard.js', () => ({
+  guardStdout: vi.fn(),
+  writeResult: vi.fn(),
+}))
+
+const { writeResult } = await import('../../src/utils/stdout-guard.js')
+const { createCommand, emitErrorResult } = await import('../../src/commands/_shared.js')
+const { ToolError } = await import('../../src/utils/errors.js')
+
+const writeResultMock = vi.mocked(writeResult)
+
+const savedExitCode = process.exitCode
+
+afterEach(() => {
+  process.exitCode = savedExitCode
+  writeResultMock.mockClear()
+})
+
+function lastStdoutJson(): unknown {
+  const calls = writeResultMock.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return JSON.parse(calls[calls.length - 1]![0])
+}
+
+describe('createCommand error path', () => {
+  const runFailing = async (error: unknown): Promise<void> => {
+    const cmd = createCommand({
+      name: 'fake-fail',
+      description: 'test double',
+      run: async () => {
+        throw error
+      },
+    }) as unknown as { run: (ctx: { args: Record<string, unknown> }) => Promise<void> }
+    await cmd.run({ args: { json: true } })
+  }
+
+  it('emits a structured error object on stdout and sets exitCode 1', async () => {
+    await runFailing(new ToolError('report path escapes the project dir', 'INVALID_REPORT_PATH'))
+
+    expect(lastStdoutJson()).toEqual({
+      error: {
+        code: 'INVALID_REPORT_PATH',
+        message: 'report path escapes the project dir',
+      },
+    })
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('falls back to UNKNOWN_ERROR for errors without a code', async () => {
+    await runFailing(new Error('boom'))
+
+    expect(lastStdoutJson()).toEqual({
+      error: { code: 'UNKNOWN_ERROR', message: 'boom' },
+    })
+    expect(process.exitCode).toBe(1)
+  })
+})
+
+describe('emitErrorResult mode gating', () => {
+  it('emits JSON when stdout is not a TTY even without --json', () => {
+    // Vitest pipes stdout, so isTTY is falsy — matches outputResult's gating.
+    emitErrorResult(new ToolError('nope', 'CODE_X'), { json: false })
+    expect(lastStdoutJson()).toEqual({ error: { code: 'CODE_X', message: 'nope' } })
+  })
+
+  it('keeps stdout untouched in interactive non-JSON mode', () => {
+    const original = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      emitErrorResult(new Error('boom'), { json: false })
+      expect(writeResultMock).not.toHaveBeenCalled()
+    } finally {
+      if (original) Object.defineProperty(process.stdout, 'isTTY', original)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+  })
+})

--- a/packages/cli/tests/tools/check-undefined.test.ts
+++ b/packages/cli/tests/tools/check-undefined.test.ts
@@ -244,6 +244,22 @@ describe('checkUndefinedKeys — scope-aware', () => {
     expect(report.undefinedKeys).toHaveLength(2)
   })
 
+  it('resolves a relative outputFile against the project dir, not the process cwd', async () => {
+    const result = await checkUndefinedKeys({ projectDir, outputFile: 'undefined-report-rel.json' })
+
+    const expectedPath = join(projectDir, 'undefined-report-rel.json')
+    expect(result).toMatchObject({ reportFile: expectedPath })
+
+    const report = JSON.parse(await readFile(expectedPath, 'utf-8')) as Record<string, unknown>
+    expect(report.tool).toBe('find_undefined_keys')
+  })
+
+  it('rejects a relative outputFile escaping the project dir', async () => {
+    await expect(
+      checkUndefinedKeys({ projectDir, outputFile: '../escape.json' }),
+    ).rejects.toThrow(/resolves outside the project directory/)
+  })
+
   it('honors codequalityOutput: writes a CodeClimate array alongside the normal report', async () => {
     const reportPath = join(projectDir, 'undefined-report-cq.json')
     const cqPath = join(projectDir, 'gl-codequality.json')

--- a/packages/cli/tests/tools/output-file-param.test.ts
+++ b/packages/cli/tests/tools/output-file-param.test.ts
@@ -3,6 +3,7 @@
  *
  * Verifies:
  * - When `outputFile` is provided, op writes JSON to disk and returns `{ reportFile, summary }`.
+ * - Relative paths resolve against the project dir, not the process cwd (#266).
  * - Paths outside the project directory are rejected even when `outputFile` is explicit.
  * - When `outputFile` is absent and no config-level `reportOutput`, full payload is returned inline.
  */
@@ -60,11 +61,27 @@ describe('getMissingTranslations — outputFile', () => {
     expect(parsed).toHaveProperty('missing')
   })
 
-  it('accepts explicit outputFile path (even outside project dir)', async () => {
+  it('resolves a relative outputFile against the project dir, not the process cwd', async () => {
+    const result = await getMissingTranslations({
+      projectDir: appAdminDir,
+      outputFile: '.i18n-reports/missing-rel.json',
+    })
+    expect(result).toHaveProperty('reportFile', join(appAdminDir, '.i18n-reports', 'missing-rel.json'))
+    const raw = await readFile(join(appAdminDir, '.i18n-reports', 'missing-rel.json'), 'utf-8')
+    expect(JSON.parse(raw)).toHaveProperty('tool', 'get_missing_translations')
+  })
+
+  it('rejects an outputFile outside the project dir', async () => {
     const outPath = join(tmpDir, 'missing-tmp.json')
     await expect(
       getMissingTranslations({ projectDir: appAdminDir, outputFile: outPath }),
-    ).resolves.toBeDefined()
+    ).rejects.toThrow(/resolves outside the project directory/)
+  })
+
+  it('rejects a relative outputFile escaping the project dir', async () => {
+    await expect(
+      getMissingTranslations({ projectDir: appAdminDir, outputFile: '../escape.json' }),
+    ).rejects.toThrow(/resolves outside the project directory/)
   })
 
   it('returns full inline payload when outputFile is absent', async () => {
@@ -95,11 +112,11 @@ describe('findEmptyTranslations — outputFile', () => {
     expect(parsed).toHaveProperty('emptyKeys')
   })
 
-  it('accepts explicit outputFile path (even outside project dir)', async () => {
+  it('rejects an outputFile outside the project dir', async () => {
     const outPath = join(tmpDir, 'empty-tmp.json')
     await expect(
       findEmptyTranslations({ projectDir: appAdminDir, outputFile: outPath }),
-    ).resolves.toBeDefined()
+    ).rejects.toThrow(/resolves outside the project directory/)
   })
 
   it('returns full inline payload when outputFile is absent', async () => {
@@ -130,11 +147,11 @@ describe('findOrphanKeys — outputFile', () => {
     expect(parsed).toHaveProperty('orphanKeys')
   })
 
-  it('accepts explicit outputFile path (even outside project dir)', async () => {
+  it('rejects an outputFile outside the project dir', async () => {
     const outPath = join(tmpDir, 'orphans-tmp.json')
     await expect(
       findOrphanKeys({ projectDir: playgroundDir, outputFile: outPath }),
-    ).resolves.toBeDefined()
+    ).rejects.toThrow(/resolves outside the project directory/)
   })
 
   it('returns full inline payload when outputFile is absent', async () => {
@@ -165,11 +182,11 @@ describe('scanCodeUsage — outputFile', () => {
     expect(parsed).toHaveProperty('usages')
   })
 
-  it('accepts explicit outputFile path (even outside project dir)', async () => {
+  it('rejects an outputFile outside the project dir', async () => {
     const outPath = join(tmpDir, 'scan-tmp.json')
     await expect(
       scanCodeUsage({ projectDir: playgroundDir, outputFile: outPath }),
-    ).resolves.toBeDefined()
+    ).rejects.toThrow(/resolves outside the project directory/)
   })
 
   it('returns full inline payload when outputFile is absent', async () => {
@@ -198,6 +215,21 @@ describe('removeOrphanKeys — outputFile', () => {
     const raw = await readFile(outPath, 'utf-8')
     const parsed = JSON.parse(raw)
     expect(parsed).toHaveProperty('tool', 'remove_orphan_keys')
+  })
+
+  it('resolves a relative outputFile against the project dir in dry-run mode', async () => {
+    const result = await removeOrphanKeys({
+      projectDir: playgroundDir,
+      dryRun: true,
+      outputFile: '.i18n-reports/cleanup-rel.json',
+    })
+    expect(result).toHaveProperty('reportFile', join(playgroundDir, '.i18n-reports', 'cleanup-rel.json'))
+  })
+
+  it('rejects a relative outputFile escaping the project dir', async () => {
+    await expect(
+      removeOrphanKeys({ projectDir: playgroundDir, dryRun: true, outputFile: '../escape.json' }),
+    ).rejects.toThrow(/resolves outside the project directory/)
   })
 
   it('rejects paths outside project dir (internal auto-generated paths are validated)', async () => {


### PR DESCRIPTION
Two related paper cuts from battle testing (#266).

## Relative `--output-file` resolved against the process cwd

`--output-file report.json --project-dir /x` run from elsewhere could never pass the in-project guard. Caller-supplied `outputFile` now flows through a single helper, `resolveOutputFile(dir, outputFile)` in `core/report.ts`, used at every consumption site (ops-check, ops-orphans x6, ops-duplicates, ops-read x3):

- relative paths anchor to the resolved project dir, not the cwd
- absolute paths pass through unchanged
- the in-project guard (`validateReportPath`) applies uniformly — previously `find_orphan_keys`, `scan_code_usage`, `get_missing_translations`, and `find_empty_translations` skipped it entirely while `check` and `remove-orphans` enforced it; per-site duplicate validate calls are gone

Behavior note: ops that formerly accepted absolute out-of-project paths now reject them, matching the guard the other ops already enforced. Tests documenting the old accept-behavior were updated, and the README example (`/tmp/orphans.json`, which `remove-orphans` already rejected) now shows the relative form.

## JSON-mode failures left stdout at zero bytes

A failing command wrote only to stderr, so consumers piping stdout into jq choked on an empty stream. `createCommand` now catches `run()` errors and emits `{"error":{"code","message"}}` through `writeResult` (the stdout-guard's pure-JSON path); `cli.ts` reuses the same `emitErrorResult` for pre-run failures (unknown command, arg parsing). Codes come from `ToolError`/`FileIOError` (`INVALID_REPORT_PATH`, `ENOENT`, …), `ConfigError` maps to `CONFIG_ERROR`, everything else to `UNKNOWN_ERROR`. Exit code stays non-zero; the human-readable message stays on stderr. TTY sessions without `--json` keep the current stderr-only behavior.

## Tests

- `tests/tools/output-file-param.test.ts` / `check-undefined.test.ts`: relative outputFile + explicit projectDir writes inside the project dir; `../escape.json` and out-of-project absolute paths rejected across ops
- `tests/cli/json-error-output.test.ts` (new): structured error object on stdout with correct code, `UNKNOWN_ERROR` fallback, exit code 1, TTY gating
- `tests/cli/bin-streams.test.ts`: e2e — failing built binary now emits parseable `{error}` JSON on stdout, diagnostics on stderr

Validation: `pnpm --filter the-i18n-cli build`, `pnpm -r test` (744 passing), `pnpm -r --filter='./packages/*' typecheck`, `pnpm lint`, `npx fallow audit --base origin/main` (exit 0) all green.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)