### PR TITLE
fix(cli): restrict bare-template collector to key-shaped candidates

### DIFF
--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -239,7 +239,19 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
   let filesScanned = 0
 
   const BARE_DOTTED_STRING = /(['"])((?:[\w-]+\.)+[\w-]+)\1/g
-  const BARE_DYNAMIC_TEMPLATE = /`([^`\\\n]{0,200}\$\{[^`\\\n]{0,200})`/g
+  /**
+   * Matches bare template literals with i18n-key shape, regardless of call
+   * context: content outside `${...}` interpolations restricted to key-like
+   * chars ([\w.-], mirroring BARE_PHP_DYNAMIC), at least one interpolation
+   * (single-level brace nesting), no newlines. A permissive backtick-to-next-
+   * backtick match turns every stray backtick (comments, strings, markdown)
+   * into a mega-expression swallowing whole code spans — bloating reports and
+   * compiling to over-matching dynamic-key regexes when it starts with an
+   * interpolation.
+   */
+  const BARE_DYNAMIC_TEMPLATE = /`([\w.-]*(?:\$\{(?:[^`{}\n]|\{[^`{}\n]*\})*\}[\w.-]*)+)`/g
+  /** Longer candidates cannot plausibly be i18n keys — drop, don't truncate. */
+  const MAX_BARE_TEMPLATE_LENGTH = 120
   /**
    * Matches PHP double-quoted interpolated strings with i18n-key shape,
    * regardless of call context — `$transKey = "api.x.{$key}"` assigned first
@@ -283,8 +295,12 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     BARE_DYNAMIC_TEMPLATE.lastIndex = 0
     for (const match of content.matchAll(BARE_DYNAMIC_TEMPLATE)) {
       const expr = match[1]
-      if (!expr?.includes('.')) continue
+      if (!expr || expr.length > MAX_BARE_TEMPLATE_LENGTH) continue
       const normalized = expr.replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '${_}')
+      // The dot must survive interpolation stripping (like BARE_PHP_DYNAMIC):
+      // `${a.b}` alone has no literal key segment and would compile to a
+      // match-any-single-segment regex.
+      if (!normalized.replace(/\$\{_\}/g, '').includes('.')) continue
       bareDynamicCandidates.add(`\`${normalized}\``)
     }
 

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extractKeys, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
+import { extractKeys, findOrphanKeysForConfig, scanSourceFiles, toRelativePath, buildDynamicKeyRegexes, buildIgnorePatternRegexes } from '../../src/scanner/code-scanner.js'
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
@@ -605,8 +605,9 @@ describe('scanSourceFiles', () => {
     expect(result.filesScanned).toBe(0)
   })
 
-  it('extracts bare dynamic candidates from template literals with dots and interpolation', async () => {
+  it('extracts bare dynamic candidates from key-shaped template literals with dots and interpolation', async () => {
     await writeFile(join(tmpDir, 'Component.vue'), [
+      // #275 — URLs are not key-shaped (`:`, `/`) and are no longer candidates.
       'const url = `https://api.example.com/${id}`',
       'const label = `common.plans.trialPeriod.${interval}`',
       'const title = `pages.${section}.items.${id}.label`',
@@ -614,8 +615,7 @@ describe('scanSourceFiles', () => {
     ].join('\n'))
 
     const result = await scanSourceFiles(tmpDir)
-    expect(result.bareDynamicCandidates.size).toBe(3)
-    expect(result.bareDynamicCandidates.has('`https://api.example.com/${_}`')).toBe(true)
+    expect(result.bareDynamicCandidates.size).toBe(2)
     expect(result.bareDynamicCandidates.has('`common.plans.trialPeriod.${_}`')).toBe(true)
     expect(result.bareDynamicCandidates.has('`pages.${_}.items.${_}.label`')).toBe(true)
   })
@@ -653,6 +653,69 @@ describe('scanSourceFiles', () => {
     expect(result.bareDynamicCandidates.has('`api.orders.status.${_}`')).toBe(true)
     const regexes = buildDynamicKeyRegexes([...result.bareDynamicCandidates].map(e => ({ expression: e })))
     expect(regexes.some(re => re.test('api.orders.status.open'))).toBe(true)
+  })
+
+  // #275 — a stray backtick must not turn the span to the next backtick into a
+  // mega-expression; only candidates with i18n-key shape survive.
+  describe('bare-template mega-capture rejection (#275)', () => {
+    it('rejects stray-backtick spans and prose templates, keeps key-shaped ones', async () => {
+      await writeFile(join(tmpDir, 'Stray.vue'), [
+        // Stray backtick followed by `${` inside a string: the permissive
+        // collector captured `${', x.count, ` here (quote-parity poisoning)
+        // and LOST the genuine template that follows on the same line.
+        "const row = fmt('`${', x.count, `${sep}.list.end`)",
+        'const msg = `Deleted ${count} rows. Undo?`',
+        'const key = `pages.${section}.title`',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir)
+      expect(result.bareDynamicCandidates).toEqual(new Set([
+        '`${_}.list.end`',
+        '`pages.${_}.title`',
+      ]))
+    })
+
+    it('drops key-shaped candidates over the max plausible key length', async () => {
+      const longKey = 'seg.'.repeat(40) // 160 chars of valid key charset
+      await writeFile(join(tmpDir, 'Long.vue'), [
+        `const long = \`${longKey}\${x}\``,
+        'const ok = `common.actions.${action}`',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir)
+      expect(result.bareDynamicCandidates).toEqual(new Set(['`common.actions.${_}`']))
+    })
+
+    it('rejects interpolation-only templates whose dot sits inside the interpolation', async () => {
+      await writeFile(join(tmpDir, 'InterpOnly.vue'), [
+        'const v = `${config.mode}`',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir)
+      expect(result.bareDynamicCandidates.size).toBe(0)
+    })
+
+    it('ground truth: a mega-capture regex must not suppress unrelated orphans', async () => {
+      // The old capture `${', x.count, ` compiled to /^[^.]+$/ and dynamic-
+      // matched EVERY single-segment key; 'promo' must stay a safe orphan.
+      // The recovered genuine `${_}.list.end` still vouches for themes.list.end.
+      await writeFile(join(tmpDir, 'Stray.vue'), [
+        "const row = fmt('`${', x.count, `${sep}.list.end`)",
+        "const title = t('pages.home.title')",
+      ].join('\n'))
+
+      const result = await findOrphanKeysForConfig({
+        keysByLayer: new Map([['root', {
+          keys: ['promo', 'themes.list.end', 'pages.home.title'],
+          localeDir: { layer: 'root' },
+        }]]),
+        resolveIgnorePatterns: () => undefined,
+        scanDirs: [tmpDir],
+      })
+
+      expect(result.orphansByLayer.root ?? []).toEqual(['promo'])
+      expect(result.dynamicMatchedCount).toBe(1)
+    })
   })
 })
 


### PR DESCRIPTION
## What

`BARE_DYNAMIC_TEMPLATE` matched any backtick-to-next-backtick span containing `${` — so every stray backtick (comments, strings, markdown snippets) turned surrounding code into a garbage "expression", and prose templates (`` `Deleted ${count} rows. Undo?` ``) became candidates too. When such a capture starts with an interpolation it compiles to a dynamic-match regex with a leading `[^.]+` that can silently suppress genuine orphans.

This mirrors the `BARE_PHP_DYNAMIC` quote-parity fix from #269 for the JS/TS side:

- content outside `${...}` interpolations restricted to key-shaped chars (`[\w.-]`), no newlines, single-level brace nesting inside interpolations:
  ```
  /`([\w.-]*(?:\$\{(?:[^`{}\n]|\{[^`{}\n]*\})*\}[\w.-]*)+)`/g
  ```
- the dot must survive interpolation stripping (`` `${a.b}` `` alone would compile to a match-any-single-segment regex)
- candidates over 120 chars are dropped, not truncated

Only the bare fallback changes — located (call-context) template extraction is untouched. `BARE_PREFIX_LITERAL` is already shape-restricted and needed no change. Bonus symmetry with the PHP fix: quote-parity poisoning previously *lost* genuine templates following a stray backtick on the same line — those are now collected.

## Real-repo verification (anny-ui, read-only dry runs)

Baseline = current `origin/main` (which already includes #269 — the pre-#269 report the issue was probed against had the 952 mega-expressions / ~3.3 MB; #269's PHP parity fix removed the multi-line blobs, this PR removes the remaining single-line garbage):

| unique dynamicKeys expressions | before | after |
|---|---|---|
| total | 994 | **432** |
| >200 chars | 0 | **0** |
| >120 chars | 3 | **0** |
| non-key-shaped (prose/punctuation) | 416 | **5**¹ |
| starting with `${_}` | 262 | **69** |

¹ all 5 are genuine *located* `t()` calls with complex interpolations (e.g. `` `common.datetime.weekdays.${WeekDayKeys[nextStart.isoWeekday()]}` ``) — located extraction is intentionally untouched.

| | before | after |
|---|---|---|
| report size | 223 kB | **184 kB** |
| safe orphans | 1493 | 1493 |
| uncertain | 31 | 31 |
| dynamic-matched | 562 | 562 |
| misplaced | 143 | 143 |

`orphanKeys` and `uncertainKeys` are **byte-identical** before/after — on this baseline none of the 562 garbage regexes happened to suppress a real key (the over-suppression risk was latent, not active), and no genuine candidate was lost. Pure precision/report-hygiene win plus hardening.

## Tests

- stray backtick + `${` poisoning produces no mega candidate AND the genuine template on the same line is recovered (parity twin of the #269 PHP test)
- prose templates and URLs are no longer candidates; key-shaped `` `foo.${x}.bar` `` shapes still collected
- >120-char key-shaped candidates dropped; interpolation-only (`` `${config.mode}` ``) rejected
- ground truth via `findOrphanKeysForConfig`: the old `/^[^.]+$/` mega-capture regex no longer suppresses an unrelated single-segment key (stays a safe orphan) while the recovered candidate still dynamic-matches its family

Validation: cli build ✓, `pnpm -r test` 724+24 pass ✓, typecheck ✓, lint 0 errors ✓, `npx fallow audit --base origin/main` exit 0, no issues in changed files ✓.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
