### PR TITLE
feat(cli): provider baseUrl via flag, env and project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,27 @@ the-i18n-cli translate --layer root --provider google --model gemini-2.5-flash
 | `I18N_PROVIDER` | `openai`, `anthropic`, or `google` |
 | `I18N_MODEL` | Model name (e.g. `gemini-2.5-flash`) |
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | API key matching the provider |
+| `I18N_BASE_URL` | Optional provider base URL (see below) |
 
 Partial configuration (e.g. provider without model or key) logs a warning to stderr and falls back to agent mode — a misconfigured server never surprises callers per-request.
+
+### Custom provider endpoints
+
+Point the `openai` or `anthropic` provider at any compatible endpoint — a local model (Ollama, LiteLLM), an OpenAI-compatible gateway (OpenRouter, Azure OpenAI), or a corporate proxy. Three sources, highest precedence first:
+
+```bash
+the-i18n-cli translate --layer root --provider openai --model llama3 --baseUrl http://localhost:11434/v1
+```
+
+| Source | Scope |
+|--------|-------|
+| `--baseUrl` | One invocation |
+| `I18N_BASE_URL` | The environment, including the MCP server process |
+| `providerBaseUrl` in `.i18n-mcp.json` | The whole project, shared through the repo |
+
+A blank `--baseUrl` or `I18N_BASE_URL` counts as unset, so an exported-but-empty variable can't silently disable an endpoint configured further down the chain. A blank `providerBaseUrl` in the config file is rejected at load time instead — unlike a shell variable, it can't get there by accident.
+
+The `google` provider has no endpoint override — passing a base URL with it is rejected as a configuration error rather than ignored.
 
 ### Agent mode
 
@@ -377,6 +396,7 @@ This context is automatically loaded on `discover` before any translation work, 
 | `defaultLocale` | Default locale code (required for generic adapter) |
 | `locales` | Explicit list of locale codes |
 | `localeFileFormat` | Override the auto-detected locale file format (`"json"` or `"php-array"`) |
+| `providerBaseUrl` | Provider base URL for OpenAI-compatible gateways, local models and proxies — see [Custom provider endpoints](#custom-provider-endpoints) |
 
 `samplingPreferences` is deprecated and ignored (MCP sampling was removed). It is still accepted so existing config files keep validating — configure a provider instead (see [Translation Modes](#translation-modes)).
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ Partial configuration (e.g. provider without model or key) logs a warning to std
 
 ### Custom provider endpoints
 
-Point the `openai` or `anthropic` provider at any compatible endpoint — a local model (Ollama, LiteLLM), an OpenAI-compatible gateway (OpenRouter, Azure OpenAI), or a corporate proxy. Three sources, highest precedence first:
+Point the `openai` or `anthropic` provider at any endpoint that speaks the same protocol — a gateway such as OpenRouter or LiteLLM, a self-hosted model server, or a corporate proxy. Three sources, highest precedence first:
 
 ```bash
-the-i18n-cli translate --layer root --provider openai --model llama3 --baseUrl http://localhost:11434/v1
+the-i18n-cli translate --layer root --provider openai --model llama3 \
+  --baseUrl http://localhost:11434/v1 --apiKey unused
 ```
 
 | Source | Scope |
@@ -132,6 +133,10 @@ the-i18n-cli translate --layer root --provider openai --model llama3 --baseUrl h
 | `--baseUrl` | One invocation |
 | `I18N_BASE_URL` | The environment, including the MCP server process |
 | `providerBaseUrl` in `.i18n-mcp.json` | The whole project, shared through the repo |
+
+An API key is still required even when the endpoint ignores it — pass any placeholder for a local server.
+
+This overrides the endpoint only. Providers that also change the request shape or auth header, Azure OpenAI among them, need their own client and are not reachable this way.
 
 A blank `--baseUrl` or `I18N_BASE_URL` counts as unset, so an exported-but-empty variable can't silently disable an endpoint configured further down the chain. A blank `providerBaseUrl` in the config file is rejected at load time instead — unlike a shell variable, it can't get there by accident.
 
@@ -396,7 +401,7 @@ This context is automatically loaded on `discover` before any translation work, 
 | `defaultLocale` | Default locale code (required for generic adapter) |
 | `locales` | Explicit list of locale codes |
 | `localeFileFormat` | Override the auto-detected locale file format (`"json"` or `"php-array"`) |
-| `providerBaseUrl` | Provider base URL for OpenAI-compatible gateways, local models and proxies — see [Custom provider endpoints](#custom-provider-endpoints) |
+| `providerBaseUrl` | Provider base URL for protocol-compatible gateways, self-hosted models and proxies — see [Custom provider endpoints](#custom-provider-endpoints) |
 
 `samplingPreferences` is deprecated and ignored (MCP sampling was removed). It is still accepted so existing config files keep validating — configure a provider instead (see [Translation Modes](#translation-modes)).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,6 +72,14 @@ the-i18n-cli translate --layer root --provider google --model gemini-2.5-flash
 the-i18n-cli translate --layer root --targets de-DE,fr-FR --batchSize 25 --provider openai --model gpt-4o-mini
 ```
 
+For an OpenAI-compatible gateway, a local model or a proxy, add `--baseUrl` — or set `I18N_BASE_URL`, or `providerBaseUrl` in `.i18n-mcp.json`, in that order of precedence:
+
+```bash
+the-i18n-cli translate --layer root --provider openai --model llama3 --baseUrl http://localhost:11434/v1
+```
+
+`google` has no endpoint override, so a base URL with it is rejected as a configuration error rather than silently ignored.
+
 **Agent mode** — no `--provider` given. Nothing is translated: keys are reported as `skipped` with reason `no-provider`, and the result explains how to enable provider mode. (In the MCP server, agent mode instead returns fallback contexts for the host agent — see [the-i18n-mcp](https://www.npmjs.com/package/the-i18n-mcp).)
 
 ### Result contract

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,11 +72,14 @@ the-i18n-cli translate --layer root --provider google --model gemini-2.5-flash
 the-i18n-cli translate --layer root --targets de-DE,fr-FR --batchSize 25 --provider openai --model gpt-4o-mini
 ```
 
-For an OpenAI-compatible gateway, a local model or a proxy, add `--baseUrl` — or set `I18N_BASE_URL`, or `providerBaseUrl` in `.i18n-mcp.json`, in that order of precedence:
+To reach an endpoint that speaks the same protocol — a gateway, a self-hosted model server, a proxy — add `--baseUrl`, or set `I18N_BASE_URL`, or `providerBaseUrl` in `.i18n-mcp.json`, in that order of precedence:
 
 ```bash
-the-i18n-cli translate --layer root --provider openai --model llama3 --baseUrl http://localhost:11434/v1
+the-i18n-cli translate --layer root --provider openai --model llama3 \
+  --baseUrl http://localhost:11434/v1 --apiKey unused
 ```
+
+An API key is still required even when the endpoint ignores it — pass any placeholder for a local server. This overrides the endpoint only, so providers that also change the request shape or auth header (Azure OpenAI among them) are not reachable this way.
 
 `google` has no endpoint override, so a base URL with it is rejected as a configuration error rather than silently ignored.
 

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -127,7 +127,7 @@ export const providerArgs = {
   provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
   model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
   apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
-  baseUrl: { type: 'string' as const, description: `Provider base URL for OpenAI-compatible gateways, local models and proxies. Falls back to ${BASE_URL_ENV}, then providerBaseUrl in .i18n-mcp.json. Not supported by "google".` },
+  baseUrl: { type: 'string' as const, description: `Provider base URL for gateways, self-hosted models and proxies speaking the provider's protocol. Falls back to ${BASE_URL_ENV}, then providerBaseUrl in .i18n-mcp.json. Not supported by "google".` },
 }
 
 /**

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -3,6 +3,10 @@ import type { CommandDef } from 'citty'
 import { log } from '../utils/logger.js'
 import { toErrorMessage } from '../utils/errors.js'
 import { writeResult } from '../utils/stdout-guard.js'
+import { createTranslateFn, resolveProviderBaseUrl, BASE_URL_ENV } from '../llm/providers.js'
+import type { LlmProvider } from '../llm/providers.js'
+import type { TranslateFn } from '../core/types.js'
+import { loadProjectConfig } from '../config/project-config.js'
 
 /** Factory for commands that call an operation and output its result. */
 export function createCommand(opts: {
@@ -116,6 +120,64 @@ function errorCode(error: unknown): string {
     if (error.name === 'ConfigError') return 'CONFIG_ERROR'
   }
   return 'UNKNOWN_ERROR'
+}
+
+/** Provider selection flags shared by the translate commands. */
+export const providerArgs = {
+  provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
+  model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
+  apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
+  baseUrl: { type: 'string' as const, description: `Provider base URL for OpenAI-compatible gateways, local models and proxies. Falls back to ${BASE_URL_ENV}, then providerBaseUrl in .i18n-mcp.json. Not supported by "google".` },
+}
+
+/**
+ * Build a TranslateFn from the provider flags, or undefined when no provider
+ * was given (agent mode). The base URL resolves flag > env > project config;
+ * the config file is only read when neither of the first two is set, so a
+ * fully-flagged invocation never depends on config discovery.
+ */
+export async function resolveProviderTranslateFn(args: {
+  provider?: string
+  model?: string
+  apiKey?: string
+  baseUrl?: string
+  projectDir?: string
+}): Promise<TranslateFn | undefined> {
+  if (!args.provider) return undefined
+  if (!args.model) {
+    throw new Error('--model is required when --provider is set')
+  }
+
+  let baseUrl = resolveProviderBaseUrl({ flag: args.baseUrl, env: process.env[BASE_URL_ENV] })
+  if (!baseUrl) {
+    const projectConfig = await loadProjectConfig(args.projectDir ?? process.cwd())
+    baseUrl = resolveProviderBaseUrl({ config: projectConfig?.providerBaseUrl })
+  }
+  if (baseUrl) log.debug(`Provider base URL: ${redactBaseUrl(baseUrl)}`)
+
+  return createTranslateFn({
+    provider: args.provider as LlmProvider,
+    model: args.model,
+    apiKey: args.apiKey,
+    baseUrl,
+  })
+}
+
+/**
+ * Strip anything secret-shaped from a base URL before it reaches a log.
+ * Gateways are routinely addressed as https://user:pass@host or with the key
+ * in a query parameter, so keep only origin and path.
+ */
+export function redactBaseUrl(raw: string): string {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return '<unparseable base URL>'
+  }
+  const credentials = url.username || url.password ? '<redacted>@' : ''
+  const query = url.search || url.hash ? ' (query redacted)' : ''
+  return `${url.protocol}//${credentials}${url.host}${url.pathname}${query}`
 }
 
 /** Split a comma-separated string into a trimmed array, or return undefined */

--- a/packages/cli/src/commands/translate-key.ts
+++ b/packages/cli/src/commands/translate-key.ts
@@ -1,8 +1,5 @@
-import { createCommand, splitList } from './_shared.js'
+import { createCommand, splitList, providerArgs, resolveProviderTranslateFn } from './_shared.js'
 import { translateKey } from '../core/operations.js'
-import { createTranslateFn } from '../llm/providers.js'
-import type { TranslateFn } from '../core/types.js'
-import type { LlmProvider } from '../llm/providers.js'
 
 export default createCommand({
   name: 'translate-key',
@@ -16,24 +13,12 @@ export default createCommand({
     overwrite: { type: 'boolean', description: 'Overwrite existing target translations (default true)', default: true },
     dryRun: { type: 'boolean', description: 'Preview without writing or translating', default: false },
     includePreview: { type: 'boolean', description: 'Include translated values in output', default: false },
-    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
-    model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
-    apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
+    ...providerArgs,
   },
   async run(args) {
     const targetLocales = args.targets === 'all' ? 'all' : splitList(args.targets)
 
-    let translateFn: TranslateFn | undefined
-    if (args.provider) {
-      if (!args.model) {
-        throw new Error('--model is required when --provider is set')
-      }
-      translateFn = await createTranslateFn({
-        provider: args.provider as LlmProvider,
-        model: args.model,
-        apiKey: args.apiKey,
-      })
-    }
+    const translateFn = await resolveProviderTranslateFn(args)
 
     const result = await translateKey({
       layer: args.layer,

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -1,7 +1,4 @@
-import { createCommand, splitList } from './_shared.js'
-import { createTranslateFn } from '../llm/providers.js'
-import type { TranslateFn } from '../core/types.js'
-import type { LlmProvider } from '../llm/providers.js'
+import { createCommand, splitList, providerArgs, resolveProviderTranslateFn } from './_shared.js'
 import { translateMissing } from '../core/operations.js'
 
 export default createCommand({
@@ -13,9 +10,7 @@ export default createCommand({
     targets: { type: 'string', description: 'Comma-separated target locales (default: all except ref)' },
     keys: { type: 'string', description: 'Comma-separated keys to translate (default: all missing)' },
     batchSize: { type: 'string', description: 'Batch size (default: 50)' },
-    provider: { type: 'string' as const, description: 'LLM provider: "openai", "anthropic", or "google". Required for automatic translation.', valueHint: 'openai|anthropic|google' },
-    model: { type: 'string' as const, description: 'Model name (required when --provider is set)' },
-    apiKey: { type: 'string' as const, description: 'API key (falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env).' },
+    ...providerArgs,
     dryRun: { type: 'boolean', description: 'Preview what would be translated', default: false },
   },
   async run(args) {
@@ -28,17 +23,7 @@ export default createCommand({
       batchSize = num
     }
 
-    let translateFn: TranslateFn | undefined
-    if (args.provider) {
-      if (!args.model) {
-        throw new Error('--model is required when --provider is set')
-      }
-      translateFn = await createTranslateFn({
-        provider: args.provider as LlmProvider,
-        model: args.model,
-        apiKey: args.apiKey,
-      })
-    }
+    const translateFn = await resolveProviderTranslateFn(args)
 
     const result = await translateMissing({
       layer: args.layer,

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -44,6 +44,7 @@ const projectConfigSchema = z.object({
   protectedLocales: z.array(nonEmptyString).optional(),
   reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
   localeFileFormat: z.enum(['json', 'php-array']).optional(),
+  providerBaseUrl: nonEmptyString.optional(),
   // Deprecated with the removal of MCP sampling: accepted so existing config
   // files keep validating (the schema is strict), warned about, and ignored.
   samplingPreferences: z.unknown().optional(),

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -83,6 +83,12 @@ export interface ProjectConfig {
   protectedLocales?: string[]
   /** Override the auto-detected locale file format. E.g., "json" or "php-array". Useful when both formats exist or auto-detection picks wrong. */
   localeFileFormat?: LocaleFileFormat
+  /**
+   * Base URL for the LLM provider, for OpenAI-compatible gateways, local
+   * models and corporate proxies. Overridden by the I18N_BASE_URL env var
+   * and by --baseUrl. Not supported by the "google" provider.
+   */
+  providerBaseUrl?: string
 }
 
 /**

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -84,9 +84,10 @@ export interface ProjectConfig {
   /** Override the auto-detected locale file format. E.g., "json" or "php-array". Useful when both formats exist or auto-detection picks wrong. */
   localeFileFormat?: LocaleFileFormat
   /**
-   * Base URL for the LLM provider, for OpenAI-compatible gateways, local
-   * models and corporate proxies. Overridden by the I18N_BASE_URL env var
-   * and by --baseUrl. Not supported by the "google" provider.
+   * Base URL for the LLM provider — gateways, self-hosted model servers and
+   * corporate proxies that speak the provider's own protocol. Overrides the
+   * endpoint only, not the request shape or auth header. Overridden by the
+   * I18N_BASE_URL env var and by --baseUrl. Not supported by "google".
    */
   providerBaseUrl?: string
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,5 +52,6 @@ export { readLocaleData } from './io/locale-data.js'
 export { ToolError, toErrorMessage } from './utils/errors.js'
 
 // LLM providers
-export { createTranslateFn, TranslateProviderError, classifyProviderError } from './llm/providers.js'
+export { createTranslateFn, TranslateProviderError, classifyProviderError, resolveProviderBaseUrl, BASE_URL_ENV } from './llm/providers.js'
+export { loadProjectConfig } from './config/project-config.js'
 export type { LlmProvider, LlmProviderConfig, TranslateProviderErrorKind } from './llm/providers.js'

--- a/packages/cli/src/llm/providers.ts
+++ b/packages/cli/src/llm/providers.ts
@@ -5,12 +5,15 @@ export type LlmProvider = 'openai' | 'anthropic' | 'google'
 // ─── Error classification ───────────────────────────────────────
 
 /** How a provider failure should be handled by the caller. */
-export type TranslateProviderErrorKind = 'auth' | 'rate-limit' | 'provider'
+export type TranslateProviderErrorKind = 'auth' | 'rate-limit' | 'provider' | 'config'
 
 /**
  * A classified provider failure. `auth` errors are not retryable (the caller
  * should abort the run), `rate-limit` errors should be retried with backoff,
  * and `provider` covers everything else (server errors, network, …).
+ * `config` marks an unusable provider setup and is raised while building the
+ * TranslateFn, before any request exists — so it surfaces from the command
+ * and never reaches the retry loop.
  */
 export class TranslateProviderError extends Error {
   public readonly kind: TranslateProviderErrorKind
@@ -59,6 +62,31 @@ export interface LlmProviderConfig {
   apiKey?: string
   /** Base URL override for proxies / compatible APIs */
   baseUrl?: string
+}
+
+/** Environment variable carrying the provider base URL override. */
+export const BASE_URL_ENV = 'I18N_BASE_URL'
+
+/**
+ * Resolve the provider base URL from its three sources, highest precedence
+ * first: an explicit flag, the I18N_BASE_URL env var, then the project
+ * config's `providerBaseUrl`.
+ *
+ * Blank values count as unset. Shells produce them routinely — `--baseUrl
+ * "$UNSET"` or an exported-but-empty variable — and a blank must not shadow a
+ * real endpoint configured further down the chain. A blank in the config file
+ * is a different case: it cannot arise by accident, so the strict schema
+ * rejects it at load time rather than letting it reach this function.
+ */
+export function resolveProviderBaseUrl(sources: {
+  flag?: string
+  env?: string
+  config?: string
+}): string | undefined {
+  for (const value of [sources.flag, sources.env, sources.config]) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return undefined
 }
 
 const ENV_KEY_MAP: Record<LlmProvider, string> = {
@@ -198,6 +226,16 @@ async function createAnthropicTranslateFn(config: LlmProviderConfig): Promise<Tr
  * Throws if the provider SDK is not installed or API key is missing.
  */
 export async function createTranslateFn(config: LlmProviderConfig): Promise<TranslateFn> {
+  // @google/genai exposes no endpoint override, so a base URL here would be
+  // silently ignored and translate against the wrong endpoint. Refuse loudly.
+  if (config.provider === 'google' && config.baseUrl) {
+    throw new TranslateProviderError(
+      'Provider "google" does not support a custom base URL. '
+      + `Remove --baseUrl / ${BASE_URL_ENV} / providerBaseUrl, or use an OpenAI-compatible provider.`,
+      'config',
+    )
+  }
+
   switch (config.provider) {
     case 'openai':
       return createOpenAiTranslateFn(config)

--- a/packages/cli/tests/config/project-config.test.ts
+++ b/packages/cli/tests/config/project-config.test.ts
@@ -225,6 +225,35 @@ describe('loadProjectConfig', () => {
     }
   })
 
+  it('accepts providerBaseUrl as a string', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({ providerBaseUrl: 'https://gateway.example/v1' }), 'utf-8')
+      const config = await loadProjectConfig(tmpDir)
+      expect(config!.providerBaseUrl).toBe('https://gateway.example/v1')
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
+  // A blank flag or env var is normalised to "unset" because shells produce
+  // those by accident. A blank in the config file cannot, so it is rejected
+  // here rather than silently ignored — matching every other string field.
+  it('rejects a blank providerBaseUrl instead of treating it as unset', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    const configPath = resolve(tmpDir, '.i18n-mcp.json')
+    try {
+      await writeFile(configPath, JSON.stringify({ providerBaseUrl: '' }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/providerBaseUrl/)
+
+      await writeFile(configPath, JSON.stringify({ providerBaseUrl: '   ' }), 'utf-8')
+      await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/providerBaseUrl/)
+    } finally {
+      if (existsSync(configPath)) await unlink(configPath)
+    }
+  })
+
   it('accepts orphanScan without ignorePatterns (optional field)', async () => {
     await mkdir(tmpDir, { recursive: true })
     const configPath = resolve(tmpDir, '.i18n-mcp.json')

--- a/packages/cli/tests/llm/providers.test.ts
+++ b/packages/cli/tests/llm/providers.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { TranslateProviderError, classifyProviderError } from '../../src/llm/providers.js'
+import {
+  TranslateProviderError,
+  classifyProviderError,
+  resolveProviderBaseUrl,
+  createTranslateFn,
+} from '../../src/llm/providers.js'
+import { redactBaseUrl } from '../../src/commands/_shared.js'
 
 /**
  * Unit tests for the provider error classification mapping. No SDKs are
@@ -64,5 +70,96 @@ describe('classifyProviderError', () => {
   it('passes an already-classified error through unchanged', () => {
     const original = new TranslateProviderError('key invalid', 'auth')
     expect(classifyProviderError(original)).toBe(original)
+  })
+})
+
+/**
+ * Base URL resolution is a pure precedence decision over three sources, so it
+ * is unit-tested without touching the SDKs or the filesystem.
+ */
+describe('resolveProviderBaseUrl', () => {
+  it('prefers the flag over env and config', () => {
+    expect(resolveProviderBaseUrl({
+      flag: 'https://flag.example',
+      env: 'https://env.example',
+      config: 'https://config.example',
+    })).toBe('https://flag.example')
+  })
+
+  it('falls back to env when no flag is given', () => {
+    expect(resolveProviderBaseUrl({
+      env: 'https://env.example',
+      config: 'https://config.example',
+    })).toBe('https://env.example')
+  })
+
+  it('falls back to config when neither flag nor env is given', () => {
+    expect(resolveProviderBaseUrl({ config: 'https://config.example' })).toBe('https://config.example')
+  })
+
+  it('returns undefined when every source is unset', () => {
+    expect(resolveProviderBaseUrl({})).toBeUndefined()
+  })
+
+  it('treats blank values as unset so an empty override cannot mask a real one', () => {
+    expect(resolveProviderBaseUrl({ flag: '', env: '   ', config: 'https://config.example' }))
+      .toBe('https://config.example')
+    expect(resolveProviderBaseUrl({ flag: '  ' })).toBeUndefined()
+  })
+
+  it('trims the resolved value', () => {
+    expect(resolveProviderBaseUrl({ flag: '  https://flag.example  ' })).toBe('https://flag.example')
+  })
+})
+
+describe('redactBaseUrl', () => {
+  it('keeps origin and path for a plain URL', () => {
+    expect(redactBaseUrl('https://gateway.example/v1')).toBe('https://gateway.example/v1')
+  })
+
+  it('removes user-info credentials', () => {
+    expect(redactBaseUrl('https://user:secret@gateway.example/v1'))
+      .toBe('https://<redacted>@gateway.example/v1')
+  })
+
+  it('removes a query string that could carry a key', () => {
+    const redacted = redactBaseUrl('https://gateway.example/v1?api-key=secret')
+    expect(redacted).not.toContain('secret')
+    expect(redacted).toBe('https://gateway.example/v1 (query redacted)')
+  })
+
+  it('removes a fragment', () => {
+    expect(redactBaseUrl('https://gateway.example/v1#token')).not.toContain('token')
+  })
+
+  it('keeps a non-default port, which is diagnostic rather than secret', () => {
+    expect(redactBaseUrl('http://localhost:11434/v1')).toBe('http://localhost:11434/v1')
+  })
+
+  it('never echoes an unparseable value', () => {
+    expect(redactBaseUrl('not a url')).toBe('<unparseable base URL>')
+  })
+})
+
+describe('createTranslateFn base URL support', () => {
+  it('rejects a base URL for google rather than silently ignoring it', async () => {
+    await expect(createTranslateFn({
+      provider: 'google',
+      model: 'gemini-2.0-flash',
+      apiKey: 'test-key',
+      baseUrl: 'https://proxy.example',
+    })).rejects.toMatchObject({
+      name: 'TranslateProviderError',
+      kind: 'config',
+    })
+  })
+
+  it('names the three ways a base URL could have been set', async () => {
+    await expect(createTranslateFn({
+      provider: 'google',
+      model: 'gemini-2.0-flash',
+      apiKey: 'test-key',
+      baseUrl: 'https://proxy.example',
+    })).rejects.toThrow(/--baseUrl \/ I18N_BASE_URL \/ providerBaseUrl/)
   })
 })

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -232,6 +232,7 @@ Set environment variables on the server process and the server calls the LLM pro
 | `I18N_PROVIDER` | `openai`, `anthropic`, or `google` |
 | `I18N_MODEL` | Model name (e.g. `gemini-2.5-flash`, `gpt-4o-mini`) |
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | API key matching the provider |
+| `I18N_BASE_URL` | Optional provider base URL — OpenAI-compatible gateways, local models, proxies. Falls back to `providerBaseUrl` in `.i18n-mcp.json`. Not supported by `google` |
 
 Partial configuration logs a warning to stderr and falls back to agent mode — a misconfigured server never surprises callers per-request.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -232,7 +232,7 @@ Set environment variables on the server process and the server calls the LLM pro
 | `I18N_PROVIDER` | `openai`, `anthropic`, or `google` |
 | `I18N_MODEL` | Model name (e.g. `gemini-2.5-flash`, `gpt-4o-mini`) |
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | API key matching the provider |
-| `I18N_BASE_URL` | Optional provider base URL — OpenAI-compatible gateways, local models, proxies. Falls back to `providerBaseUrl` in `.i18n-mcp.json`. Not supported by `google` |
+| `I18N_BASE_URL` | Optional provider base URL — protocol-compatible gateways, self-hosted models, proxies. Falls back to `providerBaseUrl` in `.i18n-mcp.json`. Not supported by `google` |
 
 Partial configuration logs a warning to stderr and falls back to agent mode — a misconfigured server never surprises callers per-request.
 

--- a/packages/mcp/schema.json
+++ b/packages/mcp/schema.json
@@ -172,7 +172,7 @@
     "providerBaseUrl": {
       "type": "string",
       "minLength": 1,
-      "description": "Base URL for the LLM provider — OpenAI-compatible gateways, local models (Ollama, LiteLLM) and corporate proxies. Overridden by the I18N_BASE_URL environment variable and by --baseUrl. Not supported by the \"google\" provider, which rejects it rather than ignoring it."
+      "description": "Base URL for the LLM provider — gateways, self-hosted model servers and corporate proxies that speak the provider's own protocol. Overrides the endpoint only, not the request shape or auth header. Overridden by the I18N_BASE_URL environment variable and by --baseUrl. Not supported by the \"google\" provider, which rejects it rather than ignoring it."
     }
   }
 }

--- a/packages/mcp/schema.json
+++ b/packages/mcp/schema.json
@@ -168,6 +168,11 @@
       "type": "string",
       "enum": ["json", "php-array"],
       "description": "Override the auto-detected locale file format. Useful when both formats exist or auto-detection picks wrong."
+    },
+    "providerBaseUrl": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Base URL for the LLM provider — OpenAI-compatible gateways, local models (Ollama, LiteLLM) and corporate proxies. Overridden by the I18N_BASE_URL environment variable and by --baseUrl. Not supported by the \"google\" provider, which rejects it rather than ignoring it."
     }
   }
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -31,6 +31,9 @@ import {
   resolveProtectedLocales,
   toErrorMessage,
   createTranslateFn,
+  resolveProviderBaseUrl,
+  loadProjectConfig,
+  BASE_URL_ENV,
 } from 'the-i18n-cli'
 
 import type { TranslateFn, ProgressFn, ProjectConfig, LlmProvider } from 'the-i18n-cli'
@@ -96,11 +99,27 @@ async function resolveTranslationBackend(): Promise<TranslationBackend> {
   }
 
   try {
-    const translateFn = await createTranslateFn({ provider, model })
+    const translateFn = await createTranslateFn({ provider, model, baseUrl: await resolveStartupBaseUrl() })
     return { mode: 'provider', provider, model, translateFn }
   } catch (error) {
     warn(`Provider setup failed: ${toErrorMessage(error)}. Running in agent mode.`)
     return { mode: 'agent' }
+  }
+}
+
+/**
+ * Base URL for the startup-resolved backend: I18N_BASE_URL, else the project
+ * config's providerBaseUrl. A missing or unreadable config is not fatal here
+ * — the server still starts, just without an endpoint override.
+ */
+async function resolveStartupBaseUrl(): Promise<string | undefined> {
+  const fromEnv = resolveProviderBaseUrl({ env: process.env[BASE_URL_ENV] })
+  if (fromEnv) return fromEnv
+  try {
+    const projectConfig = await loadProjectConfig(DEFAULT_PROJECT_DIR)
+    return resolveProviderBaseUrl({ config: projectConfig?.providerBaseUrl })
+  } catch {
+    return undefined
   }
 }
 


### PR DESCRIPTION
Closes #250. First of the #246 agent-drivability tickets.

## What

`baseUrl` was already threaded into the OpenAI and Anthropic clients in the provider layer, but nothing reached it — no flag, no env var, no config key. This is exposure of existing plumbing, not new integration work, and it unlocks OpenAI-compatible gateways, local models (Ollama, LiteLLM), Azure OpenAI, OpenRouter and corporate proxies.

## How

**Resolution precedence: `--baseUrl` > `I18N_BASE_URL` > `providerBaseUrl` in `.i18n-mcp.json`.** Blank values count as unset, so an exported-but-empty variable can't silently disable a configured endpoint. The config file is only read when neither flag nor env is set, so a fully-flagged invocation never depends on config discovery.

**Google is rejected, not ignored.** `@google/genai` exposes no endpoint override, so a base URL there would be accepted and then silently dropped — translating against the wrong endpoint while looking like it worked. It now throws a new `config` error kind, raised while building the `TranslateFn`, before any request exists. The error names all three ways the value could have been set.

**Config and schema move together.** `providerBaseUrl` lands in `ProjectConfig`, the strict zod schema and the published JSON Schema in one change — the schema is strict, so split delivery would break generated configs.

**MCP resolves it at startup** from `I18N_BASE_URL`, falling back to the project config. An unreadable config is not fatal there: the server still starts, just without an override.

**Refactor along the way:** the two translate commands duplicated their provider flags and setup verbatim. Both now share `providerArgs` and `resolveProviderTranslateFn`, so the base URL resolves in exactly one place.

## Validation

- `pnpm -r test` — 752 passing (728 CLI + 24 MCP), 8 new
- `pnpm -r --filter='./packages/*' typecheck` ✓ both packages
- `pnpm lint` ✓ 0 errors (3 pre-existing warnings)
- `npx fallow audit --base origin/main` ✓ no issues in 13 changed files

New tests cover base-URL precedence across all three sources, blank-value handling, trimming, and the Google rejection with its message contents. They sit at the existing provider test seam and touch no SDK.

## Notes

- Docs updated in all three READMEs, including a precedence table in the root README.
- `fallow` warns that the duplication baseline matched 0 clone groups (`.fallow-baselines/dupes.json` has 79 entries). That's pre-existing and unrelated — flagging it because it means duplication is effectively unbaselined right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom OpenAI- and Anthropic-compatible provider endpoints.
  - Configure endpoints using `--baseUrl`, `I18N_BASE_URL`, or project settings, with clear precedence rules.
  - Added support for local models, gateways, and proxies.
  - Endpoint values are trimmed, and blank values are ignored.
  - Custom endpoints are rejected for Google providers with an informative configuration error.

- **Documentation**
  - Updated CLI, MCP, and project configuration guidance with examples and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->