### PR TITLE
fix(cli): gate bare-candidate shapes by pattern-set language

### DIFF
--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -394,12 +394,14 @@ function collectBarePhpCandidates(content: string, bareDynamics: Set<string>): v
   }
 }
 
-function collectBareConcatCandidates(content: string, bareDynamics: Set<string>): void {
+function collectBarePrefixCandidates(content: string, bareDynamics: Set<string>): void {
   BARE_PREFIX_LITERAL.lastIndex = 0
   for (const match of content.matchAll(BARE_PREFIX_LITERAL)) {
     bareDynamics.add(`\`${match[2]}\${_}\``)
   }
+}
 
+function collectBareSuffixConcatCandidates(content: string, bareDynamics: Set<string>): void {
   BARE_SUFFIX_CONCAT.lastIndex = 0
   for (const match of content.matchAll(BARE_SUFFIX_CONCAT)) {
     const suffix = match[3]
@@ -413,17 +415,29 @@ function collectBareConcatCandidates(content: string, bareDynamics: Set<string>)
  * Collects context-free key evidence from one file's content: exact dotted
  * strings into `bareStrings`, interpolated/concatenated shapes into
  * `bareDynamics` (normalized to `${_}` slots for buildDynamicKeyRegexes).
+ *
+ * Interpolation shapes are gated by `bareShapes` (#288): the PHP shape on
+ * Vue/JS files matches template attributes like `v-if="$slots.header"`
+ * (junk `${_}.header` families); conversely PHP key construction uses `.`
+ * concat and `{$var}` interpolation only, so the backtick-template and
+ * `+`-concat shapes have nothing legitimate to find there and can only
+ * misfire (shell-exec backticks, `+`-adjacent decimals). Dotted literals
+ * and trailing-dot prefixes are language-neutral and always run.
  */
-function collectBareCandidates(content: string, constTable: Map<string, string>, bareStrings: Set<string>, bareDynamics: Set<string>): void {
+function collectBareCandidates(content: string, constTable: Map<string, string>, bareStrings: Set<string>, bareDynamics: Set<string>, bareShapes: 'js' | 'php' = 'js'): void {
   BARE_DOTTED_STRING.lastIndex = 0
   for (const match of content.matchAll(BARE_DOTTED_STRING)) {
     const candidate = match[2]
     if (candidate) bareStrings.add(candidate)
   }
+  collectBarePrefixCandidates(content, bareDynamics)
 
+  if (bareShapes === 'php') {
+    collectBarePhpCandidates(content, bareDynamics)
+    return
+  }
   collectBareTemplateCandidates(content, constTable, bareStrings, bareDynamics)
-  collectBarePhpCandidates(content, bareDynamics)
-  collectBareConcatCandidates(content, bareDynamics)
+  collectBareSuffixConcatCandidates(content, bareDynamics)
 }
 
 // ─── Scanning ───────────────────────────────────────────────────
@@ -465,7 +479,7 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     allUsages.push(...usages)
     allDynamicKeys.push(...dynamicKeys)
 
-    collectBareCandidates(content, constTable, bareStringCandidates, bareDynamicCandidates)
+    collectBareCandidates(content, constTable, bareStringCandidates, bareDynamicCandidates, pat.bareShapes)
 
     filesScanned++
   }

--- a/packages/cli/src/scanner/patterns.ts
+++ b/packages/cli/src/scanner/patterns.ts
@@ -29,6 +29,16 @@ export interface ScanPatternSet {
    * substituting declared constants there could wrongly narrow a pattern.
    */
   resolveLocalConsts?: boolean
+  /**
+   * Language family for the context-free bare-candidate collectors (#288).
+   * 'js' (default) runs the template-literal and `+`-concat shapes; 'php'
+   * runs the double-quoted `{$var}` interpolation shape instead. Ungated,
+   * the PHP shape matches Vue template attributes (`v-if="$slots.header"`),
+   * producing `${_}.header`-class candidates that suppress every key ending
+   * in those segments. Language-neutral shapes (dotted literals,
+   * trailing-dot prefixes) always run.
+   */
+  bareShapes?: 'js' | 'php'
 }
 
 // ─── Vue / Nuxt Patterns ────────────────────────────────────────
@@ -66,6 +76,7 @@ export const VUE_NUXT_PATTERNS: ScanPatternSet = {
   requiresDotForCallee: (callee: string) => callee === 't',
   promoteStaticDynamicMatches: true,
   resolveLocalConsts: true,
+  bareShapes: 'js',
 }
 
 // ─── Laravel / PHP Patterns ─────────────────────────────────────
@@ -105,6 +116,7 @@ export const LARAVEL_PATTERNS: ScanPatternSet = {
   staticKeyPatterns: [LARAVEL_STATIC_KEY],
   dynamicKeyPatterns: [LARAVEL_DYNAMIC_KEY],
   concatKeyPatterns: [LARAVEL_CONCAT_KEY],
+  bareShapes: 'php',
 }
 
 // ─── Resolution ─────────────────────────────────────────────────

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -915,6 +915,67 @@ describe('scanSourceFiles', () => {
       expect(result.uncertainByLayer.root ?? []).toEqual([])
     })
   })
+
+  // #288 — the PHP interpolation shape must not run on Vue/JS files: Vue
+  // template attributes like v-if="$slots.header" are double-quoted strings
+  // containing $identifier.segment and compiled to `${_}.header`-class
+  // candidates suppressing every key ending in those segments.
+  describe('bare-shape language gating (#288)', () => {
+    it('Vue $slots/$attrs template attributes produce zero bare dynamic candidates', async () => {
+      await writeFile(join(tmpDir, 'Table.vue'), [
+        '<template>',
+        '  <thead v-if="$slots.header">',
+        '    <slot name="header" />',
+        '  </thead>',
+        '  <input @change="$attrs.change" />',
+        '  <div v-if="$slots.actions && !$slots.empty">',
+        '    <slot name="default" />',
+        '  </div>',
+        '</template>',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir)
+      expect(result.bareDynamicCandidates.size).toBe(0)
+    })
+
+    it('gating does not disturb genuine JS shapes in the same file', async () => {
+      await writeFile(join(tmpDir, 'Mixed.vue'), [
+        '<template>',
+        '  <div v-if="$slots.header" />',
+        '</template>',
+        '<script setup>',
+        'const key = `pages.${section}.title`',
+        "const plural = base.translationPath + '.labelPlural'",
+        '</script>',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir)
+      expect(result.bareDynamicCandidates).toEqual(new Set([
+        '`pages.${_}.title`',
+        '`${_}.labelPlural`',
+      ]))
+    })
+
+    it('ground truth: $slots junk must not dynamic-match unrelated keys ending in .header', async () => {
+      await writeFile(join(tmpDir, 'Card.vue'), [
+        '<template>',
+        '  <div v-if="$slots.header"><slot name="header" /></div>',
+        '</template>',
+      ].join('\n'))
+
+      const result = await findOrphanKeysForConfig({
+        keysByLayer: new Map([['root', {
+          keys: ['pages.dashboard.header', 'components.table.empty'],
+          localeDir: { layer: 'root' },
+        }]]),
+        resolveIgnorePatterns: () => undefined,
+        scanDirs: [tmpDir],
+      })
+
+      expect(result.orphansByLayer.root ?? []).toEqual(['components.table.empty', 'pages.dashboard.header'])
+      expect(result.dynamicMatchedCount).toBe(0)
+    })
+  })
 })
 
 describe('toRelativePath', () => {

--- a/packages/cli/tests/scanner/laravel-patterns.test.ts
+++ b/packages/cli/tests/scanner/laravel-patterns.test.ts
@@ -416,4 +416,30 @@ describe('Laravel scanSourceFiles', () => {
       expect(result.dynamicMatchedCount).toBe(2)
     })
   })
+
+  // #288 — shape gating must not regress PHP collection, and the JS-only
+  // shapes (backtick templates, `+`-concat) must not run on PHP files where
+  // they can only misfire (shell-exec backticks, `+`-adjacent decimals).
+  describe('bare-shape language gating (#288)', () => {
+    it('PHP interpolated strings still produce their candidate', async () => {
+      await writeFile(join(tmpDir, 'Resource.php'), [
+        '<?php',
+        '$title = "api.{$var}.title";',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+      expect(result.bareDynamicCandidates.has('`api.${_}.title`')).toBe(true)
+    })
+
+    it('JS-only shapes do not run on PHP files', async () => {
+      await writeFile(join(tmpDir, 'Shell.php'), [
+        '<?php',
+        '$path = `${CACHE_DIR}.tmp`;',
+        '$total = $count + ".5";',
+      ].join('\n'))
+
+      const result = await scanSourceFiles(tmpDir, undefined, LARAVEL_PATTERNS)
+      expect(result.bareDynamicCandidates.size).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
Closes #288

## Problem

The bare-candidate collectors ran every shape on every scanned file regardless of language. `BARE_PHP_DYNAMIC` therefore matched Vue template attributes like `v-if="$slots.header"` and `@change="$attrs.change"` in `.vue` files, producing junk candidates (`` `${_}.header` ``, `` `${_}.actions` ``, `` `${_}.empty` ``, `` `${_}.default` ``, plus ~100 `$var->prop`-style families). With #285's conservative widening these compile to `.+?\.header`-class regexes and suppress every key ending in those segments.

## Fix

`ScanPatternSet` gains a `bareShapes: 'js' | 'php'` discriminator (mirroring the `resolveLocalConsts` precedent from #285), threaded from the scan loop into `collectBareCandidates`:

- **`'php'`** (Laravel set): runs `BARE_PHP_DYNAMIC` only. The JS-only shapes are gated off — PHP key construction uses `.` concat and `{$var}` interpolation exclusively, so the backtick-template and `+`-concat shapes have nothing legitimate to find there and can only misfire (shell-exec backticks, `+`-adjacent decimals).
- **`'js'`** (Vue/Nuxt set, default): runs `BARE_DYNAMIC_TEMPLATE` and `BARE_SUFFIX_CONCAT`; never runs the PHP shape.
- **Language-neutral, always run**: `BARE_DOTTED_STRING` and `BARE_PREFIX_LITERAL` — Laravel needs prefix literals for `'a.b.' . $var` concat and plain-argument prefixes (#262 tests).

## Before / after evidence

### anny-ui (`remove-orphans --json`, dry-run)

| metric | before | after |
|---|---|---|
| totalKeys | 8599 | 8599 |
| orphanCount | 1266 | **1270 (+4)** |
| dynamicMatchedCount | 786 | **782 (−4)** |
| uncertainCount / misplacedCount / ignoredCount | 7 / 157 / 80 | 7 / 157 / 80 |

102 junk dynamic-candidate entries vanish, including the audit families `` `${_}.header` ``, `` `${_}.actions` ``, `` `${_}.empty` `` and the whole `$var->prop` class (`booking.${_}`, `resource.${_}`, …). `` `${_}.default` `` remains — it now has a genuine JS producer, not the `$slots` junk.

Keys flipping to orphan (false suppression lifted), cross-checked against the !2021 audit's DEAD verdicts — all four have **zero** references in anny-ui source (exhaustive grep over `.vue/.ts/.js` excluding locales):

- `app-admin` / `components.integrations.googleAds.conversionsPanel.table.actions`
- `app-admin` / `pages.dashboard.widgets.bookingsByAccountRole.empty`
- `root` / `common.components.resourcePreferenceSelection.header`
- `root` / `common.terms.option`

The remaining risk-bucket keys from the audit's 7 were already deleted in !2021, so there is nothing left to flip for them.

### bookings-api (Laravel)

Output is **byte-identical** before/after (`diff` clean): 2522 total keys, 61 orphans, 1212 dynamic-matched, 6879 files scanned.

## Validation

- `pnpm --filter the-i18n-cli build` — clean
- `pnpm -r test` — 756 CLI + 26 MCP tests pass
- `pnpm -r --filter='./packages/*' typecheck` — clean
- `pnpm lint` — 0 errors (3 pre-existing warnings in untouched files)
- `npx fallow audit --base origin/main` — exit 0

New regression tests: Vue `$slots`/`$attrs` fixture produces zero bare dynamic candidates (with a ground-truth orphan assertion that `pages.dashboard.header` is no longer dynamic-matched); gating leaves genuine JS shapes in the same file intact; PHP `"api.{$var}.title"` still produces its candidate; JS-only shapes verified not to run on PHP files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanning accuracy for Vue, Nuxt, and Laravel projects by distinguishing JavaScript and PHP dynamic key patterns.
  * Prevented PHP-style expressions in JavaScript/Vue files from creating incorrect candidates.
  * Preserved detection of valid JavaScript template/concatenation patterns and PHP interpolation patterns.
  * Ensured unrelated missing keys continue to be reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->