### PR TITLE
feat(cli): resolveExitCode + --fail-on-missing / --fail-on-orphans CI gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ Auto-translate missing keys and find orphans in CI — no manual work. Runs on e
 
 Provider-agnostic. Bring your own API key for OpenAI, Anthropic, or Google.
 
+### Gating on findings
+
+Turn findings into exit codes with opt-in gates, so a pipeline blocks a merge without parsing JSON:
+
+```bash
+the-i18n-cli missing --fail-on-missing          # exit 2 when any key is missing
+the-i18n-cli remove-orphans --fail-on-orphans   # exit 2 when any orphan is found
+```
+
+| Code | Meaning |
+|------|---------|
+| `0` | The run succeeded and no gate tripped |
+| `1` | The run itself failed — bad API key, unreadable project, a translate run that translated nothing |
+| `2` | The run succeeded but a gate tripped |
+
+The split between `1` and `2` is what lets a job distinguish a missing API key from a project that simply has untranslated keys. Gates compose on one invocation, a failed run outranks a tripped gate, and a tripped gate is named in the result's `gatesTripped` array with its observed value and threshold. Commands invoked without a gate flag keep exactly the exit codes they had before.
+
+See the [CLI exit-code reference](./packages/cli/README.md#exit-codes-and-ci-gates) for the full table.
+
 ### GitHub Actions
 
 ```yaml

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,6 +61,41 @@ Run `the-i18n-cli <command> --help` for per-command options.
 | `--dryRun` | Preview changes without writing |
 | `--output-file <path>` | `missing` / `remove-orphans` / `check`: write the full report to a file, return only a summary |
 
+### Exit Codes and CI Gates
+
+| Code | Meaning |
+|------|---------|
+| `0` | The run succeeded and no gate tripped |
+| `1` | The run itself failed — bad API key, unreadable project, a translate run that translated nothing |
+| `2` | The run succeeded but a gate tripped: findings exist and the tool worked |
+
+Separating `1` from `2` lets a pipeline tell a broken setup apart from a project that simply has untranslated keys.
+
+Gates are opt-in flags, so every invocation without one keeps the exit code it has today:
+
+| Flag | Command | Trips when |
+|------|---------|-----------|
+| `--fail-on-missing` | `missing` | Any key is missing in a target locale |
+| `--fail-on-orphans` | `remove-orphans` | Any orphan key is found (dry-run still applies) |
+
+```bash
+the-i18n-cli missing --fail-on-missing          # exit 2 blocks the merge
+the-i18n-cli remove-orphans --fail-on-orphans   # dry-run, but non-zero on findings
+```
+
+Gates compose on one invocation, and a failed run outranks a tripped gate — exit `1` wins over exit `2`. When a gate trips, the JSON result gains a `gatesTripped` array naming it and reporting the observed value against the threshold; nothing else in the result changes, so existing consumers keep working:
+
+```json
+{
+  "summary": { "totalMissingKeys": 12 },
+  "gatesTripped": [
+    { "name": "fail-on-missing", "counter": "totalMissingKeys", "direction": "above", "threshold": 0, "observed": 12 }
+  ]
+}
+```
+
+`check` is the exception: it gates unconditionally with exit `1`, because a key that renders raw in production is a defect rather than a threshold.
+
 ## Translation Modes
 
 `translate` and `translate-key` run in one of two modes — every result reports which one ran (`mode: "provider" | "agent" | "dry-run"`).

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -20,6 +20,13 @@ export function createCommand(opts: {
    * isTotalFailure check.
    */
   failWhen?: (result: unknown) => boolean
+  /**
+   * Opt-in CI gates this command accepts. The factory reads the requesting
+   * flag off args and evaluates every gate uniformly, so no command grows
+   * bespoke exit logic. Declaring a gate does not add its flag — pair each
+   * spec with an entry in `args`.
+   */
+  gates?: GateSpec[]
   run: (args: any) => Promise<unknown>
 }): CommandDef {
   return defineCommand({
@@ -28,16 +35,137 @@ export function createCommand(opts: {
     async run({ args }) {
       try {
         const result = await opts.run(args)
-        outputResult(result, args)
-        if (isTotalFailure(result) || opts.failWhen?.(result)) {
-          process.exitCode = 1
-        }
+        const runFailed = isTotalFailure(result) || (opts.failWhen?.(result) ?? false)
+        const decision = resolveExitCode(result, requestedGates(opts.gates ?? [], args), runFailed)
+        outputResult(withGateReport(result, decision.tripped), args)
+        // Assign only on a non-zero decision: a clean run must leave the exit
+        // code exactly as it found it, as it did before gates existed.
+        if (decision.code !== EXIT_SUCCESS) process.exitCode = decision.code
       } catch (error) {
         emitErrorResult(error, args)
-        process.exitCode = 1
+        process.exitCode = EXIT_RUN_FAILED
       }
     },
   }) as any
+}
+
+/** The run succeeded and no gate tripped. */
+export const EXIT_SUCCESS = 0
+/** The run itself failed — a bad API key, an unreadable project, a total translate failure. */
+export const EXIT_RUN_FAILED = 1
+/** The run succeeded but a requested gate tripped — findings exist, the tool worked. */
+export const EXIT_GATE_TRIPPED = 2
+
+/**
+ * A CI gate a command accepts. `flag` is the arg that requests it; `counter`
+ * is the field of `result.summary` carrying the observed value. Omitting
+ * `threshold` takes it from the flag's own value, so a boolean flag pairs
+ * with `threshold: 0` and a numeric one (`--fail-under 90`) omits it.
+ */
+export interface GateSpec {
+  flag: string
+  counter: string
+  /** 'above' trips when observed > threshold (default); 'below' when observed < threshold. */
+  direction?: 'above' | 'below'
+  threshold?: number
+}
+
+/** A gate the caller asked for, with its threshold already resolved. */
+export interface RequestedGate {
+  name: string
+  counter: string
+  direction: 'above' | 'below'
+  threshold: number
+}
+
+/** A gate that tripped, as reported in the result. */
+export interface TrippedGate extends RequestedGate {
+  observed: number
+}
+
+export interface ExitDecision {
+  code: typeof EXIT_SUCCESS | typeof EXIT_RUN_FAILED | typeof EXIT_GATE_TRIPPED
+  tripped: TrippedGate[]
+}
+
+/**
+ * Pure decision from an operation result plus the gates the caller requested
+ * to an exit code. A failed run outranks a tripped gate — exit 1 wins over
+ * exit 2 — and gates are not even consulted in that case, because counters
+ * from a run that fell over say nothing about the project.
+ */
+export function resolveExitCode(
+  result: unknown,
+  gates: RequestedGate[],
+  runFailed = false,
+): ExitDecision {
+  if (runFailed) return { code: EXIT_RUN_FAILED, tripped: [] }
+
+  const tripped: TrippedGate[] = []
+  for (const gate of gates) {
+    const observed = observedValue(result, gate.counter)
+    if (observed === undefined || !trips(gate, observed)) continue
+    tripped.push({ ...gate, observed })
+  }
+
+  return {
+    code: tripped.length > 0 ? EXIT_GATE_TRIPPED : EXIT_SUCCESS,
+    tripped,
+  }
+}
+
+/**
+ * Read a gate's counter off result.summary. Works on inline results and on
+ * the { reportFile, summary } shape alike, since both carry the summary.
+ * A missing or non-numeric counter yields undefined and never trips a gate.
+ */
+function observedValue(result: unknown, counter: string): number | undefined {
+  if (result === null || typeof result !== 'object') return undefined
+  const summary = (result as Record<string, unknown>).summary
+  if (summary === null || typeof summary !== 'object') return undefined
+  const value = (summary as Record<string, unknown>)[counter]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function trips(gate: RequestedGate, observed: number): boolean {
+  return gate.direction === 'below' ? observed < gate.threshold : observed > gate.threshold
+}
+
+/** Filter the declared gates down to the ones this invocation asked for. */
+function requestedGates(specs: GateSpec[], args: Record<string, unknown>): RequestedGate[] {
+  const requested: RequestedGate[] = []
+  for (const spec of specs) {
+    const raw = args[spec.flag]
+    if (raw === undefined || raw === null || raw === false || raw === '') continue
+    const threshold = spec.threshold ?? Number(raw)
+    if (!Number.isFinite(threshold)) continue
+    requested.push({
+      name: kebabCase(spec.flag),
+      counter: spec.counter,
+      direction: spec.direction ?? 'above',
+      threshold,
+    })
+  }
+  return requested
+}
+
+/**
+ * Name a tripped gate by the flag that requested it, so the JSON says
+ * "fail-on-missing" — what the user typed — rather than "failOnMissing".
+ */
+function kebabCase(flag: string): string {
+  return flag.replace(/[A-Z]/g, c => `-${c.toLowerCase()}`)
+}
+
+/**
+ * Attach the gate report without disturbing the rest of the result: consumers
+ * parsing today's shape keep working, and a run where nothing tripped is
+ * byte-for-byte what it was before gates existed.
+ */
+function withGateReport(result: unknown, tripped: TrippedGate[]): unknown {
+  if (tripped.length === 0) return result
+  if (result === null || typeof result !== 'object' || Array.isArray(result)) return result
+  return { ...(result as Record<string, unknown>), gatesTripped: tripped }
 }
 
 /**

--- a/packages/cli/src/commands/missing.ts
+++ b/packages/cli/src/commands/missing.ts
@@ -9,7 +9,9 @@ export default createCommand({
     ref: { type: 'string', description: 'Reference locale (default: project default)' },
     targets: { type: 'string', description: 'Comma-separated target locales (default: all except ref)' },
     outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
+    failOnMissing: { type: 'boolean', description: 'Exit 2 when any key is missing (CI gate)', default: false },
   },
+  gates: [{ flag: 'failOnMissing', counter: 'totalMissingKeys', threshold: 0 }],
   async run(args) {
     return getMissingTranslations({
       layer: args.layer,

--- a/packages/cli/src/commands/remove-orphans.ts
+++ b/packages/cli/src/commands/remove-orphans.ts
@@ -10,7 +10,9 @@ export default createCommand({
     dryRun: { type: 'boolean', description: 'Preview without removing (default: true)', default: true },
     outputFile: { type: 'string', description: 'Write full output to this file path and return only a summary (useful for large outputs)' },
     codequalityOutput: { type: 'string', description: 'Also write the orphan findings as a GitLab Code Quality (CodeClimate) JSON report to this file path' },
+    failOnOrphans: { type: 'boolean', description: 'Exit 2 when any orphan key is found (CI gate)', default: false },
   },
+  gates: [{ flag: 'failOnOrphans', counter: 'orphanCount', threshold: 0 }],
   async run(args) {
     return removeOrphanKeys({
       layer: args.layer,

--- a/packages/cli/tests/cli/exit-code.test.ts
+++ b/packages/cli/tests/cli/exit-code.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { isTotalFailure } from '../../src/commands/_shared.js'
+import {
+  isTotalFailure,
+  resolveExitCode,
+  EXIT_SUCCESS,
+  EXIT_RUN_FAILED,
+  EXIT_GATE_TRIPPED,
+} from '../../src/commands/_shared.js'
+import type { RequestedGate } from '../../src/commands/_shared.js'
 
 /**
  * Unit tests for the CI exit-code decision: a completed run exits non-zero
- * only when it achieved nothing (failures present, zero successes).
+ * only when it achieved nothing (failures present, zero successes), or when
+ * an opt-in gate the caller requested tripped (#248).
  */
 
 describe('isTotalFailure', () => {
@@ -55,5 +63,118 @@ describe('isTotalFailure', () => {
   it('requires both counters to be numbers before deciding', () => {
     expect(isTotalFailure({ summary: { totalFailed: 4 } })).toBe(false)
     expect(isTotalFailure({ summary: { totalFailed: '4', totalTranslated: '0' } })).toBe(false)
+  })
+})
+
+describe('resolveExitCode', () => {
+  const missingGate: RequestedGate = {
+    name: 'fail-on-missing',
+    counter: 'totalMissingKeys',
+    direction: 'above',
+    threshold: 0,
+  }
+  const orphanGate: RequestedGate = {
+    name: 'fail-on-orphans',
+    counter: 'orphanCount',
+    direction: 'above',
+    threshold: 0,
+  }
+
+  describe('without gates — today\'s behaviour, unchanged', () => {
+    it('exits 0 for a clean run', () => {
+      expect(resolveExitCode({ summary: { totalMissingKeys: 12 } }, []))
+        .toEqual({ code: EXIT_SUCCESS, tripped: [] })
+    })
+
+    it('exits 1 when the run itself failed', () => {
+      expect(resolveExitCode({ summary: {} }, [], true))
+        .toEqual({ code: EXIT_RUN_FAILED, tripped: [] })
+    })
+
+    it('never trips on findings the caller did not gate on', () => {
+      expect(resolveExitCode({ summary: { totalMissingKeys: 999, orphanCount: 999 } }, []).code)
+        .toBe(EXIT_SUCCESS)
+    })
+  })
+
+  describe('gate evaluation', () => {
+    it('exits 2 when the observed count is above the threshold', () => {
+      const decision = resolveExitCode({ summary: { totalMissingKeys: 12 } }, [missingGate])
+      expect(decision.code).toBe(EXIT_GATE_TRIPPED)
+      expect(decision.tripped).toEqual([{ ...missingGate, observed: 12 }])
+    })
+
+    it('exits 0 when the observed count sits at the threshold', () => {
+      expect(resolveExitCode({ summary: { totalMissingKeys: 0 } }, [missingGate]).code)
+        .toBe(EXIT_SUCCESS)
+    })
+
+    it('works on the reportFile shape, which carries only the summary', () => {
+      expect(resolveExitCode({ reportFile: '/tmp/r.json', summary: { orphanCount: 3 } }, [orphanGate]).code)
+        .toBe(EXIT_GATE_TRIPPED)
+    })
+
+    it('supports a below-threshold direction for coverage-style gates', () => {
+      const coverage: RequestedGate = {
+        name: 'fail-under',
+        counter: 'completionPercent',
+        direction: 'below',
+        threshold: 90,
+      }
+      expect(resolveExitCode({ summary: { completionPercent: 84 } }, [coverage]).code)
+        .toBe(EXIT_GATE_TRIPPED)
+      expect(resolveExitCode({ summary: { completionPercent: 90 } }, [coverage]).code)
+        .toBe(EXIT_SUCCESS)
+      expect(resolveExitCode({ summary: { completionPercent: 97 } }, [coverage]).code)
+        .toBe(EXIT_SUCCESS)
+    })
+  })
+
+  describe('a failed run outranks a tripped gate', () => {
+    it('reports exit 1, not exit 2, when both would apply', () => {
+      const decision = resolveExitCode({ summary: { totalMissingKeys: 12 } }, [missingGate], true)
+      expect(decision.code).toBe(EXIT_RUN_FAILED)
+    })
+
+    it('reports no tripped gates, since counters from a failed run mean nothing', () => {
+      expect(resolveExitCode({ summary: { totalMissingKeys: 12 } }, [missingGate], true).tripped)
+        .toEqual([])
+    })
+  })
+
+  describe('composition', () => {
+    it('evaluates several gates on one invocation', () => {
+      const decision = resolveExitCode(
+        { summary: { totalMissingKeys: 4, orphanCount: 7 } },
+        [missingGate, orphanGate],
+      )
+      expect(decision.code).toBe(EXIT_GATE_TRIPPED)
+      expect(decision.tripped.map(g => g.name)).toEqual(['fail-on-missing', 'fail-on-orphans'])
+    })
+
+    it('trips on one gate while the other stays clean', () => {
+      const decision = resolveExitCode(
+        { summary: { totalMissingKeys: 0, orphanCount: 7 } },
+        [missingGate, orphanGate],
+      )
+      expect(decision.code).toBe(EXIT_GATE_TRIPPED)
+      expect(decision.tripped.map(g => g.name)).toEqual(['fail-on-orphans'])
+    })
+  })
+
+  describe('results lacking the counter never trip a gate', () => {
+    it.each([
+      ['a summary without the counter', { summary: { totalKeys: 40 } }],
+      ['a non-numeric counter', { summary: { totalMissingKeys: '12' } }],
+      ['a NaN counter', { summary: { totalMissingKeys: Number.NaN } }],
+      ['a non-object summary', { summary: 'text' }],
+      ['no summary at all', { missing: {} }],
+      ['null', null],
+      ['a primitive', 'string'],
+      ['an array', []],
+    ])('%s', (_label, result) => {
+      expect(resolveExitCode(result, [missingGate, orphanGate]))
+        .toEqual({ code: EXIT_SUCCESS, tripped: [] })
+    })
   })
 })

--- a/packages/cli/tests/cli/gate-exit-code-bin.test.ts
+++ b/packages/cli/tests/cli/gate-exit-code-bin.test.ts
@@ -1,0 +1,107 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const binPath = resolve(__dirname, '../../dist/bin.js')
+
+/**
+ * End-to-end proof that a gate produces a genuine process exit code (#248) —
+ * the unit tests cover the decision, but only the real binary shows that
+ * citty parses --fail-on-missing and that the code survives to the shell.
+ * Requires a built dist (CI builds before testing).
+ */
+async function runBin(args: string[], cwd: string): Promise<{ stdout: string, code: number }> {
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [binPath, ...args], { cwd })
+    return { stdout, code: 0 }
+  } catch (error) {
+    const e = error as { stdout?: string, code?: number }
+    return { stdout: e.stdout ?? '', code: e.code ?? 1 }
+  }
+}
+
+describe('gate exit codes through the real binary', () => {
+  let projectDir: string
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'i18n-gate-exit-'))
+    await mkdir(join(projectDir, 'locales'), { recursive: true })
+    await writeFile(
+      join(projectDir, '.i18n-mcp.json'),
+      JSON.stringify({ defaultLocale: 'en', localeDirs: ['locales'], locales: ['en', 'de'] }),
+    )
+    // Keys are namespaced because the code scanner only treats dotted,
+    // key-shaped candidates as references (#281).
+    await writeFile(
+      join(projectDir, 'locales/en.json'),
+      JSON.stringify({ common: { greeting: 'Hello', farewell: 'Goodbye' } }),
+    )
+    // de is missing `common.farewell` — one missing key against the reference locale.
+    await writeFile(
+      join(projectDir, 'locales/de.json'),
+      JSON.stringify({ common: { greeting: 'Hallo' } }),
+    )
+  })
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('exits 2 and names the gate when --fail-on-missing finds missing keys', async () => {
+    const { stdout, code } = await runBin(['missing', '--fail-on-missing'], projectDir)
+
+    expect(code).toBe(2)
+    expect(JSON.parse(stdout)).toMatchObject({
+      summary: { totalMissingKeys: 1 },
+      gatesTripped: [{ name: 'fail-on-missing', observed: 1, threshold: 0 }],
+    })
+  })
+
+  it('exits 0 on the same project without the gate flag', async () => {
+    const { stdout, code } = await runBin(['missing'], projectDir)
+
+    expect(code).toBe(0)
+    const result = JSON.parse(stdout) as Record<string, unknown>
+    expect(result.summary).toMatchObject({ totalMissingKeys: 1 })
+    expect(result).not.toHaveProperty('gatesTripped')
+  })
+
+  it('exits 0 with the gate flag once nothing is missing', async () => {
+    await writeFile(
+      join(projectDir, 'locales/de.json'),
+      JSON.stringify({ common: { greeting: 'Hallo', farewell: 'Tschüss' } }),
+    )
+
+    const { code } = await runBin(['missing', '--fail-on-missing'], projectDir)
+
+    expect(code).toBe(0)
+  })
+
+  // remove-orphans is dry-run by default, so the gate reports without writing.
+  it('exits 2 when --fail-on-orphans finds a key no source file references', async () => {
+    await mkdir(join(projectDir, 'src'), { recursive: true })
+    await writeFile(join(projectDir, 'src/app.ts'), `export const label = t('common.greeting')\n`)
+
+    const { stdout, code } = await runBin(['remove-orphans', '--fail-on-orphans'], projectDir)
+
+    expect(code).toBe(2)
+    expect(JSON.parse(stdout)).toMatchObject({
+      gatesTripped: [{ name: 'fail-on-orphans', counter: 'orphanCount', threshold: 0 }],
+    })
+  })
+
+  it('exits 0 once every key is referenced', async () => {
+    await writeFile(
+      join(projectDir, 'src/app.ts'),
+      `export const label = t('common.greeting')\nexport const bye = t('common.farewell')\n`,
+    )
+
+    const { code } = await runBin(['remove-orphans', '--fail-on-orphans'], projectDir)
+
+    expect(code).toBe(0)
+  })
+})

--- a/packages/cli/tests/cli/gate-flags.test.ts
+++ b/packages/cli/tests/cli/gate-flags.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+
+/**
+ * Wiring tests for the opt-in CI gates (#248): the command factory reads the
+ * requesting flag off args, evaluates the gates the command declared, and
+ * reports the tripped ones in the result. The decision itself is unit-tested
+ * in exit-code.test.ts; this file covers the seam between flags and factory.
+ */
+
+// writeResult bypasses stdout spies via a bound reference captured at module
+// load — mock the guard so command output stays out of the test stream, and
+// so the emitted result can be inspected.
+vi.mock('../../src/utils/stdout-guard.js', () => ({
+  guardStdout: vi.fn(),
+  writeResult: vi.fn(),
+}))
+
+const { writeResult } = await import('../../src/utils/stdout-guard.js')
+const { createCommand } = await import('../../src/commands/_shared.js')
+
+const missingGate = { flag: 'failOnMissing', counter: 'totalMissingKeys', threshold: 0 }
+const orphanGate = { flag: 'failOnOrphans', counter: 'orphanCount', threshold: 0 }
+
+const savedExitCode = process.exitCode
+
+beforeEach(() => {
+  vi.mocked(writeResult).mockClear()
+})
+
+afterEach(() => {
+  process.exitCode = savedExitCode
+})
+
+/** Run a command double and return what it wrote to stdout. */
+async function runFake(
+  opts: { gates?: typeof missingGate[], failWhen?: (r: unknown) => boolean, result: unknown },
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const cmd = createCommand({
+    name: 'fake',
+    description: 'test double',
+    gates: opts.gates,
+    failWhen: opts.failWhen,
+    run: async () => opts.result,
+  }) as unknown as { run: (ctx: { args: Record<string, unknown> }) => Promise<void> }
+
+  await cmd.run({ args: { json: true, ...args } })
+
+  const written = vi.mocked(writeResult).mock.calls.at(-1)?.[0] ?? 'null'
+  return JSON.parse(written) as Record<string, unknown>
+}
+
+describe('gate flags', () => {
+  it('exits 2 and names the tripped gate when the flag is set', async () => {
+    const output = await runFake(
+      { gates: [missingGate], result: { summary: { totalMissingKeys: 12 } } },
+      { failOnMissing: true },
+    )
+
+    expect(process.exitCode).toBe(2)
+    expect(output.gatesTripped).toEqual([
+      { name: 'fail-on-missing', counter: 'totalMissingKeys', direction: 'above', threshold: 0, observed: 12 },
+    ])
+  })
+
+  it('leaves the exit code and the result shape alone when the flag is absent', async () => {
+    const output = await runFake(
+      { gates: [missingGate], result: { missing: { de: ['a.b'] }, summary: { totalMissingKeys: 12 } } },
+      {},
+    )
+
+    expect(process.exitCode).toBe(savedExitCode)
+    expect(output).toEqual({ missing: { de: ['a.b'] }, summary: { totalMissingKeys: 12 } })
+  })
+
+  it('does not trip when the flag is set but there is nothing to find', async () => {
+    const output = await runFake(
+      { gates: [missingGate], result: { summary: { totalMissingKeys: 0 } } },
+      { failOnMissing: true },
+    )
+
+    expect(process.exitCode).toBe(savedExitCode)
+    expect(output).not.toHaveProperty('gatesTripped')
+  })
+
+  it('composes several gates on one invocation', async () => {
+    const output = await runFake(
+      {
+        gates: [missingGate, orphanGate],
+        result: { summary: { totalMissingKeys: 4, orphanCount: 7 } },
+      },
+      { failOnMissing: true, failOnOrphans: true },
+    )
+
+    expect(process.exitCode).toBe(2)
+    expect(output.gatesTripped).toHaveLength(2)
+  })
+
+  it('evaluates only the gates whose flags were passed', async () => {
+    const output = await runFake(
+      {
+        gates: [missingGate, orphanGate],
+        result: { summary: { totalMissingKeys: 4, orphanCount: 7 } },
+      },
+      { failOnOrphans: true },
+    )
+
+    expect((output.gatesTripped as Array<{ name: string }>).map(g => g.name))
+      .toEqual(['fail-on-orphans'])
+  })
+
+  // A gate says "the project has findings"; failWhen and isTotalFailure say
+  // "the run fell over". CI must be able to tell those apart.
+  it('reports a failed run as exit 1 even when a gate would also trip', async () => {
+    const output = await runFake(
+      {
+        gates: [missingGate],
+        failWhen: () => true,
+        result: { summary: { totalMissingKeys: 12 } },
+      },
+      { failOnMissing: true },
+    )
+
+    expect(process.exitCode).toBe(1)
+    expect(output).not.toHaveProperty('gatesTripped')
+  })
+
+  it('keeps exit 1 for a total translate failure, with no gates declared', async () => {
+    await runFake(
+      { result: { summary: { totalTranslated: 0, totalFailed: 4 } } },
+      {},
+    )
+
+    expect(process.exitCode).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #248. First of the #246 drivability tickets to land after #250, and the keystone for #253 and #254.

## The problem

`missing`, `empty` and `remove-orphans` always exit 0. The only non-zero path was a translate run that achieved literally nothing. A pipeline could gate only by piping stdout into `jq` — which is exactly how the anny-ui pipeline broke, reading `.summary.totalOrphans` when the field is `.summary.orphanCount`. This is the last surviving item of the deleted `CI-ISSUES.md`.

## The prefactor

The factory's inline `isTotalFailure(result) || failWhen(result)` check is now a pure function:

```ts
resolveExitCode(result, gates, runFailed) => { code, tripped }
```

Commands declare the gates they accept **as data** — the flag that requests the gate and the `summary` counter it reads:

```ts
gates: [{ flag: 'failOnMissing', counter: 'totalMissingKeys', threshold: 0 }]
```

The factory filters those down to the ones this invocation actually asked for, evaluates them uniformly, and no command grows bespoke exit logic. The spec also carries a `direction` (`above` / `below`) and an optional `threshold` that falls back to the flag's own numeric value — so **#253's `--fail-under 90` is a data change, not new mechanism**. There is a unit test for that direction already, to keep the seam honest.

## Exit codes

| Code | Meaning |
|------|---------|
| `0` | Success, no gate tripped |
| `1` | The run itself failed — unchanged `isTotalFailure` / `failWhen` semantics |
| `2` | The run succeeded but a gate tripped |

A failed run outranks a tripped gate, and gates are **not consulted at all** in that case: counters from a run that fell over say nothing about the project, so reporting them as findings would be a lie.

## Backward compatibility

Both properties are covered by tests rather than asserted:

- An invocation with no gate flags produces exactly the exit code it did before — the factory assigns `process.exitCode` only on a non-zero decision, so a clean run still leaves it untouched.
- The emitted result is byte-for-byte unchanged unless a gate actually trips, at which point it gains one top-level `gatesTripped` array. Nothing else moves.

`check` is deliberately left alone: its `failWhen` gate is unconditional and stays exit `1`, because a key rendering raw in production is a defect, not a threshold.

## Tests

- `tests/cli/exit-code.test.ts` — extended in place, as the ticket asked, since it already owned this seam. 26 cases covering direction, thresholds, composition, precedence, and the "results lacking the counter never trip" table.
- `tests/cli/gate-flags.test.ts` — new: the flag-to-factory wiring and the result annotation.
- `tests/cli/gate-exit-code-bin.test.ts` — new: drives the **real binary** against a temp fixture for both gates, confirming citty parses the flags and the code survives to the shell. This is what proves exit 2 is genuine rather than a unit-test artifact.

Full suite: 809 CLI + 26 MCP tests pass. Lint and typecheck clean, no new warnings.

## Two notes

1. ~~`tests/cli/gitlab-template.test.ts` fails to load locally.~~ **Retracted:** this was stale local `node_modules`, not a repo defect. `yaml@2.8.2` is correctly declared in `packages/cli` devDependencies and present in the lockfile's importer entry; a `pnpm install` links it and the file passes (4 tests). Nothing to fix, and CI was never affected.

2. Writing the e2e fixture surfaced that the code scanner only treats **dotted, key-shaped** candidates as references — single-segment keys like `t('greeting')` never match, so every such key reads as an orphan. That is the documented #281 behaviour and correct for this repo's conventions; the fixture now uses namespaced keys and says why in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
