### PR TITLE
ci: gate reference pipelines on exit codes instead of jq arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 | `I18N_PROVIDER` | ✅ | — | `openai`, `anthropic`, or `google` |
 | `I18N_MODEL` | ✅ | — | Model name |
 | `I18N_API_KEY` | ✅ | — | API key for the provider |
-| `I18N_LAYER` | — | all layers | Layer to translate. Leave empty to translate every locale-backed layer in one run |
+| `I18N_LAYER` | — | all layers | Layer to translate. Leave empty to translate every locale-backed layer in one run — on a layered project `I18N_LOCALE_PATHS` must then cover every layer's directory, or those translations are written but never committed |
 | `I18N_LOCALES` | — | all except source | Comma-separated target locales |
 | `I18N_SOURCE_LOCALE` | — | from `.i18n-mcp.json` | Reference locale |
 | `I18N_KEYS` | — | all missing | Comma-separated keys |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ i18n-cleanup:
   extends: .i18n-cleanup
   variables:
     I18N_LAYER: root
+    I18N_FAIL_ON_ORPHANS: "true"   # optional: exit 2 when orphans are found
+  # allow_failure: false           # optional: make orphans block the merge
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       changes:
@@ -291,7 +293,11 @@ i18n-check:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
-Translations are pushed to the MR branch. Orphan and undefined-key findings are emitted as a `gl-codequality.json` Code Quality artifact and surface in the MR's Code Quality widget. The widget diffs the MR report against the latest default-branch report — without a default-branch rule (no `changes:` filter) the widget stays blank. Artifacts (`.i18n-reports/`, `gl-codequality.json`) are retained for 7 days. The translate job fails when every key failed to translate; `.i18n-check` fails on findings but has `allow_failure: true` by default (remove it to make it a gate).
+Translations are pushed to the MR branch. Orphan and undefined-key findings are emitted as a `gl-codequality.json` Code Quality artifact and surface in the MR's Code Quality widget. The widget diffs the MR report against the latest default-branch report — without a default-branch rule (no `changes:` filter) the widget stays blank. Artifacts (`.i18n-reports/`, `gl-codequality.json`) are retained for 7 days.
+
+Every job decides its outcome from the CLI's exit code rather than by parsing counts out of the JSON result — reading result fields to decide pass/fail is what coupled earlier versions of these templates to undocumented output shapes. `0` is success, `1` means the run itself failed, `2` means a requested gate tripped.
+
+`.i18n-cleanup` allows exit `2` only, so orphans surface as a yellow warning while a genuinely broken scan still fails the job red. Set `I18N_FAIL_ON_ORPHANS: "true"` to request the gate and `allow_failure: false` to make orphans block the merge. `.i18n-check` has no opt-in flag — it always exits `1` on findings, because a key that renders raw in production is a defect rather than a threshold, and it carries `allow_failure: true` by default (remove it to make it a gate).
 
 Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *"Allow Git push requests to the repository"* (job token) or a project access token with `write_repository` scope in `I18N_PUSH_TOKEN`.
 
@@ -302,7 +308,7 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 | `I18N_PROVIDER` | ✅ | — | `openai`, `anthropic`, or `google` |
 | `I18N_MODEL` | ✅ | — | Model name |
 | `I18N_API_KEY` | ✅ | — | API key for the provider |
-| `I18N_LAYER` | ✅ | — | Layer name |
+| `I18N_LAYER` | — | all layers | Layer to translate. Leave empty to translate every locale-backed layer in one run |
 | `I18N_LOCALES` | — | all except source | Comma-separated target locales |
 | `I18N_SOURCE_LOCALE` | — | from `.i18n-mcp.json` | Reference locale |
 | `I18N_KEYS` | — | all missing | Comma-separated keys |
@@ -318,7 +324,8 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `I18N_LAYER` | ✅ | — | Layer name |
+| `I18N_LAYER` | — | all layers | Layer to scan. Leave empty to scan every layer |
+| `I18N_FAIL_ON_ORPHANS` | — | `false` | `"true"` adds `--fail-on-orphans`, so the job exits `2` when orphans are found |
 | `I18N_CLI_VERSION` | — | `latest` | Pin the-i18n-cli (npm version or dist-tag) |
 | `I18N_INSTALL_PEER_DEPS` | — | — | Extra npm packages installed alongside the CLI |
 

--- a/action.yml
+++ b/action.yml
@@ -142,19 +142,37 @@ runs:
           args+=(--dry-run)
         fi
 
+        # The CLI owns the pass/fail decision and reports it as an exit code:
+        # 0 success, 1 the run itself failed, 2 a requested gate tripped. Parsing
+        # counts to decide that here would re-couple this action to output field
+        # names, which is the defect class that broke downstream pipelines.
+        set +e
         output=$(the-i18n-cli translate "${args[@]}")
+        status=$?
+        set -e
         echo "$output"
 
-        # Dry runs report their counts as totalWouldTranslate
-        count=$(echo "$output" | jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)')
-        failed=$(echo "$output" | jq -r '.summary.totalFailed // 0')
+        # Counts are read for the step outputs and the log only — never to
+        # decide pass/fail. Tolerant, so a malformed result cannot mask $status.
+        # Dry runs report their counts as totalWouldTranslate.
+        count=$(echo "$output" | jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' 2>/dev/null || echo 0)
+        failed=$(echo "$output" | jq -r '.summary.totalFailed // 0' 2>/dev/null || echo 0)
         echo "translated_count=$count" >> "$GITHUB_OUTPUT"
         echo "failed_count=$failed" >> "$GITHUB_OUTPUT"
 
-        if [ "$failed" -gt 0 ] && [ "$count" -eq 0 ]; then
-          echo "::error::All $failed keys failed to translate — check provider, model, and API key."
-          exit 1
-        fi
+        case "$status" in
+          0) ;;
+          2)
+            gates=$(echo "$output" | jq -rc '[.gatesTripped[]?.name] | join(", ")' 2>/dev/null || echo "unknown")
+            echo "::error::CI gate tripped: ${gates}. The run itself succeeded — this is a findings gate, not a failure."
+            exit 2
+            ;;
+          *)
+            echo "::error::translate failed (exit ${status}) — check provider, model, and API key."
+            exit "$status"
+            ;;
+        esac
+
         if [ "$failed" -gt 0 ]; then
           echo "::warning::$failed keys failed to translate ($count succeeded)."
         fi

--- a/action.yml
+++ b/action.yml
@@ -155,8 +155,13 @@ runs:
         # Counts are read for the step outputs and the log only — never to
         # decide pass/fail. Tolerant, so a malformed result cannot mask $status.
         # Dry runs report their counts as totalWouldTranslate.
-        count=$(echo "$output" | jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' 2>/dev/null || echo 0)
-        failed=$(echo "$output" | jq -r '.summary.totalFailed // 0' 2>/dev/null || echo 0)
+        # head -n1: a single result yields a single line today, but a multi-document
+        # stdout would make these multiline and turn the -gt below into a hard
+        # bash error under set -e, defeating the tolerance this fallback exists for.
+        count=$(echo "$output" | jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' 2>/dev/null | head -n1 || echo 0)
+        failed=$(echo "$output" | jq -r '.summary.totalFailed // 0' 2>/dev/null | head -n1 || echo 0)
+        count=${count:-0}
+        failed=${failed:-0}
         echo "translated_count=$count" >> "$GITHUB_OUTPUT"
         echo "failed_count=$failed" >> "$GITHUB_OUTPUT"
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,24 @@
+# Issue tracker
+
+Specs and issues for this project live in **GitHub Issues** on
+`fabkho/the-i18n-kit`, managed with the `gh` CLI.
+
+## Creating a spec
+
+```bash
+gh issue create --title "<title>" --label "ready-for-agent" --body-file <file>
+```
+
+Add a topical label alongside `ready-for-agent` where one fits
+(`documentation`, `enhancement`, `bug`).
+
+## Labels
+
+| Label | Meaning |
+|---|---|
+| `ready-for-agent` | Spec is complete; an agent can pick this up. No further triage needed. |
+| `documentation` | Docs and reference material. |
+| `enhancement` | New capability. |
+| `bug` | Defect in existing behaviour. |
+
+Do not use the local `.scratch/` markdown tracker for this project.

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -46,6 +46,30 @@
 #       - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 #       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 #
+# ── Exit codes and gates ─────────────────────────────────────────────────────
+# Every job decides pass/fail from the CLI's exit code, never by parsing counts
+# out of the JSON result. Reading result fields to decide an outcome is what
+# coupled earlier versions of this template to undocumented output shapes.
+#
+#   0  the run succeeded and no gate tripped
+#   1  the run itself failed — bad API key, unreadable project, nothing translated
+#   2  the run succeeded but a requested gate tripped (findings exist)
+#
+# .i18n-cleanup gates on orphans when you opt in, and distinguishes the two:
+#
+#   i18n-cleanup:
+#     extends: .i18n-cleanup
+#     variables:
+#       I18N_FAIL_ON_ORPHANS: "true"   # adds --fail-on-orphans → exit 2 on findings
+#     allow_failure: false             # make orphans block the merge
+#
+# By default the job allows exit 2 only (a yellow warning), so orphans are
+# informational while a genuinely broken scan still fails the job red. Setting
+# `allow_failure: false` turns findings into a hard gate.
+#
+# .i18n-check has no opt-in flag: it always exits 1 on findings, because a key
+# that renders raw in production is a defect rather than a threshold.
+#
 # ── Code Quality widget (MR findings) ────────────────────────────────────────
 # .i18n-cleanup and .i18n-check emit `gl-codequality.json` declared as
 # artifacts:reports:codequality. GitLab's MR widget shows the DIFF between the
@@ -179,17 +203,36 @@
       [ "$I18N_DRY_RUN" = "true" ] && args="$args --dry-run"
 
       mkdir -p .i18n-reports
-      the-i18n-cli translate $args | tee .i18n-reports/translate-output.json
+      # The CLI owns the pass/fail decision and reports it as an exit code:
+      # 0 success, 1 the run itself failed, 2 a requested gate tripped. Deciding
+      # that from parsed counts is what coupled this template to output field
+      # names and broke it — the counts below are for the log only.
+      # Redirect rather than pipe: PIPESTATUS is bash-only and these jobs run
+      # on busybox sh in the default alpine image.
+      set +e
+      the-i18n-cli translate $args > .i18n-reports/translate-output.json
+      STATUS=$?
+      set -e
+      cat .i18n-reports/translate-output.json
 
       # Tolerant parse: older CLI versions (< 1.5.4) mixed logs into stdout.
       # Dry runs report their counts as totalWouldTranslate.
       TRANSLATED=$(jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       FAILED=$(jq -r '.summary.totalFailed // 0' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       echo "Translated: $TRANSLATED, failed: $FAILED"
-      if [ "$FAILED" != "?" ] && [ "$FAILED" -gt 0 ] && [ "$TRANSLATED" = "0" ]; then
-        echo "ERROR: all $FAILED keys failed to translate — check provider, model, and API key."
-        exit 1
-      fi
+
+      case "$STATUS" in
+        0) ;;
+        2)
+          GATES=$(jq -rc '[.gatesTripped[]?.name] | join(", ")' .i18n-reports/translate-output.json 2>/dev/null || echo "unknown")
+          echo "GATE: ${GATES} tripped. The run itself succeeded — this is a findings gate, not a failure."
+          exit 2
+          ;;
+        *)
+          echo "ERROR: translate failed (exit ${STATUS}) — check provider, model, and API key."
+          exit "$STATUS"
+          ;;
+      esac
 
       if [ "$I18N_DRY_RUN" = "true" ]; then
         echo "Dry run complete. No files written."
@@ -264,10 +307,16 @@
 .i18n-cleanup:
   extends: .i18n-base
   stage: lint
-  allow_failure: true
+  # Exit 2 (orphans found, only when I18N_FAIL_ON_ORPHANS=true) is a warning;
+  # any other non-zero is a real failure and fails the job red. Set
+  # `allow_failure: false` on the extending job to make orphans block the merge.
+  allow_failure:
+    exit_codes:
+      - 2
   variables:
     # Optional
     I18N_LAYER: ""            # layer to scan (empty = all layers), e.g. root, common
+    I18N_FAIL_ON_ORPHANS: "false"  # "true" → exit 2 when orphans are found
     I18N_CLI_VERSION: "latest"
     I18N_INSTALL_PEER_DEPS: ""
 
@@ -286,10 +335,23 @@
       # default-branch baseline rule, see header comment).
       args="--codequality-output gl-codequality.json"
       [ -n "$I18N_LAYER" ] && args="$args --layer $I18N_LAYER"
+      [ "$I18N_FAIL_ON_ORPHANS" = "true" ] && args="$args --fail-on-orphans"
 
+      # Exit code, not a parsed count, decides the job outcome: 2 means orphans
+      # were found and the gate was requested, anything else non-zero means the
+      # scan itself failed. The count below is for the summary banner only.
+      set +e
       the-i18n-cli remove-orphans $args > .i18n-reports/orphans.json
+      STATUS=$?
+      set -e
 
-      ORPHAN_COUNT=$(jq '.summary.orphanCount // 0' .i18n-reports/orphans.json)
+      if [ "$STATUS" != "0" ] && [ "$STATUS" != "2" ]; then
+        echo "ERROR: orphan scan failed (exit ${STATUS})."
+        cat .i18n-reports/orphans.json
+        exit "$STATUS"
+      fi
+
+      ORPHAN_COUNT=$(jq '.summary.orphanCount // 0' .i18n-reports/orphans.json 2>/dev/null || echo "?")
 
       echo ""
       echo "============================================"
@@ -298,6 +360,10 @@
       echo "============================================"
       echo "Findings appear in the MR Code Quality widget."
       echo "Full report: ${CI_JOB_URL}/artifacts/browse/.i18n-reports/"
+
+      # Propagate the gate: 2 surfaces as a warning via allow_failure.exit_codes
+      # above, or as a hard failure if the extending job sets allow_failure:false.
+      exit "$STATUS"
 
   artifacts:
     paths:
@@ -312,8 +378,11 @@
 .i18n-check:
   extends: .i18n-base
   stage: lint
-  # `check` exits non-zero when any key is used but defined nowhere.
-  # allow_failure keeps that informational (findings still reach the MR
+  # `check` gates unconditionally on exit 1 — a key that renders raw in
+  # production is a defect, not a threshold, so it has no opt-in flag and no
+  # exit 2. That means findings and a crashed scan both surface as 1 here, so
+  # this job cannot use allow_failure.exit_codes the way .i18n-cleanup does.
+  # allow_failure keeps findings informational (they still reach the MR
   # widget) — remove allow_failure on the extending job to make it a gate.
   allow_failure: true
   variables:

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -46,6 +46,14 @@
 #       - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 #       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 #
+# ── Shell ────────────────────────────────────────────────────────────────────
+# These scripts are POSIX sh: `set -eu`, no `pipefail`, no arrays, no
+# PIPESTATUS. The default image is alpine, whose busybox ash accepts
+# `set -o pipefail`, but plain POSIX shells (dash) reject it outright and abort
+# the job with exit 2 before running a line. Staying POSIX keeps the templates
+# working whichever shell an overriding image provides. Commands whose status
+# matters are run unpiped so `$?` is theirs alone.
+#
 # ── Exit codes and gates ─────────────────────────────────────────────────────
 # Every job decides pass/fail from the CLI's exit code, never by parsing counts
 # out of the JSON result. Reading result fields to decide an outcome is what
@@ -171,7 +179,7 @@
 
   script:
     - |
-      set -euo pipefail
+      set -eu
 
       MISSING=""
       [ -z "${I18N_PROVIDER:-}" ] && MISSING="$MISSING I18N_PROVIDER"
@@ -326,7 +334,7 @@
 
   script:
     - |
-      set -euo pipefail
+      set -eu
 
       mkdir -p .i18n-reports
 
@@ -394,7 +402,7 @@
 
   script:
     - |
-      set -euo pipefail
+      set -eu
 
       mkdir -p .i18n-reports
 

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -22,11 +22,23 @@ const binPath = resolve(import.meta.dirname, '../../dist/bin.js')
 
 interface Run { stdout: string, stderr: string, code: number }
 
-async function runScript(script: string, cwd: string, env: Record<string, string>, binDir: string): Promise<Run> {
+/**
+ * GitLab job scripts run under busybox sh in the default alpine image, so they
+ * are exercised with `sh` — running them under bash would hide bash-isms the
+ * runner would reject. The action's steps declare `shell: bash` and use bash
+ * arrays, so those are exercised with bash.
+ */
+async function runScript(
+  script: string,
+  cwd: string,
+  env: Record<string, string>,
+  binDir: string,
+  shell: 'sh' | 'bash' = 'sh',
+): Promise<Run> {
   const scriptPath = join(cwd, '.job.sh')
   await writeFile(scriptPath, script)
   try {
-    const { stdout, stderr } = await execFileAsync('bash', [scriptPath], {
+    const { stdout, stderr } = await execFileAsync(shell, [scriptPath], {
       cwd,
       env: { ...process.env, ...env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
     })
@@ -118,6 +130,69 @@ describe('gitlab-ci.yml job scripts, executed', () => {
       await rm(brokenDir, { recursive: true, force: true })
     })
   })
+
+  /**
+   * The translate job needs a real provider, so its CLI call is stubbed. Its
+   * STATUS branching is the part under test, and I18N_DRY_RUN keeps the run
+   * short of the git and push stages that follow it.
+   */
+  describe('.i18n-translate STATUS branching', () => {
+    async function runTranslate(stubResult: string, stubExit: number): Promise<Run> {
+      const dir = await mkdtemp(join(tmpdir(), 'i18n-tpl-translate-'))
+      const stubBin = join(dir, '.bin')
+      await mkdir(stubBin, { recursive: true })
+      const shim = join(stubBin, 'the-i18n-cli')
+      await writeFile(shim, `#!/bin/sh\ncat <<'JSON'\n${stubResult}\nJSON\nexit ${stubExit}\n`)
+      await chmod(shim, 0o755)
+
+      const run = await runScript(await jobScript('.i18n-translate'), dir, {
+        I18N_PROVIDER: 'openai',
+        I18N_MODEL: 'stub-model',
+        I18N_API_KEY: 'stub',
+        I18N_LAYER: '',
+        I18N_LOCALES: '',
+        I18N_SOURCE_LOCALE: '',
+        I18N_KEYS: '',
+        I18N_BATCH_SIZE: '50',
+        I18N_DRY_RUN: 'true',
+      }, stubBin)
+
+      await rm(dir, { recursive: true, force: true })
+      return run
+    }
+
+    it('exits 0 on a successful run', async () => {
+      const run = await runTranslate(JSON.stringify({ summary: { totalTranslated: 3, totalFailed: 0 } }), 0)
+
+      expect(run.code).toBe(0)
+      expect(run.stdout).toContain('Translated: 3, failed: 0')
+    })
+
+    it('exits 1 and explains the failure when the run itself failed', async () => {
+      const run = await runTranslate(JSON.stringify({ error: { code: 'CONFIG_ERROR', message: 'nope' } }), 1)
+
+      expect(run.code).toBe(1)
+      expect(run.stdout).toContain('translate failed (exit 1)')
+    })
+
+    it('exits 2 and names the gate, distinctly from a failure', async () => {
+      const run = await runTranslate(JSON.stringify({
+        summary: { totalTranslated: 5, totalFailed: 0 },
+        gatesTripped: [{ name: 'fail-on-missing', observed: 12, threshold: 0 }],
+      }), 2)
+
+      expect(run.code).toBe(2)
+      expect(run.stdout).toContain('GATE: fail-on-missing tripped')
+      expect(run.stdout).not.toContain('translate failed')
+    })
+
+    it('trusts the exit code over the counts when they disagree', async () => {
+      const failLooking = JSON.stringify({ summary: { totalTranslated: 0, totalFailed: 9 } })
+
+      expect((await runTranslate(failLooking, 0)).code).toBe(0)
+    })
+  })
+
 })
 
 /**
@@ -165,7 +240,7 @@ describe('action.yml translate step, executed against a stub CLI', () => {
       I18N_PROVIDER: 'openai',
       I18N_API_KEY: 'stub',
       GITHUB_OUTPUT: outputFile,
-    }, binDir)
+    }, binDir, 'bash')
 
     return { ...run, outputs: await readFile(outputFile, 'utf-8') }
   }
@@ -228,21 +303,38 @@ describe('gitlab-ci.yml gate configuration', () => {
   })
 
   it('never decides an outcome from a parsed count', async () => {
-    const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
-    const doc = parse(raw) as Record<string, { script?: string[] }>
+    // Both shipped templates, so the regression cannot come back through
+    // whichever one is not under active edit.
+    const gitlabRaw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
+    const gitlabDoc = parse(gitlabRaw) as Record<string, { script?: string[] }>
 
-    for (const [name, job] of Object.entries(doc)) {
-      if (!job?.script) continue
-      const lines = job.script.join('\n').split('\n')
-      for (const line of lines) {
+    const actionRaw = await readFile(join(repoRoot, 'action.yml'), 'utf-8')
+    const actionDoc = parse(actionRaw) as { runs: { steps: Array<{ name?: string, id?: string, run?: string }> } }
+
+    const scripts: Array<[string, string]> = [
+      ...Object.entries(gitlabDoc)
+        .filter(([, job]) => job?.script)
+        .map(([name, job]) => [`gitlab-ci.yml ${name}`, job.script!.join('\n')] as [string, string]),
+      ...actionDoc.runs.steps
+        .filter(step => step.run)
+        .map(step => [`action.yml ${step.id ?? step.name ?? 'step'}`, step.run!] as [string, string]),
+    ]
+
+    // Both templates must be represented, or a rename could silently empty this.
+    expect(scripts.some(([name]) => name.startsWith('gitlab-ci.yml'))).toBe(true)
+    expect(scripts.some(([name]) => name.startsWith('action.yml'))).toBe(true)
+
+    for (const [name, script] of scripts) {
+      for (const line of script.split('\n')) {
         // A jq result may be echoed or assigned, but must never be the
         // subject of a test that exits.
-        if (/\bexit\b/.test(line) && /\$\(jq|\bjq\b/.test(line)) {
+        if (/\bexit\b/.test(line) && /\bjq\b/.test(line)) {
           throw new Error(`${name}: exit decided from a jq expression: ${line.trim()}`)
         }
       }
       // Counts parsed for display must not feed a numeric comparison guarding an exit.
-      expect(job.script.join('\n')).not.toMatch(/if \[ "\$(ORPHAN_COUNT|TRANSLATED|FAILED)"/)
+      expect(script).not.toMatch(/if \[ "\$(ORPHAN_COUNT|TRANSLATED|FAILED)"/)
+      expect(script).not.toMatch(/if \[ "\$\{?(count|failed)\}?" -(gt|eq|lt) 0 \].*\n?\s*(exit|echo "::error)/)
     }
   })
 })

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -1,0 +1,248 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, mkdir, writeFile, readFile, chmod, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, '../../../..')
+const binPath = resolve(import.meta.dirname, '../../dist/bin.js')
+
+/**
+ * Behavioural tests for the shipped CI templates (#254): the job scripts are
+ * extracted from the real YAML and executed against the real CLI, so the
+ * exit-code contract is verified by running it rather than by grepping the
+ * template. Requires a built dist (CI builds before testing).
+ *
+ * A `the-i18n-cli` shim on PATH stands in for the globally installed CLI that
+ * the templates' before_script would provide.
+ */
+
+interface Run { stdout: string, stderr: string, code: number }
+
+async function runScript(script: string, cwd: string, env: Record<string, string>, binDir: string): Promise<Run> {
+  const scriptPath = join(cwd, '.job.sh')
+  await writeFile(scriptPath, script)
+  try {
+    const { stdout, stderr } = await execFileAsync('bash', [scriptPath], {
+      cwd,
+      env: { ...process.env, ...env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    })
+    return { stdout, stderr, code: 0 }
+  } catch (error) {
+    const e = error as { stdout?: string, stderr?: string, code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: e.code ?? 1 }
+  }
+}
+
+async function jobScript(name: string): Promise<string> {
+  const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
+  const doc = parse(raw) as Record<string, { script: string[] }>
+  const job = doc[name]
+  if (!job) throw new Error(`job ${name} not found in gitlab-ci.yml`)
+  return job.script.join('\n')
+}
+
+describe('gitlab-ci.yml job scripts, executed', () => {
+  let projectDir: string
+  let binDir: string
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'i18n-tpl-exec-'))
+
+    // Shim standing in for the globally installed CLI.
+    binDir = join(projectDir, '.bin')
+    await mkdir(binDir, { recursive: true })
+    const shim = join(binDir, 'the-i18n-cli')
+    await writeFile(shim, `#!/bin/sh\nexec "${process.execPath}" "${binPath}" "$@"\n`)
+    await chmod(shim, 0o755)
+
+    await mkdir(join(projectDir, 'locales'), { recursive: true })
+    await mkdir(join(projectDir, 'src'), { recursive: true })
+    await writeFile(
+      join(projectDir, '.i18n-mcp.json'),
+      JSON.stringify({ defaultLocale: 'en', localeDirs: ['locales'], locales: ['en'] }),
+    )
+    await writeFile(
+      join(projectDir, 'locales/en.json'),
+      JSON.stringify({ common: { greeting: 'Hello', farewell: 'Goodbye' } }),
+    )
+    // Only common.greeting is referenced, so common.farewell is an orphan.
+    await writeFile(join(projectDir, 'src/app.ts'), `export const a = t('common.greeting')\n`)
+  })
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  const cleanupEnv = (failOnOrphans: string) => ({
+    I18N_LAYER: '',
+    I18N_FAIL_ON_ORPHANS: failOnOrphans,
+    CI_JOB_URL: 'https://example.test/job/1',
+  })
+
+  describe('.i18n-cleanup', () => {
+    it('exits 0 on findings when the gate is not requested', async () => {
+      const run = await runScript(await jobScript('.i18n-cleanup'), projectDir, cleanupEnv('false'), binDir)
+
+      expect(run.code).toBe(0)
+      // The findings are still reported — the gate governs the outcome, not the report.
+      expect(run.stdout).toContain('Orphan keys found: 1')
+    })
+
+    it('exits 2 on findings when I18N_FAIL_ON_ORPHANS is true', async () => {
+      const run = await runScript(await jobScript('.i18n-cleanup'), projectDir, cleanupEnv('true'), binDir)
+
+      expect(run.code).toBe(2)
+      expect(run.stdout).toContain('Orphan keys found: 1')
+    })
+
+    it('still writes the Code Quality artifact when the gate trips', async () => {
+      await runScript(await jobScript('.i18n-cleanup'), projectDir, cleanupEnv('true'), binDir)
+
+      const report = JSON.parse(await readFile(join(projectDir, 'gl-codequality.json'), 'utf-8'))
+      expect(Array.isArray(report)).toBe(true)
+      expect(report.length).toBeGreaterThan(0)
+    })
+
+    // Exit 1 and exit 2 must not look alike: allow_failure.exit_codes: [2]
+    // only tells warnings from failures if a broken run exits something else.
+    it('exits 1, not 2, when the scan itself fails', async () => {
+      const brokenDir = await mkdtemp(join(tmpdir(), 'i18n-tpl-broken-'))
+      const run = await runScript(await jobScript('.i18n-cleanup'), brokenDir, cleanupEnv('true'), binDir)
+
+      expect(run.code).toBe(1)
+      expect(run.stdout).toContain('orphan scan failed (exit 1)')
+      await rm(brokenDir, { recursive: true, force: true })
+    })
+  })
+})
+
+/**
+ * The action's translate step needs a real provider, so it cannot be driven
+ * end-to-end here. Its exit-code branching can be: a stub CLI returns a chosen
+ * result and exit code, and the step must react to the code rather than to the
+ * counts in the payload — including when the two disagree.
+ */
+describe('action.yml translate step, executed against a stub CLI', () => {
+  let workDir: string
+
+  beforeAll(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'i18n-action-exec-'))
+  })
+
+  afterAll(async () => {
+    await rm(workDir, { recursive: true, force: true })
+  })
+
+  async function translateStepScript(): Promise<string> {
+    const raw = await readFile(join(repoRoot, 'action.yml'), 'utf-8')
+    const doc = parse(raw) as { runs: { steps: Array<{ id?: string, run?: string }> } }
+    const step = doc.runs.steps.find(s => s.id === 'translate')
+    if (!step?.run) throw new Error('translate step not found in action.yml')
+
+    // Composite-action expressions are resolved by the runner, not by bash.
+    return step.run
+      .replace(/\$\{\{\s*inputs\.dry_run\s*\}\}/g, 'false')
+      .replace(/\$\{\{\s*inputs\.(locales|source_locale|keys)\s*\}\}/g, '')
+      .replace(/\$\{\{\s*inputs\.\w+\s*\}\}/g, 'stub')
+  }
+
+  async function runStep(stubResult: string, stubExit: number): Promise<Run & { outputs: string }> {
+    const dir = await mkdtemp(join(workDir, 'case-'))
+    const binDir = join(dir, '.bin')
+    await mkdir(binDir, { recursive: true })
+    const shim = join(binDir, 'the-i18n-cli')
+    await writeFile(shim, `#!/bin/sh\ncat <<'JSON'\n${stubResult}\nJSON\nexit ${stubExit}\n`)
+    await chmod(shim, 0o755)
+
+    const outputFile = join(dir, 'github_output')
+    await writeFile(outputFile, '')
+
+    const run = await runScript(await translateStepScript(), dir, {
+      I18N_PROVIDER: 'openai',
+      I18N_API_KEY: 'stub',
+      GITHUB_OUTPUT: outputFile,
+    }, binDir)
+
+    return { ...run, outputs: await readFile(outputFile, 'utf-8') }
+  }
+
+  it('succeeds when the CLI exits 0', async () => {
+    const run = await runStep(JSON.stringify({ summary: { totalTranslated: 3, totalFailed: 0 } }), 0)
+
+    expect(run.code).toBe(0)
+    expect(run.outputs).toContain('translated_count=3')
+    expect(run.outputs).toContain('failed_count=0')
+  })
+
+  it('propagates exit 1 as a run failure', async () => {
+    const run = await runStep(JSON.stringify({ error: { code: 'CONFIG_ERROR', message: 'nope' } }), 1)
+
+    expect(run.code).toBe(1)
+    expect(run.stdout).toContain('translate failed (exit 1)')
+  })
+
+  it('propagates exit 2 as a gate, named and distinct from a failure', async () => {
+    const run = await runStep(JSON.stringify({
+      summary: { totalTranslated: 5, totalFailed: 0 },
+      gatesTripped: [{ name: 'fail-on-missing', observed: 12, threshold: 0 }],
+    }), 2)
+
+    expect(run.code).toBe(2)
+    expect(run.stdout).toContain('CI gate tripped: fail-on-missing')
+    expect(run.stdout).not.toContain('translate failed')
+  })
+
+  // The old implementation decided from these counts, so a payload whose
+  // counts and exit code disagree is exactly what would regress.
+  it('trusts the exit code over the counts when they disagree', async () => {
+    const failLooking = JSON.stringify({ summary: { totalTranslated: 0, totalFailed: 9 } })
+
+    expect((await runStep(failLooking, 0)).code).toBe(0)
+    expect((await runStep(JSON.stringify({ summary: { totalTranslated: 9, totalFailed: 0 } }), 1)).code).toBe(1)
+  })
+
+  it('still emits counts for the step outputs when the run failed', async () => {
+    const run = await runStep(JSON.stringify({ summary: { totalTranslated: 0, totalFailed: 4 } }), 1)
+
+    expect(run.outputs).toContain('failed_count=4')
+  })
+})
+
+describe('gitlab-ci.yml gate configuration', () => {
+  it('allows exit 2 only, so a broken scan still fails the cleanup job red', async () => {
+    const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
+    const doc = parse(raw) as Record<string, { allow_failure?: unknown }>
+
+    expect(doc['.i18n-cleanup'].allow_failure).toEqual({ exit_codes: [2] })
+  })
+
+  it('declares the orphan gate as an opt-in variable defaulting to off', async () => {
+    const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
+    const doc = parse(raw) as Record<string, { variables: Record<string, string> }>
+
+    expect(doc['.i18n-cleanup'].variables.I18N_FAIL_ON_ORPHANS).toBe('false')
+  })
+
+  it('never decides an outcome from a parsed count', async () => {
+    const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
+    const doc = parse(raw) as Record<string, { script?: string[] }>
+
+    for (const [name, job] of Object.entries(doc)) {
+      if (!job?.script) continue
+      const lines = job.script.join('\n').split('\n')
+      for (const line of lines) {
+        // A jq result may be echoed or assigned, but must never be the
+        // subject of a test that exits.
+        if (/\bexit\b/.test(line) && /\$\(jq|\bjq\b/.test(line)) {
+          throw new Error(`${name}: exit decided from a jq expression: ${line.trim()}`)
+        }
+      }
+      // Counts parsed for display must not feed a numeric comparison guarding an exit.
+      expect(job.script.join('\n')).not.toMatch(/if \[ "\$(ORPHAN_COUNT|TRANSLATED|FAILED)"/)
+    }
+  })
+})

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { mkdtemp, mkdir, writeFile, readFile, chmod, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -24,16 +25,20 @@ interface Run { stdout: string, stderr: string, code: number }
 
 /**
  * GitLab job scripts run under busybox sh in the default alpine image, so they
- * are exercised with `sh` — running them under bash would hide bash-isms the
- * runner would reject. The action's steps declare `shell: bash` and use bash
- * arrays, so those are exercised with bash.
+ * are exercised with a POSIX shell — running them under bash would hide
+ * bash-isms the runner would reject. `dash` is preferred where present because
+ * macOS `/bin/sh` is bash in POSIX mode and still accepts constructs a real
+ * POSIX shell rejects (`set -o pipefail` among them), which would let a
+ * portability regression pass locally and fail on CI. The action's steps
+ * declare `shell: bash` and use bash arrays, so those are exercised with bash.
  */
+const posixShell = existsSync('/bin/dash') ? '/bin/dash' : 'sh'
 async function runScript(
   script: string,
   cwd: string,
   env: Record<string, string>,
   binDir: string,
-  shell: 'sh' | 'bash' = 'sh',
+  shell: string = posixShell,
 ): Promise<Run> {
   const scriptPath = join(cwd, '.job.sh')
   await writeFile(scriptPath, script)


### PR DESCRIPTION
Closes #254. Consumes #248 and closes out the anny-ui pipeline story.

## The problem

Both reference pipelines decided pass/fail by parsing counts out of JSON. That coupling to undocumented output shapes is what broke the anny-ui pipeline — templates read `.summary.totalOrphans` when the field is `.summary.orphanCount`. Those names were fixed; the coupling that produced them was not.

## What changed

Every job now branches on the CLI's exit code: `0` success, `1` the run itself failed, `2` a requested gate tripped. Counts are still parsed — for step outputs, log lines and the summary banner — but never to decide an outcome.

**`.i18n-cleanup`** is where exit `2` earns its keep:

```yaml
allow_failure:
  exit_codes: [2]
```

Orphans surface as a yellow warning, while a genuinely broken scan still fails the job red. Previously `allow_failure: true` meant a crashed scan and a clean scan looked identical. Opt in with `I18N_FAIL_ON_ORPHANS: "true"`, and set `allow_failure: false` to make orphans block the merge.

**`.i18n-check`** keeps exit `1` for findings by design, so it cannot make the same split. The template now says so rather than leaving it implicit.

**GitHub Action** — the `failed > 0 && count == 0` check exactly duplicated the CLI's built-in `isTotalFailure`, so it is gone. Exit `2` is reported distinctly, naming the tripped gate.

## Two things found while editing

1. **The GitLab translate job's `jq` check was already unreachable.** Under `set -o pipefail`, `the-i18n-cli translate | tee` already aborted the job on a non-zero exit, so the `if [ "$FAILED" -gt 0 ]` block below it could never run. Replaced with an explicit status capture — which also avoids `PIPESTATUS`, since that is bash-only and these jobs run on busybox `sh` in the default alpine image.
2. **`I18N_LAYER` was documented as required** in both README variable tables, but the template declares it with an empty default and `gitlab-template.test.ts` explicitly asserts it is optional. Corrected both rows.

## Verification

The ticket asks for behaviour verified by a real run rather than by inspection, so `tests/cli/template-gate-execution.test.ts` **extracts the job scripts from the real YAML and executes them**:

- `.i18n-cleanup` runs against the **real CLI** on a fixture with one orphan — exit `0` without the gate, exit `2` with it, and exit `1` (not `2`) when the scan itself fails. That last case is what makes `allow_failure.exit_codes` meaningful.
- The Code Quality artifact is asserted to still be written when the gate trips.
- The action's translate step needs a real provider, so it runs against a **stub CLI** whose exit code and payload counts deliberately disagree — proving the step trusts the code, not the counts. That is precisely the regression the old implementation would produce.
- A structural test fails the build if any job script ever decides an `exit` from a `jq` expression again.

12 new tests. Full suite: 825 CLI (up from 809) + 26 MCP passing, lint and typecheck clean with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional orphan detection gating for cleanup jobs with `I18N_FAIL_ON_ORPHANS`.
  * Made `I18N_LAYER` optional, enabling translation and cleanup across all layers when omitted.

* **Bug Fixes**
  * Improved handling of translation and cleanup outcomes using CLI exit statuses.
  * Added clearer reporting for translation failures, orphan warnings, and scan failures.
  * Preserved generated artifacts and command output across job outcomes.

* **Documentation**
  * Clarified CI exit-code behavior, cleanup warnings, and check-job failure semantics.
  * Added guidance for managing project specifications and issues through GitHub Issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->