### PR TITLE
fix(cli): report unresolved and ambiguous locale refs instead of dropping them

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,6 +96,28 @@ Gates compose on one invocation, and a failed run outranks a tripped gate — ex
 
 `check` is the exception: it gates unconditionally with exit `1`, because a key that renders raw in production is a defect rather than a threshold.
 
+## Referring to Locales
+
+Anywhere a locale is named — `--ref`, `--targets`, `protectedLocales`, the keys of a `write_translations` payload — you may use the locale's **code**, its **language tag**, or its **file name** (extension included). Resolution takes them in that order.
+
+**Prefer the code.** Codes are unique by construction; language tags are not. A project can declare an informal and a formal German that both carry `language: "de-DE"`, in which case `de-DE` is ambiguous — it resolves to the first match, and that depends on the order of your framework's locale array. The precedence rule guarantees only that a locale's own code is never shadowed by a *different* locale's language tag.
+
+A ref that matches nothing is reported rather than silently dropped:
+
+```json
+{
+  "written": ["common.save"],
+  "filesWritten": 2,
+  "unresolvedLocales": [
+    { "ref": "de-DE-formal", "keys": ["common.save"], "suggestion": "Did you mean \"de-formal\" or \"de-DE\" or \"de-DE-formal.json\"?" }
+  ]
+}
+```
+
+`unresolvedLocales` is the only reliable signal that a write did less than you asked: the key still appears in `written` because the other locales succeeded, and `filesWritten` is short by one. A ref matching several locales is reported the same way under `ambiguousLocales`, naming every candidate and the one that was used. Both fields are absent when every ref resolves uniquely, so a clean write is byte-for-byte what it always was.
+
+Note that a locale's `file` must be given with its extension (`de-DE-formal.json`); the bare stem is not a valid ref.
+
 ## Translation Modes
 
 `translate` and `translate-key` run in one of two modes — every result reports which one ran (`mode: "provider" | "agent" | "dry-run"`).

--- a/packages/cli/src/core/ops-write.ts
+++ b/packages/cli/src/core/ops-write.ts
@@ -27,8 +27,10 @@ import type {
   ScaffoldLocaleResult,
   ScaffoldLocaleFileInfo,
   PlaceholderValidationResult,
+  UnresolvedLocaleRef,
 } from './types.js'
-import { findWritableLayerOrThrow, findLocaleImpl, findLocaleSuggestion } from './shared.js'
+import { findWritableLayerOrThrow, findLocaleImpl, findLocaleSuggestion, resolveLocaleRef } from './shared.js'
+import type { LocaleRefAmbiguity } from './shared.js'
 import { validatePlaceholders, mergePlaceholderValidation } from './ops-translate.js'
 
 /**
@@ -45,6 +47,8 @@ async function applyTranslations(
   const applied: string[] = []
   const skipped: string[] = []
   const warnings: string[] = []
+  const unresolved = new Map<string, UnresolvedLocaleRef>()
+  const ambiguities = new Map<string, LocaleRefAmbiguity>()
   const filesWritten = new Set<string>()
   const preview: Array<{ locale: string; key: string; value: string }> = []
 
@@ -73,9 +77,30 @@ async function applyTranslations(
           warnings.push(`${key} (${localeRef}): ${warning}`)
         }
       }
-      const locale = findLocale(config, localeRef)
+      const { locale, ambiguity } = resolveLocaleRef(config, localeRef)
+      if (ambiguity && !ambiguities.has(localeRef)) {
+        ambiguities.set(localeRef, ambiguity)
+        log.warn(
+          `Locale ref "${localeRef}" matches ${ambiguity.candidates.length} locales by ${ambiguity.matchedBy} `
+          + `(${ambiguity.candidates.join(', ')}) — using "${ambiguity.resolvedTo}". Use a locale code to be explicit.`,
+        )
+      }
       if (!locale) {
-        log.warn(`Locale not found: ${localeRef}, skipping.${findLocaleSuggestion(config, localeRef)}`)
+        // stderr alone is invisible to an MCP caller, and the key still lands
+        // in `applied` via the other locales — so the result must carry this
+        // or the write reads as a clean success (#301).
+        const suggestion = findLocaleSuggestion(config, localeRef)
+        log.warn(`Locale not found: ${localeRef}, skipping.${suggestion}`)
+        const existing = unresolved.get(localeRef)
+        if (existing) {
+          existing.keys.push(key)
+        } else {
+          unresolved.set(localeRef, {
+            ref: localeRef,
+            keys: [key],
+            ...(suggestion ? { suggestion: suggestion.trim() } : {}),
+          })
+        }
         continue
       }
       if (!byLocale.has(locale)) {
@@ -124,11 +149,29 @@ async function applyTranslations(
       : `${error.key} (${error.locale}): placeholder mismatch; missing: ${error.missing.join(', ') || '-'}; extra: ${error.extra.join(', ') || '-'}`))
   }
 
+  // A dropped ref is a warning too, so callers that only read `warnings`
+  // still see it — but it also gets its own field, because "the write silently
+  // did less than you asked" is not the same class as a placeholder nit.
+  for (const u of unresolved.values()) {
+    warnings.push(
+      `Locale "${u.ref}" matched no known locale — ${u.keys.length} key(s) not written for it.`
+      + (u.suggestion ? ` ${u.suggestion}` : ''),
+    )
+  }
+
   const result: MutationResult = {
     applied: [...new Set(applied)],
     skipped: [...new Set(skipped)],
     warnings,
     filesWritten: filesWritten.size,
+  }
+
+  if (unresolved.size > 0) {
+    result.unresolvedLocales = [...unresolved.values()]
+  }
+
+  if (ambiguities.size > 0) {
+    result.ambiguousLocales = [...ambiguities.values()]
   }
 
   if (placeholderValidation) {
@@ -163,7 +206,7 @@ export async function writeTranslations(opts: {
   const mode = opts.mode ?? 'upsert'
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation } = await applyTranslations(
+  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
     config, layer, translations, mode, findLocaleImpl, isDryRun,
   )
 
@@ -181,6 +224,8 @@ export async function writeTranslations(opts: {
     if (skipped.length > 0) { result.skippedKeys = skipped }
     if (warnings.length > 0) { result.warnings = warnings }
     if (placeholderValidation) { result.placeholderValidation = placeholderValidation }
+    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
+    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
     return result
   }
 
@@ -191,6 +236,8 @@ export async function writeTranslations(opts: {
   }
   if (warnings.length > 0) { result.warnings = warnings }
   if (placeholderValidation) { result.placeholderValidation = placeholderValidation }
+  if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
+  if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
   return result
 }
 
@@ -210,7 +257,7 @@ export async function addTranslations(opts: {
   const config = await detectI18nConfig(dir)
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation } = await applyTranslations(
+  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
     config, layer, translations, 'add', findLocaleImpl, isDryRun,
   )
 
@@ -234,6 +281,8 @@ export async function addTranslations(opts: {
     if (placeholderValidation) {
       result.placeholderValidation = placeholderValidation
     }
+    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
+    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
     return result
   }
 
@@ -248,6 +297,8 @@ export async function addTranslations(opts: {
   if (placeholderValidation) {
     summary.placeholderValidation = placeholderValidation
   }
+  if (unresolvedLocales) { summary.unresolvedLocales = unresolvedLocales }
+  if (ambiguousLocales) { summary.ambiguousLocales = ambiguousLocales }
 
   return summary
 }
@@ -268,7 +319,7 @@ export async function updateTranslations(opts: {
   const config = await detectI18nConfig(dir)
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, filesWritten, preview, placeholderValidation } = await applyTranslations(
+  const { applied, skipped, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
     config, layer, translations, 'update', findLocaleImpl, isDryRun,
   )
 
@@ -289,6 +340,8 @@ export async function updateTranslations(opts: {
     if (placeholderValidation) {
       result.placeholderValidation = placeholderValidation
     }
+    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
+    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
     return result
   }
 

--- a/packages/cli/src/core/ops-write.ts
+++ b/packages/cli/src/core/ops-write.ts
@@ -185,6 +185,32 @@ async function applyTranslations(
   return result
 }
 
+/** The optional diagnostics every mutation result carries. */
+interface MutationDiagnostics {
+  warnings?: string[]
+  placeholderValidation?: PlaceholderValidationResult
+  unresolvedLocales?: UnresolvedLocaleRef[]
+  ambiguousLocales?: LocaleRefAmbiguity[]
+}
+
+/**
+ * Copy the diagnostics off a MutationResult onto a public result, omitting the
+ * empty ones so a clean run keeps its minimal shape. Centralised so the
+ * write/add/update branches cannot drift apart on which of them they remember
+ * to surface — they already had, before unresolvedLocales existed.
+ */
+function attachDiagnostics<T extends MutationDiagnostics>(
+  result: T,
+  mutation: MutationResult,
+  opts: { warnings?: boolean } = {},
+): T {
+  if (opts.warnings !== false && mutation.warnings.length > 0) result.warnings = mutation.warnings
+  if (mutation.placeholderValidation) result.placeholderValidation = mutation.placeholderValidation
+  if (mutation.unresolvedLocales) result.unresolvedLocales = mutation.unresolvedLocales
+  if (mutation.ambiguousLocales) result.ambiguousLocales = mutation.ambiguousLocales
+  return result
+}
+
 /**
  * Write translation keys to the specified layer with mode control.
  *
@@ -206,9 +232,8 @@ export async function writeTranslations(opts: {
   const mode = opts.mode ?? 'upsert'
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
-    config, layer, translations, mode, findLocaleImpl, isDryRun,
-  )
+  const mutation = await applyTranslations(config, layer, translations, mode, findLocaleImpl, isDryRun)
+  const { applied, skipped, filesWritten, preview } = mutation
 
   if (isDryRun) {
     const result: WriteTranslationsResult = {
@@ -222,23 +247,14 @@ export async function writeTranslations(opts: {
       },
     }
     if (skipped.length > 0) { result.skippedKeys = skipped }
-    if (warnings.length > 0) { result.warnings = warnings }
-    if (placeholderValidation) { result.placeholderValidation = placeholderValidation }
-    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
-    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
-    return result
+    return attachDiagnostics(result, mutation)
   }
 
-  const result: WriteTranslationsResult = {
+  return attachDiagnostics({
     written: applied,
     skipped,
     filesWritten,
-  }
-  if (warnings.length > 0) { result.warnings = warnings }
-  if (placeholderValidation) { result.placeholderValidation = placeholderValidation }
-  if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
-  if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
-  return result
+  } as WriteTranslationsResult, mutation)
 }
 
 /**
@@ -257,9 +273,8 @@ export async function addTranslations(opts: {
   const config = await detectI18nConfig(dir)
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, warnings, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
-    config, layer, translations, 'add', findLocaleImpl, isDryRun,
-  )
+  const mutation = await applyTranslations(config, layer, translations, 'add', findLocaleImpl, isDryRun)
+  const { applied, skipped, filesWritten, preview } = mutation
 
   if (isDryRun) {
     const result: AddTranslationsResult = {
@@ -275,32 +290,14 @@ export async function addTranslations(opts: {
     if (skipped.length > 0) {
       result.skippedKeys = skipped
     }
-    if (warnings.length > 0) {
-      result.warnings = warnings
-    }
-    if (placeholderValidation) {
-      result.placeholderValidation = placeholderValidation
-    }
-    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
-    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
-    return result
+    return attachDiagnostics(result, mutation)
   }
 
-  const summary: AddTranslationsResult = {
+  return attachDiagnostics({
     added: applied,
     skipped,
     filesWritten,
-  }
-  if (warnings.length > 0) {
-    summary.warnings = warnings
-  }
-  if (placeholderValidation) {
-    summary.placeholderValidation = placeholderValidation
-  }
-  if (unresolvedLocales) { summary.unresolvedLocales = unresolvedLocales }
-  if (ambiguousLocales) { summary.ambiguousLocales = ambiguousLocales }
-
-  return summary
+  } as AddTranslationsResult, mutation)
 }
 
 /**
@@ -319,9 +316,8 @@ export async function updateTranslations(opts: {
   const config = await detectI18nConfig(dir)
   const isDryRun = opts.dryRun ?? false
 
-  const { applied, skipped, filesWritten, preview, placeholderValidation, unresolvedLocales, ambiguousLocales } = await applyTranslations(
-    config, layer, translations, 'update', findLocaleImpl, isDryRun,
-  )
+  const mutation = await applyTranslations(config, layer, translations, 'update', findLocaleImpl, isDryRun)
+  const { applied, skipped, filesWritten, preview } = mutation
 
   if (isDryRun) {
     const result: UpdateTranslationsResult = {
@@ -337,23 +333,16 @@ export async function updateTranslations(opts: {
     if (skipped.length > 0) {
       result.skippedKeys = skipped
     }
-    if (placeholderValidation) {
-      result.placeholderValidation = placeholderValidation
-    }
-    if (unresolvedLocales) { result.unresolvedLocales = unresolvedLocales }
-    if (ambiguousLocales) { result.ambiguousLocales = ambiguousLocales }
-    return result
+    // warnings: false — updateTranslations has never surfaced them, and this
+    // deprecated wrapper is not the place to change its contract.
+    return attachDiagnostics(result, mutation, { warnings: false })
   }
 
-  const result: UpdateTranslationsResult = {
+  return attachDiagnostics({
     updated: applied,
     skipped,
     filesWritten,
-  }
-  if (placeholderValidation) {
-    result.placeholderValidation = placeholderValidation
-  }
-  return result
+  } as UpdateTranslationsResult, mutation, { warnings: false })
 }
 
 /**

--- a/packages/cli/src/core/shared.ts
+++ b/packages/cli/src/core/shared.ts
@@ -62,7 +62,10 @@ export function localeRefInfo(locale: LocaleDefinition): LocaleRefInfo {
 }
 
 function localeAcceptedRefs(locale: LocaleDefinition): string[] {
-  return [locale.code, locale.language, locale.file].filter(Boolean) as string[]
+  // Deduped: code and language are frequently the same string (a generic
+  // adapter derives both from the filename), and "de" or "de" or "de.json"
+  // reads like a bug in the suggestion rather than one locale's three refs.
+  return [...new Set([locale.code, locale.language, locale.file].filter(Boolean) as string[])]
 }
 
 function formatLocaleChoices(locales: LocaleDefinition[]): string {
@@ -71,27 +74,97 @@ function formatLocaleChoices(locales: LocaleDefinition[]): string {
     .join('\n')
 }
 
+const stripJson = (ref: string) => (ref.endsWith('.json') ? ref.slice(0, -5) : ref)
+
+/**
+ * How well one of a locale's refs matches the requested one. Higher wins.
+ * Ranking matters rather than first-match: for "de-DE-formal", the informal
+ * `de` locale matches by containment (its language is `de-DE`) while the
+ * formal one matches exactly once `.json` is stripped from its file name.
+ * First-match order returned `de`, pointing the caller at the wrong locale —
+ * following that hint would write formal German into the informal file (#301).
+ */
+function suggestionScore(locale: LocaleDefinition, normalized: string): number {
+  let best = 0
+  for (const ref of localeAcceptedRefs(locale)) {
+    const candidate = stripJson(ref)
+    if (candidate === normalized) return 3
+    if (candidate.toLowerCase() === normalized.toLowerCase()) best = Math.max(best, 2)
+    else if (candidate.includes(normalized) || normalized.includes(candidate)) best = Math.max(best, 1)
+  }
+  return best
+}
+
 export function findLocaleSuggestion(config: I18nConfig, localeRef: string): string {
-  const normalized = localeRef.endsWith('.json') ? localeRef.slice(0, -5) : localeRef
-  const suggestion = config.locales.find((locale) => {
-    return localeAcceptedRefs(locale).some((ref) => {
-      const normalizedRef = ref.endsWith('.json') ? ref.slice(0, -5) : ref
-      return normalizedRef === normalized
-        || normalizedRef.toLowerCase() === normalized.toLowerCase()
-        || normalizedRef.includes(normalized)
-        || normalized.includes(normalizedRef)
-    })
-  })
+  const normalized = stripJson(localeRef)
+
+  let suggestion: LocaleDefinition | undefined
+  let bestScore = 0
+  for (const locale of config.locales) {
+    const score = suggestionScore(locale, normalized)
+    if (score > bestScore) {
+      bestScore = score
+      suggestion = locale
+    }
+  }
   if (!suggestion) return ''
 
   const refs = localeAcceptedRefs(suggestion).map(ref => `"${ref}"`).join(' or ')
   return ` Did you mean ${refs}?`
 }
 
+/** Fields a locale ref may match, in resolution precedence order. */
+const LOCALE_MATCH_FIELDS = ['code', 'language', 'file'] as const
+export type LocaleMatchField = (typeof LOCALE_MATCH_FIELDS)[number]
+
+export interface LocaleRefAmbiguity {
+  ref: string
+  /** The field that matched more than one locale. */
+  matchedBy: LocaleMatchField
+  /** Codes of every locale the ref matched, in config order. */
+  candidates: string[]
+  /** The one that was used — the first candidate. */
+  resolvedTo: string
+}
+
+export interface LocaleRefResolution {
+  locale?: LocaleDefinition
+  ambiguity?: LocaleRefAmbiguity
+}
+
+/**
+ * Resolve a locale ref with deliberate precedence: an exact `code` outranks a
+ * `language` tag, which outranks a `file` name.
+ *
+ * Codes are unique by construction; language tags are not — two locales can
+ * both declare `de-DE` (an informal and a formal German, say). Without
+ * precedence, a locale's unique code could be shadowed by a different locale's
+ * language tag purely through config ordering. Within one field a ref that
+ * still matches several locales is reported as ambiguous rather than silently
+ * resolved to whichever came first, because that choice depends on array order
+ * and can change under the caller without warning (#301).
+ */
+export function resolveLocaleRef(config: I18nConfig, localeRef: string): LocaleRefResolution {
+  for (const field of LOCALE_MATCH_FIELDS) {
+    const matches = config.locales.filter(locale => locale[field] === localeRef)
+    const [first] = matches
+    if (!first) continue
+    if (matches.length === 1) return { locale: first }
+    return {
+      locale: first,
+      ambiguity: {
+        ref: localeRef,
+        matchedBy: field,
+        candidates: matches.map(m => m.code),
+        resolvedTo: first.code,
+      },
+    }
+  }
+  return {}
+}
+
 export function findLocaleImpl(config: I18nConfig, localeRef: string) {
-  return config.locales.find(
-    l => l.code === localeRef || l.file === localeRef || l.language === localeRef,
-  )
+  return resolveLocaleRef(config, localeRef).locale
 }
 
 /**

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -6,6 +6,8 @@
 // ─── detect_i18n_config ──────────────────────────────────────────
 // Returns I18nConfig directly (re-exported from config/types)
 export type { I18nConfig } from '../config/types.js'
+import type { LocaleRefAmbiguity } from './shared.js'
+export type { LocaleRefAmbiguity } from './shared.js'
 
 // ─── list_locale_dirs ────────────────────────────────────────────
 
@@ -56,6 +58,19 @@ export interface LocaleRefInfo {
   name?: string
 }
 
+/**
+ * A locale ref in the request that matched no known locale. Its values were
+ * not written; the keys still appear in `written` because other locales
+ * succeeded, so this field is the only signal the write did less than asked.
+ */
+export interface UnresolvedLocaleRef {
+  ref: string
+  /** Keys whose value for this ref was dropped. */
+  keys: string[]
+  /** "Did you mean …?", when a near match exists. */
+  suggestion?: string
+}
+
 export interface MutationResult {
   applied: string[]
   skipped: string[]
@@ -63,6 +78,10 @@ export interface MutationResult {
   filesWritten: number
   preview?: MutationPreview[]
   placeholderValidation?: PlaceholderValidationResult
+  /** Present only when a ref resolved to nothing. */
+  unresolvedLocales?: UnresolvedLocaleRef[]
+  /** Present only when a ref matched several locales and precedence picked one. */
+  ambiguousLocales?: LocaleRefAmbiguity[]
 }
 
 export interface AddTranslationsResult {
@@ -74,6 +93,10 @@ export interface AddTranslationsResult {
   skipped: string[]
   filesWritten?: number
   warnings?: string[]
+  /** Present only when a locale ref resolved to nothing — see UnresolvedLocaleRef. */
+  unresolvedLocales?: UnresolvedLocaleRef[]
+  /** Present only when a locale ref matched several locales. */
+  ambiguousLocales?: LocaleRefAmbiguity[]
   placeholderValidation?: PlaceholderValidationResult
   summary?: {
     keysToAdd: number
@@ -93,6 +116,10 @@ export interface WriteTranslationsResult {
   filesWritten?: number
   warnings?: string[]
   placeholderValidation?: PlaceholderValidationResult
+  /** Present only when a locale ref resolved to nothing — see UnresolvedLocaleRef. */
+  unresolvedLocales?: UnresolvedLocaleRef[]
+  /** Present only when a locale ref matched several locales. */
+  ambiguousLocales?: LocaleRefAmbiguity[]
   summary?: {
     keysWritten: number
     keysSkipped: number
@@ -109,6 +136,10 @@ export interface UpdateTranslationsResult {
   updated?: string[]
   skipped: string[]
   filesWritten?: number
+  /** Present only when a locale ref resolved to nothing — see UnresolvedLocaleRef. */
+  unresolvedLocales?: UnresolvedLocaleRef[]
+  /** Present only when a locale ref matched several locales. */
+  ambiguousLocales?: LocaleRefAmbiguity[]
   placeholderValidation?: PlaceholderValidationResult
   summary?: {
     keysToUpdate: number

--- a/packages/cli/tests/core/locale-ref-resolution.test.ts
+++ b/packages/cli/tests/core/locale-ref-resolution.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { resolveLocaleRef, findLocaleImpl, findLocaleSuggestion } from '../../src/core/shared.js'
+import type { I18nConfig } from '../../src/config/types.js'
+
+/**
+ * Locale-ref resolution (#301). The real-world shape this guards against is
+ * anny-ui's, where two locales share a language tag:
+ *
+ *   code=de         language=de-DE  file=de-DE.json
+ *   code=de-formal  language=de-DE  file=de-DE-formal.json
+ *
+ * so "de-DE" matches two locales and "de-DE-formal" matches none — it is not a
+ * code, not a language tag, and the file carries a .json extension.
+ */
+const config = {
+  locales: [
+    { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+    { code: 'de-formal', language: 'de-DE', file: 'de-DE-formal.json' },
+    { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+    { code: 'en-us', language: 'en-US', file: 'en-US.json' },
+  ],
+} as unknown as I18nConfig
+
+describe('resolveLocaleRef', () => {
+  it('resolves a unique code', () => {
+    expect(resolveLocaleRef(config, 'de-formal').locale?.code).toBe('de-formal')
+    expect(resolveLocaleRef(config, 'de-formal').ambiguity).toBeUndefined()
+  })
+
+  it('resolves a unique language tag', () => {
+    expect(resolveLocaleRef(config, 'en-GB').locale?.code).toBe('en')
+  })
+
+  it('resolves a file name, extension included', () => {
+    expect(resolveLocaleRef(config, 'de-DE-formal.json').locale?.code).toBe('de-formal')
+  })
+
+  it('returns nothing for a ref that matches no field', () => {
+    // The exact ref that silently dropped writes in anny-ui.
+    expect(resolveLocaleRef(config, 'de-DE-formal').locale).toBeUndefined()
+    expect(resolveLocaleRef(config, 'nope').locale).toBeUndefined()
+  })
+
+  describe('ambiguity', () => {
+    it('reports a ref that matches several locales by language', () => {
+      const { locale, ambiguity } = resolveLocaleRef(config, 'de-DE')
+
+      expect(locale?.code).toBe('de')
+      expect(ambiguity).toEqual({
+        ref: 'de-DE',
+        matchedBy: 'language',
+        candidates: ['de', 'de-formal'],
+        resolvedTo: 'de',
+      })
+    })
+
+    it('does not flag a ref that matches exactly one locale', () => {
+      expect(resolveLocaleRef(config, 'de').ambiguity).toBeUndefined()
+      expect(resolveLocaleRef(config, 'en-US').ambiguity).toBeUndefined()
+    })
+  })
+
+  describe('precedence: code outranks language outranks file', () => {
+    // A code must never be shadowed by another locale's language tag, or
+    // config ordering silently decides which locale a caller addressed.
+    it('prefers the locale whose code matches over one whose language matches', () => {
+      const shadowed = {
+        locales: [
+          { code: 'de-DE', language: 'de-AT', file: 'de-AT.json' },
+          { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+        ],
+      } as unknown as I18nConfig
+
+      // 'de-DE' is locale 2's language but locale 1's code — the code wins,
+      // even though the language match comes second in the array.
+      expect(resolveLocaleRef(shadowed, 'de-DE').locale?.code).toBe('de-DE')
+      expect(resolveLocaleRef(shadowed, 'de-DE').ambiguity).toBeUndefined()
+    })
+
+    it('prefers a language match over a file match', () => {
+      const cfg = {
+        locales: [
+          { code: 'a', language: 'x', file: 'shared.json' },
+          { code: 'b', language: 'shared.json', file: 'b.json' },
+        ],
+      } as unknown as I18nConfig
+
+      expect(resolveLocaleRef(cfg, 'shared.json').locale?.code).toBe('b')
+    })
+  })
+
+  describe('findLocaleSuggestion ranks matches instead of taking the first', () => {
+    it('points at the formal locale for "de-DE-formal", not the informal one', () => {
+      // `de` matches by containment (its language is de-DE); `de-formal`
+      // matches exactly once .json is stripped from its file. Suggesting `de`
+      // would send formal German into the informal file.
+      expect(findLocaleSuggestion(config, 'de-DE-formal')).toContain('"de-formal"')
+      expect(findLocaleSuggestion(config, 'de-DE-formal')).not.toMatch(/Did you mean "de"/)
+    })
+
+    it('still suggests a near miss when nothing matches exactly', () => {
+      expect(findLocaleSuggestion(config, 'en-G')).toContain('"en"')
+    })
+
+    it('returns nothing when no locale is remotely close', () => {
+      expect(findLocaleSuggestion(config, 'zzz')).toBe('')
+    })
+  })
+
+  it('findLocaleImpl keeps returning just the locale', () => {
+    expect(findLocaleImpl(config, 'de-formal')?.code).toBe('de-formal')
+    expect(findLocaleImpl(config, 'de-DE')?.code).toBe('de')
+    expect(findLocaleImpl(config, 'de-DE-formal')).toBeUndefined()
+  })
+})

--- a/packages/cli/tests/tools/write-unresolved-locales.test.ts
+++ b/packages/cli/tests/tools/write-unresolved-locales.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/**
+ * A write naming a locale ref that resolves to nothing must say so in the
+ * result (#301). Previously it warned on stderr and returned a clean success:
+ * the key still appeared in `written` because the other locales succeeded, so
+ * over MCP — where stderr is the server's own log — the caller could not tell
+ * a four-locale write from a three-locale one.
+ *
+ * The locale table mirrors anny-ui's, where `de` and `de-formal` share the
+ * language tag `de-DE`.
+ */
+let tempDir: string
+
+vi.mock('../../src/config/detector.js', async () => {
+  const { resolve } = await import('node:path')
+  return {
+    detectI18nConfig: vi.fn(async (projectDir: string) => ({
+      rootDir: projectDir,
+      defaultLocale: 'de',
+      fallbackLocale: { default: ['de'] },
+      locales: [
+        { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+        { code: 'de-formal', language: 'de-DE', file: 'de-DE-formal.json' },
+        { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+      ],
+      localeDirs: [
+        { path: resolve(projectDir, 'locales'), layer: 'root', layerRootDir: projectDir },
+      ],
+      layerRootDirs: [projectDir],
+      projectConfig: {},
+      apps: [{ name: 'root', rootDir: projectDir, layers: ['root'] }],
+    })),
+    clearConfigCache: vi.fn(),
+    getCachedConfig: vi.fn(() => null),
+  }
+})
+
+const { writeTranslations } = await import('../../src/core/operations.js')
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'i18n-unresolved-'))
+  await mkdir(join(tempDir, 'locales'), { recursive: true })
+  for (const f of ['de-DE.json', 'de-DE-formal.json', 'en-GB.json']) {
+    await writeFile(join(tempDir, 'locales', f), '{}\n')
+  }
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+const read = async (file: string) =>
+  JSON.parse(await readFile(resolve(tempDir, 'locales', file), 'utf-8'))
+
+describe('write_translations with an unresolvable locale ref', () => {
+  it('reports the dropped ref instead of reading as a clean success', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: {
+        'common.save': { 'de': 'Speichern', 'en': 'Save', 'de-DE-formal': 'Speichern Sie' },
+      },
+    })
+
+    expect(result.unresolvedLocales).toEqual([
+      expect.objectContaining({ ref: 'de-DE-formal', keys: ['common.save'] }),
+    ])
+    // The failure mode: the key is still reported written, because two locales
+    // did succeed. The new field is what distinguishes the two cases.
+    expect(result.written).toContain('common.save')
+    expect(result.filesWritten).toBe(2)
+  })
+
+  it('carries the "did you mean" hint into the result, not only stderr', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: { 'common.save': { 'de': 'Speichern', 'de-DE-formal': 'Speichern Sie' } },
+    })
+
+    expect(result.unresolvedLocales?.[0]?.suggestion).toMatch(/de-formal/)
+  })
+
+  it('also surfaces it in warnings, for callers that only read those', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: { 'common.save': { 'de': 'Speichern', 'de-DE-formal': 'x' } },
+    })
+
+    expect(result.warnings?.join('\n')).toMatch(/de-DE-formal.*matched no known locale/)
+  })
+
+  it('does not write the dropped locale to disk', async () => {
+    await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: { 'common.save': { 'de': 'Speichern', 'de-DE-formal': 'Speichern Sie' } },
+    })
+
+    expect(await read('de-DE.json')).toEqual({ common: { save: 'Speichern' } })
+    expect(await read('de-DE-formal.json')).toEqual({})
+  })
+
+  it('groups every affected key under one entry per ref', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: {
+        'a.one': { 'de': '1', 'de-DE-formal': '1' },
+        'a.two': { 'de': '2', 'de-DE-formal': '2' },
+      },
+    })
+
+    expect(result.unresolvedLocales).toHaveLength(1)
+    expect(result.unresolvedLocales?.[0]?.keys).toEqual(['a.one', 'a.two'])
+  })
+
+  it('reports it on a dry run too, before anything is written', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      dryRun: true,
+      translations: { 'common.save': { 'de': 'Speichern', 'de-DE-formal': 'x' } },
+    })
+
+    expect(result.dryRun).toBe(true)
+    expect(result.unresolvedLocales?.[0]?.ref).toBe('de-DE-formal')
+  })
+})
+
+describe('write_translations with an ambiguous locale ref', () => {
+  it('reports a ref that matches several locales rather than silently first-matching', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: { 'common.save': { 'de-DE': 'Speichern' } },
+    })
+
+    expect(result.ambiguousLocales).toEqual([
+      { ref: 'de-DE', matchedBy: 'language', candidates: ['de', 'de-formal'], resolvedTo: 'de' },
+    ])
+    // It still resolves — this is a warning, not a refusal.
+    expect(await read('de-DE.json')).toEqual({ common: { save: 'Speichern' } })
+  })
+})
+
+describe('a fully successful write is unchanged', () => {
+  it('adds neither field when every ref resolves uniquely', async () => {
+    const result = await writeTranslations({
+      layer: 'root',
+      projectDir: tempDir,
+      translations: {
+        'common.save': { 'de': 'Speichern', 'de-formal': 'Speichern Sie', 'en': 'Save' },
+      },
+    })
+
+    expect(result).not.toHaveProperty('unresolvedLocales')
+    expect(result).not.toHaveProperty('ambiguousLocales')
+    expect(result.filesWritten).toBe(3)
+    expect(result.warnings).toBeUndefined()
+  })
+})

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -108,7 +108,7 @@ The Vue and React/Next adapters resolve a single locale directory and take the a
 | `discover` | Auto-detect framework, locales, layers, protected locales, and the active translation mode + list locale dirs by layer with file counts and namespaces. **Call first.** |
 | `list_namespaces` | List the translation key tree grouped by namespace prefix, with counts per node |
 | `get_translations` | Cross-locale view of keys with `locale: "*"` (add `compact: true` for a per-key summary) — or read a single locale |
-| `write_translations` | Write key-value pairs. Mode: `upsert` (default), `add`, or `update`. Supports `dryRun` |
+| `write_translations` | Write key-value pairs. Mode: `upsert` (default), `add`, or `update`. Supports `dryRun`. Locale keys may be a code, language tag or file name — prefer the code (see [Referring to locales](#referring-to-locales)) |
 | `remove_translations` | Remove keys from all locale files in a layer |
 | `rename_translation_key` | Rename/move a key across all locales |
 | `get_missing_translations` | Find keys missing in target locales |
@@ -128,6 +128,24 @@ The Vue and React/Next adapters resolve a single locale directory and take the a
 | `add-language` | Add a new language end-to-end: config, scaffold, translate, verify |
 
 ## Examples
+
+### Referring to locales
+
+A locale may be named by its **code**, its **language tag**, or its **file name** (extension included), resolved in that order. **Prefer the code** — codes are unique, language tags need not be. A project with an informal and a formal German that both declare `language: "de-DE"` makes `de-DE` ambiguous, and it resolves by config order.
+
+A ref that matches nothing does not fail the call, it is reported:
+
+```json
+{
+  "written": ["common.save"],
+  "filesWritten": 2,
+  "unresolvedLocales": [
+    { "ref": "de-DE-formal", "keys": ["common.save"], "suggestion": "Did you mean \"de-formal\" …?" }
+  ]
+}
+```
+
+Check `unresolvedLocales` after a write. The key still appears in `written` because the other locales succeeded, so it is the only signal that one locale was dropped — `filesWritten` will also be short. Ambiguous refs appear under `ambiguousLocales` with every candidate and the one used. Neither field is present when all refs resolve uniquely.
 
 ### `write_translations` — Hand-crafted translations
 

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -196,6 +196,35 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.results).toBeUndefined()
   })
 
+  // #301: stderr is the server's own log, so an MCP caller can only learn
+  // that a locale ref was dropped if the result itself says so.
+  it('write_translations reports an unresolvable locale ref in the result', async () => {
+    const { json } = await callTool('write_translations', {
+      projectDir,
+      layer: 'root',
+      translations: { 'actions.cancel': { de: 'Abbrechen', 'de-DE-formal': 'Brechen Sie ab' } },
+    })
+
+    expect(json?.unresolvedLocales).toEqual([
+      expect.objectContaining({ ref: 'de-DE-formal', keys: ['actions.cancel'] }),
+    ])
+    // The trap this guards: the key IS written, for the locale that resolved.
+    expect(json?.written).toContain('actions.cancel')
+    expect(json?.filesWritten).toBe(1)
+  })
+
+  it('write_translations leaves the result shape untouched when every ref resolves', async () => {
+    const { json } = await callTool('write_translations', {
+      projectDir,
+      layer: 'root',
+      translations: { 'actions.close': { de: 'Schliessen', en: 'Close' } },
+    })
+
+    expect(json).not.toHaveProperty('unresolvedLocales')
+    expect(json).not.toHaveProperty('ambiguousLocales')
+    expect(json?.filesWritten).toBe(2)
+  })
+
   it('find_duplicate_keys returns a valid empty result for a single-layer project', async () => {
     const { json } = await callTool('find_duplicate_keys', { projectDir })
 


### PR DESCRIPTION
Closes #301. Found in production: a `write_translations` call for four locales reported `written: [key]` with no error and no `skipped` entry, but wrote three files. A formal-German key silently never existed.

## The failure

`ops-write.ts` dropped an unresolvable ref with a `log.warn` and a bare `continue`. It never reached `warnings` — which already existed in that same function and was already returned in the result — nor `skipped`, which tracks keys rather than locales. Because the other locales succeeded, the key still landed in `applied`, so the payload read as a clean success. Only `filesWritten` being one short betrayed it, and only if you knew to count.

Over MCP this is strictly worse than on the CLI: stderr is the server's own log, so the calling agent sees a pure success object.

## What changed

**`unresolvedLocales`** on every write result — each dropped ref, the keys it affected, and a suggestion. Mirrored into `warnings` for callers that only read those. Absent when every ref resolves, so a clean write is byte-for-byte unchanged.

```json
{
  "written": ["common.save"],
  "filesWritten": 2,
  "unresolvedLocales": [
    { "ref": "de-DE-formal", "keys": ["common.save"], "suggestion": "Did you mean \"de-formal\" …?" }
  ]
}
```

**Deliberate precedence.** `findLocaleImpl` was one `.find()` across code, file and language, so a locale's unique code could be shadowed by a *different* locale's language tag purely through config order. Now `code` outranks `language` outranks `file`, and a ref matching several locales within one tier is reported as **`ambiguousLocales`** — naming every candidate and the one used — rather than silently first-matched.

That case is not hypothetical. anny-ui declares:

```
code=de         language=de-DE  file=de-DE.json
code=de-formal  language=de-DE  file=de-DE-formal.json
```

so `de-DE` matches two locales and resolves by array order. It picks the intended one today by luck; reordering that array would silently swap the source locale of every translate run.

## A second bug found while testing

`findLocaleSuggestion` took the first locale whose refs overlapped the input. For `de-DE-formal` that is **`de`** — the informal locale — because `de-DE` is a substring of it. The hint actively pointed at the wrong locale, and following it would write formal German into the informal file.

I only caught this because the test asserted the suggestion *content* rather than its presence. It now ranks candidates, preferring an exact match once `.json` is stripped (which is what makes `de-formal` win), and dedupes refs that repeat when a locale's code and language are identical.

My issue text claimed this function "already computes the right answer, it just goes to stderr". That was wrong.

## Tests

- `tests/core/locale-ref-resolution.test.ts` — 12 cases over the anny-ui locale table: precedence, code-shadowing, ambiguity reporting, and the suggestion ranking.
- `tests/tools/write-unresolved-locales.test.ts` — 8 end-to-end writes against real files, including that the dropped locale is genuinely not written, that keys group per ref, that dry runs report it, and that a fully-resolving write gains neither field.
- `packages/mcp/tests/server.test.ts` — 2 cases proving the fields survive to an MCP caller, which is the surface the bug actually bit on.

849 CLI + 28 MCP tests pass. Lint and typecheck clean, no new warnings.

## Docs

Both READMEs gain a "Referring to locales" section: the three accepted forms, why the code is the one to use, that a `file` ref needs its extension, and that `unresolvedLocales` is the field to check after a write.

## Not included

Only the write path reports this. `translate`, `remove` and `rename` resolve refs through the same seam and would benefit from the same treatment — worth a follow-up now that `resolveLocaleRef` exists to build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Locale references can now use locale codes, language tags, or filenames.
  * References are resolved using code, language, then filename precedence.
  * Ambiguous and unresolved references are reported with affected keys, suggestions, and warnings.
  * Successful writes continue when some locale references cannot be resolved.
  * Dry-run operations provide the same resolution diagnostics.

* **Documentation**
  * Added guidance, examples, precedence rules, ambiguity handling, and file-extension requirements.

* **Tests**
  * Added coverage for matching, suggestions, partial writes, warnings, ambiguity, and dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->