### PR TITLE
docs: state that the orphan scan protects dynamic keys rather than removing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Add to your MCP host (VS Code, Cursor, Claude Desktop, Zed):
 
 ---
 
+## Dead Key Detection
+
+`remove-orphans` finds translation keys no source file references. The hard part is not finding unused keys — it is not deleting keys that only *look* unused, and the scan is built around that.
+
+**Dynamic references are detected, not ignored.** A key reachable through `` t(`a.b.${type}.title`) ``, a concatenated prefix, or an ambiguous `$te()` probe is classified as **used** and never removed. Keys owned by a shared layer but referenced from an app that doesn't consume it are reported as `misplacedUsages` and never removed either. Only keys with no evidence of use anywhere in a consuming app are offered for deletion — and `remove-orphans` is dry-run by default.
+
+Every report separates the buckets, so a cleanup is reviewable rather than a leap of faith:
+
+| Bucket | Removed? |
+|---|---|
+| `orphanKeys` — no evidence of use | yes, on an explicit non-dry run |
+| `dynamic-matched` — a dynamic pattern could produce it | no |
+| `uncertainKeys` — evidence is ambiguous | no |
+| `misplacedUsages` — used only from a non-consuming app | no |
+| `ignored` — matched `orphanScan.ignorePatterns` | no |
+
+On a real 8,000-key monorepo about 12% of keys land in the protective buckets. That is the scan being conservative on purpose.
+
+→ [How the scanner works, what it can and cannot see](./packages/cli/README.md#how-orphan-detection-works)
+
+---
+
 ## Translation Modes
 
 The translate operations (`translate` / `translate-key` in the CLI, `translate_missing` / `translate_key` in the MCP server) run in one of two modes. Every result reports which mode ran (`mode: "provider" | "agent" | "dry-run"`).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -172,6 +172,8 @@ Locales listed in `protectedLocales` (see Project Config) are excluded from defa
 | Multiline calls | prefix on a different line than `t(` | caught by bare-string fallbacks (heuristic) |
 | Multi-app scoping | key in a shared layer | usage counts only from apps that consume the layer; cross-app usages are reported as `misplacedUsages`, never removed |
 
+**The scan never removes a key it is unsure about.** Dynamic references are detected, not ignored: a key that *could* be produced by a template pattern, a concatenated prefix or an ambiguous probe is classified as used and left alone. Deletion is reserved for keys with no evidence of use anywhere in a consuming app. On a real 8,000-key project roughly 12% of keys land in the protective buckets — that is the scan working, not failing.
+
 **Classification buckets** — only `orphanKeys` is ever removed; everything else is protective:
 
 - `orphanKeys` — no evidence of use in any consuming app: safe to remove
@@ -186,7 +188,16 @@ Locales listed in `protectedLocales` (see Project Config) are excluded from defa
 - Keys composed at runtime from data (API responses, database values, enums built dynamically)
 - Keys referenced only outside the scanned source (backend responses, external configs, docs)
 
-**Recommended code style for exact scanning:** prefer full literal keys, or literal key maps (`const KEYS = { draft: 'x.status.draft', ... } as const`) over string-building — every key stays greppable and the scanner needs no heuristics. Vue projects can enforce this with `@intlify/eslint-plugin-vue-i18n`'s `no-dynamic-keys` rule.
+**Recommended code style — anchor dynamic keys, don't avoid them.** Dynamic keys are tracked and are often the right design; what matters is that the *namespace* stays literal at the call site:
+
+```ts
+t(`${prefix}.title`)                          // widens to any key ending .title
+t(`components.integrations.${type}.title`)    // widens to one segment under a known namespace
+```
+
+Both are counted as used, but the first suppresses every `.title` key in the project — on a large catalog that can be hundreds of keys the scan can no longer audit. Keeping a literal leading segment costs nothing and keeps the report meaningful. Literal key maps (`const KEYS = { draft: 'x.status.draft' } as const`) are the fully-static alternative where the set is closed.
+
+Prefixes assembled in another scope defeat this even when they are literal — a `computed` returning `'a.b.' + x` reaches the call site as an opaque variable. Inline the namespace instead of the whole key.
 
 `remove-orphans` is dry-run by default; run removals as a reviewed MR and treat the report's `uncertainKeys`/`dynamicKeys` sections as the audit trail.
 


### PR DESCRIPTION
The scan's defining property — it detects dynamic references and refuses to delete anything it cannot prove unused — was only inferable from a bullet list in the CLI README, and absent from the root README entirely. A reader evaluating the tool could reasonably conclude `remove-orphans` is grep-and-delete.

## Changes

**Root README gains a "Dead Key Detection" section** with the bucket table and the guarantee that only `orphanKeys` is ever removed, plus the real figure: on an 8,000-key monorepo ~12% of keys land in the protective buckets.

**CLI README leads with the guarantee** instead of burying it under "Classification buckets".

**Drops the recommendation to enable `@intlify`'s `no-dynamic-keys`.** Dynamic keys are tracked and frequently the right design; banning them costs value for no safety gain. The guidance now targets what actually degrades a scan — an unanchored namespace:

```ts
t(`${prefix}.title`)                          // widens to any key ending .title
t(`components.integrations.${type}.title`)    // widens to one segment under a known namespace
```

Both count as used, but on a real project the first suppresses **544** `.title` keys while the second suppresses three. The computed-prefix trap is called out too, since a `computed` returning `'a.b.' + x` is literal at its definition and opaque at the call site — which is exactly how one codebase ended up hand-maintaining an `orphanScan.ignorePatterns` entry for a namespace its own code already knew.

## Measurements

From a scan of a 8,059-key Nuxt monorepo (2,556 source files):

| | |
|---|---|
| dynamic expressions from real call sites | 180, **all anchored** |
| unbounded-prefix expressions | 6, across 3 files |
| keys those 6 suppress | **614 (7% of the catalog)** |
| total protective-bucket keys | 966 (12%) |

Which is the case for guidance rather than prohibition: the codebase already anchors 174 of 180 dynamic keys. The six exceptions cost more than all the rest combined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented conservative dead-key detection for dynamic references.
  * Clarified that uncertain references are treated as used and protected from removal.
  * Added guidance on protective report categories, dry-run and deletion behavior.
  * Updated recommendations for literal namespace anchors and explained dynamic-key matching limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->