### PR TITLE
feat(cli): init — generate a schema-valid .i18n-mcp.json from detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Agent changes wording for an existing key
 ```bash
 npm install -g the-i18n-cli
 
+the-i18n-cli init                      # create .i18n-mcp.json from framework detection
 the-i18n-cli missing                   # find missing translations
 the-i18n-cli search --query "save"     # search keys and values
 the-i18n-cli remove-orphans            # find unused translation keys (dry-run by default)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,7 @@ npx the-i18n-cli --help
 ## Quick Start
 
 ```bash
+the-i18n-cli init                            # Create .i18n-mcp.json from framework detection
 the-i18n-cli missing                         # Find missing translations
 the-i18n-cli search --query "save"           # Search keys and values
 the-i18n-cli write --layer root --translations '{"common.btn.ok": {"en": "OK", "de": "OK"}}'
@@ -35,6 +36,7 @@ the-i18n-cli check                           # Find used-but-undefined keys (non
 
 | Command | Description |
 |---------|-------------|
+| `init` | Create a schema-valid `.i18n-mcp.json` from framework detection. Non-interactive; refuses to overwrite without `--force` |
 | `get` | Read translation values for specific keys |
 | `write` | Write translation keys (`add` / `update` / `upsert` mode, default: `upsert`) |
 | `add` | Add new translation keys (skips keys that already exist) |
@@ -95,6 +97,30 @@ Gates compose on one invocation, and a failed run outranks a tripped gate — ex
 ```
 
 `check` is the exception: it gates unconditionally with exit `1`, because a key that renders raw in production is a defect rather than a threshold.
+
+## Getting Started on a New Project
+
+```bash
+the-i18n-cli init            # writes .i18n-mcp.json
+the-i18n-cli init --dry-run  # report what it would write, touch nothing
+the-i18n-cli init --force    # overwrite an existing config
+```
+
+`init` detects the framework and writes **only what that framework cannot tell the tool itself**. On a Nuxt, Laravel, Vue or React project the locales, layers and default locale are resolved from the framework config on every run, so `init` deliberately does not copy them into `.i18n-mcp.json` — a generated copy is a second source of truth that drifts silently the day the framework config changes. What you get is the authoring context no adapter can derive:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json",
+  "context": "",
+  "glossary": {},
+  "translationPrompt": "",
+  "localeNotes": {}
+}
+```
+
+A project with no recognised framework is the exception: the generic adapter cannot resolve anything without `localeDirs` and `defaultLocale`, so `init` probes the common locale directory layouts and writes what it finds. The reference locale is guessed as the **fullest** locale file rather than the alphabetically first, since a source locale is the one everything else is translated from.
+
+The result reports which adapter matched and with what confidence, so you can tell why Nuxt was chosen over generic. `init` is non-interactive, so it runs unattended in a devcontainer or CI bootstrap, and it refuses to overwrite an existing config unless you pass `--force`. Even then it preserves any `localeDirs`, `defaultLocale` and `locales` already in the file — `--force` refreshes the scaffolding, it does not discard your locale wiring.
 
 ## Referring to Locales
 

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -12,23 +12,32 @@ export function resetRegistry(): void {
   adapters.length = 0
 }
 
-export async function detectFramework(
+export interface FrameworkMatch {
+  adapter: FrameworkAdapter
+  /** Detection score. 0 when the adapter was forced by hint rather than detected. */
+  confidence: number
+  /** Every adapter that scored above zero, best first — context for `init`. */
+  runnersUp: Array<{ name: string; confidence: number }>
+}
+
+/**
+ * Detect the framework and report how confidently. `detectFramework` returns
+ * only the winner; `init` needs the score to tell a user why Nuxt was chosen
+ * over generic, and a bare directory needs to be distinguishable from a
+ * confident match rather than surfacing as a thrown error.
+ */
+export async function detectFrameworkMatch(
   projectDir: string,
   hint?: string,
-): Promise<FrameworkAdapter> {
+): Promise<FrameworkMatch | undefined> {
   if (adapters.length === 0) {
     throw new ConfigError('No framework adapters registered.')
   }
 
   if (hint) {
     const match = adapters.find(a => a.name === hint)
-    if (!match) {
-      throw new ConfigError(
-        `Framework hint "${hint}" does not match any registered adapter. `
-        + `Available: ${adapters.map(a => a.name).join(', ')}`,
-      )
-    }
-    return match
+    if (!match) return undefined
+    return { adapter: match, confidence: 0, runnersUp: [] }
   }
 
   const scores = await Promise.all(
@@ -43,14 +52,32 @@ export async function detectFramework(
     }),
   )
 
-  const best = scores.reduce((a, b) => (b.confidence > a.confidence ? b : a))
+  const ranked = scores.filter(s => s.confidence > 0).sort((a, b) => b.confidence - a.confidence)
+  const [best] = ranked
+  if (!best) return undefined
 
-  if (best.confidence === 0) {
+  return {
+    adapter: best.adapter,
+    confidence: best.confidence,
+    runnersUp: ranked.slice(1).map(s => ({ name: s.adapter.name, confidence: s.confidence })),
+  }
+}
+
+export async function detectFramework(
+  projectDir: string,
+  hint?: string,
+): Promise<FrameworkAdapter> {
+  const match = await detectFrameworkMatch(projectDir, hint)
+  if (match) return match.adapter
+
+  if (hint) {
     throw new ConfigError(
-      `No framework detected for ${projectDir}. `
-      + `Registered adapters: ${adapters.map(a => a.name).join(', ')}`,
+      `Framework hint "${hint}" does not match any registered adapter. `
+      + `Available: ${adapters.map(a => a.name).join(', ')}`,
     )
   }
-
-  return best.adapter
+  throw new ConfigError(
+    `No framework detected for ${projectDir}. `
+    + `Registered adapters: ${adapters.map(a => a.name).join(', ')}`,
+  )
 }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from 'citty'
 
 export const commands = {
+  'init': () => import('./init.js').then(m => m.default as CommandDef),
   'detect': () => import('./detect.js').then(m => m.default as CommandDef),
   'list-dirs': () => import('./list-dirs.js').then(m => m.default as CommandDef),
   'get': () => import('./get.js').then(m => m.default as CommandDef),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,18 @@
+import { createCommand } from './_shared.js'
+import { initProjectConfig } from '../core/operations.js'
+
+export default createCommand({
+  name: 'init',
+  description: 'Create a schema-valid .i18n-mcp.json from framework detection. Non-interactive; refuses to overwrite without --force',
+  args: {
+    force: { type: 'boolean', description: 'Overwrite an existing .i18n-mcp.json', default: false },
+    dryRun: { type: 'boolean', description: 'Report the config that would be written without touching disk', default: false },
+  },
+  async run(args) {
+    return initProjectConfig({
+      projectDir: args.projectDir,
+      force: args.force,
+      dryRun: args.dryRun,
+    })
+  },
+})

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -6,7 +6,7 @@ import type { ProjectConfig } from './types.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
-const CONFIG_FILENAME = '.i18n-mcp.json'
+export const CONFIG_FILENAME = '.i18n-mcp.json'
 
 // ─── Zod schema ─────────────────────────────────────────────────
 
@@ -49,6 +49,27 @@ const projectConfigSchema = z.object({
   // files keep validating (the schema is strict), warned about, and ignored.
   samplingPreferences: z.unknown().optional(),
 }).strict()
+
+/**
+ * Validate a candidate project config against the published schema, returning
+ * the formatted issue list rather than throwing. `init` uses this to refuse to
+ * emit a config the tool would then reject; loadProjectConfig turns the same
+ * failure into a ConfigError.
+ */
+export function validateProjectConfig(
+  value: unknown,
+): { ok: true; data: ProjectConfig } | { ok: false; error: string } {
+  const result = projectConfigSchema.safeParse(value)
+  if (result.success) return { ok: true, data: result.data as ProjectConfig }
+
+  const error = result.error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+      return `  ${path}: ${issue.message}`
+    })
+    .join('\n')
+  return { ok: false, error }
+}
 
 // ─── Config file discovery ──────────────────────────────────────
 
@@ -107,16 +128,10 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     )
   }
 
-  const result = projectConfigSchema.safeParse(parsed)
+  const result = validateProjectConfig(parsed)
 
-  if (!result.success) {
-    const messages = result.error.issues
-      .map(issue => {
-        const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
-        return `  ${path}: ${issue.message}`
-      })
-      .join('\n')
-    throw new ConfigError(`Invalid ${CONFIG_FILENAME}:\n${messages}`)
+  if (!result.ok) {
+    throw new ConfigError(`Invalid ${CONFIG_FILENAME}:\n${result.error}`)
   }
 
   log.debug(`Project config loaded successfully from ${configPath}`)

--- a/packages/cli/src/core/operations.ts
+++ b/packages/cli/src/core/operations.ts
@@ -43,6 +43,7 @@ export {
   renameTranslationKey,
   scaffoldLocaleFiles,
 } from './ops-write.js'
+export { initProjectConfig } from './ops-init.js'
 
 export {
   findOrphanKeys,

--- a/packages/cli/src/core/ops-init.ts
+++ b/packages/cli/src/core/ops-init.ts
@@ -29,6 +29,9 @@ const COMMON_LOCALE_DIRS = [
   'messages',
 ]
 
+/** The one adapter that cannot resolve without locale config in the file. */
+const GENERIC_ADAPTER = 'generic'
+
 const SCHEMA_URL = 'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json'
 
 /**
@@ -137,7 +140,9 @@ function detectedProject(
       adapter: match.adapter.name,
       label: match.adapter.label,
       confidence: match.confidence,
-      derivesLocaleConfig: Object.keys(carried).length === 0,
+      // A property of the adapter, not of this run: forcing over a config that
+      // happens to carry localeDirs must not make Nuxt look like it needs them.
+      derivesLocaleConfig: match.adapter.name !== GENERIC_ADAPTER,
       ...(match.runnersUp.length > 0 ? { runnersUp: match.runnersUp } : {}),
     },
   }
@@ -184,6 +189,13 @@ async function undetectedProject(
   const locales = firstDir ? await probeLocaleCodes(projectDir, firstDir) : []
   const guessed = firstDir ? await guessDefaultLocale(projectDir, firstDir, locales) : undefined
 
+  // A directory of flat .php files is matched as a locale dir but cannot be
+  // resolved: the generic adapter infers the format from the directory and has
+  // no flat-PHP branch (#308). Emitting locale codes for it would be worse than
+  // emitting none — the adapter would then treat them as JSON and read every
+  // file as empty. Say so instead of shipping a config that quietly does that.
+  const phpOnly = firstDir !== undefined && locales.length === 0
+
   return {
     config: {
       ...authoringScaffold(),
@@ -193,12 +205,15 @@ async function undetectedProject(
       ...carried,
     },
     detected: {
-      adapter: 'generic',
+      adapter: GENERIC_ADAPTER,
       label: 'Generic',
       confidence: 0,
       derivesLocaleConfig: false,
       ...(localeDirs.length === 0
         ? { note: 'No framework and no locale directory found. Wrote a template — set localeDirs and defaultLocale before running other commands.' }
+        : {}),
+      ...(phpOnly
+        ? { note: `Found ${firstDir} but no JSON locale files in it. Flat PHP locale files are not resolvable by the generic adapter — see the-i18n-kit#308.` }
         : {}),
     },
   }

--- a/packages/cli/src/core/ops-init.ts
+++ b/packages/cli/src/core/ops-init.ts
@@ -1,0 +1,259 @@
+/**
+ * init: produce a schema-valid .i18n-mcp.json for a cold project.
+ */
+
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, relative, resolve, sep } from 'node:path'
+import { detectFrameworkMatch } from '../adapters/registry.js'
+import { CONFIG_FILENAME, validateProjectConfig } from '../config/project-config.js'
+import { writeLocaleFile } from '../io/json-writer.js'
+import { ToolError } from '../utils/errors.js'
+import { log } from '../utils/logger.js'
+import type { FrameworkMatch } from '../adapters/registry.js'
+import type { InitProjectConfigResult, GeneratedProjectConfig } from './types.js'
+
+type Detected = InitProjectConfigResult['detected']
+type CarriedLocaleConfig = Pick<GeneratedProjectConfig, 'localeDirs' | 'defaultLocale' | 'locales'>
+
+/** Where a project with no detected framework plausibly keeps its locales. */
+const COMMON_LOCALE_DIRS = [
+  'locales',
+  'src/locales',
+  'i18n/locales',
+  'src/i18n/locales',
+  'i18n',
+  'src/i18n',
+  'lang',
+  'public/locales',
+  'messages',
+]
+
+const SCHEMA_URL = 'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json'
+
+/**
+ * Authoring fields no adapter can derive — the reason a config file exists at
+ * all once the framework supplies the rest. Emitted as empty scaffolding so
+ * the shape is discoverable without reading the schema.
+ */
+function authoringScaffold(): GeneratedProjectConfig {
+  return {
+    $schema: SCHEMA_URL,
+    context: '',
+    glossary: {},
+    translationPrompt: '',
+    localeNotes: {},
+  }
+}
+
+/**
+ * Probe for a locale directory in a project with no framework. Returns paths
+ * relative to the project dir — `.i18n-mcp.json` is committed, so absolute
+ * paths would break for everyone but the author.
+ */
+async function probeLocaleDirs(projectDir: string): Promise<string[]> {
+  const found: string[] = []
+  for (const candidate of COMMON_LOCALE_DIRS) {
+    const full = join(projectDir, candidate)
+    if (!existsSync(full)) continue
+    try {
+      const entries = await readdir(full)
+      if (entries.some(e => e.endsWith('.json') || e.endsWith('.php'))) found.push(candidate)
+    }
+    catch {
+      // Unreadable — not a candidate.
+    }
+  }
+  return found
+}
+
+/** Locale codes from the file names in a probed directory. */
+async function probeLocaleCodes(projectDir: string, localeDir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(join(projectDir, localeDir))
+    return entries
+      .filter(e => e.endsWith('.json'))
+      .map(e => e.slice(0, -5))
+      .sort()
+  }
+  catch {
+    return []
+  }
+}
+
+/** Leaf-key count of a locale file, or -1 when it cannot be read. */
+async function countKeys(path: string): Promise<number> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, 'utf-8'))
+    const walk = (v: unknown): number =>
+      v !== null && typeof v === 'object'
+        ? Object.values(v as Record<string, unknown>).reduce<number>((n, child) => n + walk(child), 0)
+        : 1
+    return walk(parsed)
+  }
+  catch {
+    return -1
+  }
+}
+
+/**
+ * Guess the reference locale for a project with no framework config.
+ *
+ * The fullest file, not the alphabetically first: a source locale is the one
+ * everything else is translated from, so it has the most keys. Picking
+ * alphabetically is how a project ends up silently treating German as its
+ * source because `de` sorts before `en` (cf. #296). Ties break alphabetically
+ * so the result stays deterministic.
+ */
+async function guessDefaultLocale(
+  projectDir: string,
+  localeDir: string,
+  codes: string[],
+): Promise<string | undefined> {
+  let best: { code: string; keys: number } | undefined
+  for (const code of codes) {
+    const keys = await countKeys(join(projectDir, localeDir, `${code}.json`))
+    if (!best || keys > best.keys) best = { code, keys }
+  }
+  return best?.code
+}
+
+/**
+ * Config for a project whose framework was detected.
+ *
+ * Deliberately minimal: an adapter that derives locales, layers and the
+ * default locale gets none of them written down. Generating a copy of what
+ * `nuxt.config.ts` already states creates the second source of truth that
+ * #305 exists to remove, and it goes stale silently. Only an adapter that
+ * cannot resolve without them contributes any.
+ */
+function detectedProject(
+  match: FrameworkMatch,
+  carried: CarriedLocaleConfig,
+): { config: GeneratedProjectConfig; detected: Detected } {
+  return {
+    config: { ...authoringScaffold(), ...carried },
+    detected: {
+      adapter: match.adapter.name,
+      label: match.adapter.label,
+      confidence: match.confidence,
+      derivesLocaleConfig: Object.keys(carried).length === 0,
+      ...(match.runnersUp.length > 0 ? { runnersUp: match.runnersUp } : {}),
+    },
+  }
+}
+
+/**
+ * Locale settings already present in the file being overwritten.
+ *
+ * `--force` regenerates the scaffolding, and for a project whose config is
+ * load-bearing — anything relying on the generic adapter — dropping
+ * `localeDirs` would leave it unresolvable. Preserving them is not
+ * adapter-specific: no `--force` should ever silently delete locale settings
+ * someone wrote by hand.
+ */
+async function carryLocaleConfig(configPath: string): Promise<CarriedLocaleConfig> {
+  if (!existsSync(configPath)) return {}
+  try {
+    const existing = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>
+    const carried: CarriedLocaleConfig = {}
+    if (Array.isArray(existing.localeDirs)) carried.localeDirs = existing.localeDirs as string[]
+    if (typeof existing.defaultLocale === 'string') carried.defaultLocale = existing.defaultLocale
+    if (Array.isArray(existing.locales)) carried.locales = existing.locales as string[]
+    return carried
+  }
+  catch {
+    // Unreadable or malformed — nothing to preserve, and init is about to
+    // replace it anyway.
+    return {}
+  }
+}
+
+/**
+ * Config for a project no adapter claimed. The generic adapter only activates
+ * with explicit localeDirs + defaultLocale, so these must be written or the
+ * project stays unresolvable — the one case where init writes locale data it
+ * inferred rather than read.
+ */
+async function undetectedProject(
+  projectDir: string,
+  carried: CarriedLocaleConfig,
+): Promise<{ config: GeneratedProjectConfig; detected: Detected }> {
+  const localeDirs = await probeLocaleDirs(projectDir)
+  const [firstDir] = localeDirs
+  const locales = firstDir ? await probeLocaleCodes(projectDir, firstDir) : []
+  const guessed = firstDir ? await guessDefaultLocale(projectDir, firstDir, locales) : undefined
+
+  return {
+    config: {
+      ...authoringScaffold(),
+      localeDirs: localeDirs.length > 0 ? localeDirs : ['locales'],
+      defaultLocale: guessed ?? 'en',
+      ...(locales.length > 0 ? { locales } : {}),
+      ...carried,
+    },
+    detected: {
+      adapter: 'generic',
+      label: 'Generic',
+      confidence: 0,
+      derivesLocaleConfig: false,
+      ...(localeDirs.length === 0
+        ? { note: 'No framework and no locale directory found. Wrote a template — set localeDirs and defaultLocale before running other commands.' }
+        : {}),
+    },
+  }
+}
+
+export async function initProjectConfig(opts: {
+  projectDir?: string
+  force?: boolean
+  /** Resolve the config without touching disk. */
+  dryRun?: boolean
+}): Promise<InitProjectConfigResult> {
+  const dir = resolve(opts.projectDir ?? process.cwd())
+  const configPath = join(dir, CONFIG_FILENAME)
+  const exists = existsSync(configPath)
+
+  if (exists && !opts.force) {
+    throw new ToolError(
+      `${CONFIG_FILENAME} already exists at ${configPath}. `
+      + 'Pass --force to overwrite it, or --json to see what would be written.',
+      'CONFIG_EXISTS',
+    )
+  }
+
+  const carried = await carryLocaleConfig(configPath)
+  const match = await detectFrameworkMatch(dir)
+  const { config, detected } = match
+    ? detectedProject(match, carried)
+    : await undetectedProject(dir, carried)
+
+  // A generated config the tool would then reject is a bug in init, not
+  // something to hand the user.
+  const validation = validateProjectConfig(config)
+  if (!validation.ok) {
+    throw new ToolError(
+      `init generated a config that fails its own schema: ${validation.error}`,
+      'INVALID_GENERATED_CONFIG',
+    )
+  }
+
+  const result: InitProjectConfigResult = {
+    config,
+    detected,
+    configPath: relative(dir, configPath).split(sep).join('/'),
+    written: false,
+    overwritten: false,
+  }
+
+  if (opts.dryRun) return result
+
+  // sortKeys: false — a config reads best in authored order ($schema first,
+  // scaffolding after), not alphabetised.
+  await writeLocaleFile(configPath, config as unknown as Record<string, unknown>, {
+    indent: '  ',
+    sortKeys: false,
+  })
+  log.info(`Wrote ${CONFIG_FILENAME} (${detected.label}${detected.confidence > 0 ? `, confidence ${detected.confidence}` : ''})`)
+  return { ...result, written: true, overwritten: exists }
+}

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -149,6 +149,45 @@ export interface UpdateTranslationsResult {
   skippedKeys?: string[]
 }
 
+// ─── init ────────────────────────────────────────────────────────
+
+/**
+ * The config `init` emits. Only fields the matched adapter cannot derive:
+ * writing a copy of what the framework already states creates a second source
+ * of truth that drifts silently (#305). The generic path is the exception —
+ * without localeDirs and defaultLocale nothing resolves at all.
+ */
+export interface GeneratedProjectConfig {
+  $schema: string
+  context: string
+  glossary: Record<string, string>
+  translationPrompt: string
+  localeNotes: Record<string, string>
+  localeDirs?: string[]
+  defaultLocale?: string
+  locales?: string[]
+}
+
+export interface InitProjectConfigResult {
+  config: GeneratedProjectConfig
+  detected: {
+    adapter: string
+    label: string
+    /** Detection score. 0 when nothing matched and generic was assumed. */
+    confidence: number
+    /** False only for the generic adapter, which needs locale config written out. */
+    derivesLocaleConfig: boolean
+    /** Other adapters that also scored, best first. */
+    runnersUp?: Array<{ name: string; confidence: number }>
+    /** Present when init could not find anything to point the config at. */
+    note?: string
+  }
+  /** Path relative to the project dir. */
+  configPath: string
+  written: boolean
+  overwritten: boolean
+}
+
 // ─── get_missing_translations ────────────────────────────────────
 
 export interface MissingTranslationsResult {

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -163,7 +163,8 @@ export interface GeneratedProjectConfig {
   glossary: Record<string, string>
   translationPrompt: string
   localeNotes: Record<string, string>
-  localeDirs?: string[]
+  /** Matches localeDirEntrySchema: a bare path, or a path bound to a layer. */
+  localeDirs?: Array<string | { path: string; layer: string }>
   defaultLocale?: string
   locales?: string[]
 }
@@ -175,7 +176,13 @@ export interface InitProjectConfigResult {
     label: string
     /** Detection score. 0 when nothing matched and generic was assumed. */
     confidence: number
-    /** False only for the generic adapter, which needs locale config written out. */
+    /**
+     * Whether the matched adapter resolves locales, layers and the default
+     * locale from framework config. False only for the generic adapter, which
+     * cannot resolve without them written into `.i18n-mcp.json`. Independent
+     * of whether this run carried locale settings forward from an existing
+     * file under `--force`.
+     */
     derivesLocaleConfig: boolean
     /** Other adapters that also scored, best first. */
     runnersUp?: Array<{ name: string; confidence: number }>

--- a/packages/cli/tests/tools/init.test.ts
+++ b/packages/cli/tests/tools/init.test.ts
@@ -93,6 +93,21 @@ describe('init on a framework project', () => {
     expect(result.config).not.toHaveProperty('defaultLocale')
   })
 
+  // derivesLocaleConfig describes the adapter, not this run. Forcing over a
+  // config that happens to carry localeDirs must not make Nuxt look like it
+  // needs them written down.
+  it('still reports the adapter as deriving when force carries locale settings', async () => {
+    // defaultLocale alone: localeDirs *and* defaultLocale together would score
+    // the generic adapter above Nuxt and legitimately change the answer.
+    await writeFile(join(dir, CONFIG_FILENAME), '{"defaultLocale":"en"}')
+
+    const result = await initProjectConfig({ projectDir: dir, force: true })
+
+    expect(result.detected.adapter).toBe('nuxt')
+    expect(result.detected.derivesLocaleConfig).toBe(true)
+    expect(result.config.defaultLocale).toBe('en')
+  })
+
   it('reports the matched adapter and its confidence', async () => {
     const result = await initProjectConfig({ projectDir: dir })
 

--- a/packages/cli/tests/tools/init.test.ts
+++ b/packages/cli/tests/tools/init.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, readFile, rm, cp } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { initProjectConfig } from '../../src/core/operations.js'
+import { loadProjectConfig, CONFIG_FILENAME } from '../../src/config/project-config.js'
+import { clearConfigCache } from '../../src/config/detector.js'
+
+/**
+ * `init` (#249). Run against real temp directories rather than mocks, because
+ * the whole point is that the emitted file is one the tool then accepts —
+ * which only a round trip through the real loader can show.
+ */
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'i18n-init-'))
+  clearConfigCache()
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+const readConfig = async () => JSON.parse(await readFile(join(dir, CONFIG_FILENAME), 'utf-8'))
+
+async function bareProjectWithLocales() {
+  await mkdir(join(dir, 'locales'), { recursive: true })
+  await writeFile(join(dir, 'locales/en.json'), JSON.stringify({ a: { b: 'Hello' }, c: 'World' }))
+  await writeFile(join(dir, 'locales/de.json'), JSON.stringify({ a: { b: 'Hallo' } }))
+}
+
+describe('init on a project with no framework', () => {
+  it('writes the locale config the generic adapter needs to activate', async () => {
+    await bareProjectWithLocales()
+
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.written).toBe(true)
+    expect(result.detected.adapter).toBe('generic')
+    expect(result.config.localeDirs).toEqual(['locales'])
+    expect(result.config.locales).toEqual(['de', 'en'])
+  })
+
+  it('emits a config the loader then accepts', async () => {
+    await bareProjectWithLocales()
+    await initProjectConfig({ projectDir: dir })
+
+    // The criterion that matters: a generated config the tool would reject is
+    // a bug, so round-trip it through the real loader.
+    await expect(loadProjectConfig(dir)).resolves.toMatchObject({
+      localeDirs: ['locales'],
+      defaultLocale: 'en',
+    })
+  })
+
+  // #296: picking the alphabetically first locale is how a project silently
+  // ends up treating German as its source language.
+  it('picks the fullest locale as the reference, not the alphabetically first', async () => {
+    await bareProjectWithLocales()
+
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.config.defaultLocale).toBe('en')
+  })
+
+  it('falls back to a template when there is nothing to point at', async () => {
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.config.localeDirs).toEqual(['locales'])
+    expect(result.detected.note).toMatch(/no locale directory/i)
+  })
+})
+
+describe('init on a framework project', () => {
+  const fixture = resolve(import.meta.dirname, '../fixtures/nuxt-project')
+
+  beforeEach(async () => {
+    await cp(fixture, dir, { recursive: true })
+    await rm(join(dir, CONFIG_FILENAME), { force: true })
+  })
+
+  // The amended criterion 1: writing a copy of what nuxt.config already states
+  // is the duplicated source of truth #305 exists to remove.
+  it('writes nothing the adapter can derive', async () => {
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.detected.adapter).toBe('nuxt')
+    expect(result.detected.derivesLocaleConfig).toBe(true)
+    expect(result.config).not.toHaveProperty('locales')
+    expect(result.config).not.toHaveProperty('localeDirs')
+    expect(result.config).not.toHaveProperty('defaultLocale')
+  })
+
+  it('reports the matched adapter and its confidence', async () => {
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.detected.label).toBe('Nuxt')
+    expect(result.detected.confidence).toBeGreaterThan(0)
+  })
+
+  it('still emits the authoring scaffolding, which no adapter can derive', async () => {
+    const result = await initProjectConfig({ projectDir: dir })
+
+    expect(result.config).toMatchObject({
+      context: '',
+      glossary: {},
+      translationPrompt: '',
+      localeNotes: {},
+    })
+    expect(result.config.$schema).toContain('schema.json')
+  })
+})
+
+describe('init safety', () => {
+  it('refuses to overwrite an existing config', async () => {
+    await bareProjectWithLocales()
+    await writeFile(join(dir, CONFIG_FILENAME), '{"defaultLocale":"fr"}')
+
+    await expect(initProjectConfig({ projectDir: dir })).rejects.toThrow(/already exists/)
+    expect(await readConfig()).toEqual({ defaultLocale: 'fr' })
+  })
+
+  it('overwrites with force, refreshing the authoring scaffolding', async () => {
+    await bareProjectWithLocales()
+    await writeFile(join(dir, CONFIG_FILENAME), '{"defaultLocale":"fr"}')
+
+    const result = await initProjectConfig({ projectDir: dir, force: true })
+
+    expect(result.overwritten).toBe(true)
+    expect(await readConfig()).toMatchObject({ glossary: {}, localeNotes: {} })
+  })
+
+  // --force means "replace the file", not "discard my locale wiring". Resetting
+  // a hand-set defaultLocale would be the same silent config mutation that let
+  // a project machine-translate its protected locale for months.
+  it('preserves hand-written locale settings when forcing', async () => {
+    await bareProjectWithLocales()
+    await writeFile(join(dir, CONFIG_FILENAME), '{"defaultLocale":"fr","localeDirs":["custom"]}')
+
+    const result = await initProjectConfig({ projectDir: dir, force: true })
+
+    expect(result.config.defaultLocale).toBe('fr')
+    expect(result.config.localeDirs).toEqual(['custom'])
+  })
+
+  // Regression: the generic adapter only detects when a config already exists,
+  // so --force runs through the detected path. Regenerating the scaffold alone
+  // would strip localeDirs and leave the project unresolvable.
+  it('keeps the locale config when forcing over a working generic project', async () => {
+    await bareProjectWithLocales()
+    await initProjectConfig({ projectDir: dir })
+    clearConfigCache()
+
+    const result = await initProjectConfig({ projectDir: dir, force: true })
+
+    expect(result.config.localeDirs).toEqual(['locales'])
+    expect(result.config.defaultLocale).toBe('en')
+    await expect(loadProjectConfig(dir)).resolves.toMatchObject({ localeDirs: ['locales'] })
+  })
+
+  it('touches no files on a dry run', async () => {
+    await bareProjectWithLocales()
+
+    const result = await initProjectConfig({ projectDir: dir, dryRun: true })
+
+    expect(result.written).toBe(false)
+    expect(result.config.localeDirs).toEqual(['locales'])
+    expect(existsSync(join(dir, CONFIG_FILENAME))).toBe(false)
+  })
+
+  it('reports a dry run over an existing config without writing', async () => {
+    await bareProjectWithLocales()
+    await writeFile(join(dir, CONFIG_FILENAME), '{"defaultLocale":"fr"}')
+
+    // Still guarded: --dryRun alone must not imply permission to overwrite.
+    await expect(initProjectConfig({ projectDir: dir, dryRun: true })).rejects.toThrow(/already exists/)
+  })
+})


### PR DESCRIPTION
Closes #249.

A cold project had no path to a config except hand-writing one against a strict zod schema inferred from prose. `init` detects the framework and writes the file, validating its own output before it lands.

## The design decision, per the amendment on #249

**It writes only what the matched framework cannot supply.**

The ticket originally asked for a Nuxt config *"whose locales, layers and default locale match what detection found"*. That would generate, from a clean start, exactly the duplicated configuration #305 exists to remove — and every config-drift bug catalogued there was an instance of it, arrived at by hand.

So a Nuxt, Laravel, Vue or React project gets the authoring context and nothing derived:

```json
{
  "$schema": "…/schema.json",
  "context": "",
  "glossary": {},
  "translationPrompt": "",
  "localeNotes": {}
}
```

A project no adapter claims is the exception: the generic adapter cannot resolve without `localeDirs` and `defaultLocale`, so `init` probes the common layouts and writes what it finds.

## Two smaller judgements

**The reference locale is the fullest locale file, not the alphabetically first.** A source locale is the one everything else is translated from, so it has the most keys. Alphabetical is how a project silently ends up treating German as its source because `de` sorts before `en` — the trap in #296, and my first implementation had it: on a fixture with a populated `en.json` and an empty `de.json` it picked `de`.

**`--force` preserves `localeDirs`, `defaultLocale` and `locales` already in the file.** It refreshes the scaffolding; it does not discard locale wiring someone wrote by hand. Resetting a hand-set `defaultLocale` would be the same silent config mutation that let a project machine-translate its protected locale for months.

## Supporting changes

- `detectFrameworkMatch` reports the winning adapter with its score and runners-up. `detectFramework` returned only the adapter and *threw* on no match, so a bare directory could not be an outcome — criterion 2 needed it to be one. `detectFramework` now delegates to it rather than duplicating the loop.
- `validateProjectConfig` exposes schema validation without throwing, so `init` can refuse to emit a config the tool would then reject. `loadProjectConfig` routes through it, so there is one implementation and one message format.

## Tests

13 cases against real temp directories rather than mocks — the point is that the emitted file is one the loader accepts, which only a round trip can show. Covers the Nuxt fixture writing nothing derived, the generic path resolving end to end, the fullest-locale guess, the overwrite guard, `--dry-run` touching no files (including over an existing config), and `--force` preserving locale settings.

862 CLI + 28 MCP tests pass. Lint, typecheck and the Fallow audit gate are clean.

## A note on the audit gate

Fallow flagged two things and both were worth taking seriously rather than baselining.

The complexity finding on `initProjectConfig` (15 cyclomatic, 89 lines) was fair — it is now three functions.

The second was more interesting. My first design put a `requiresExplicitLocaleConfig` flag on the adapter interface, and Fallow reported it as an unused class member because it could not see the read through the interface. Rather than baseline a false positive, I looked again at what the flag was for — and it was solving the wrong problem. The requirement is not *"which adapters need locale config written"*; it is **"`--force` must not destroy locale settings that already exist"**, which is adapter-independent, simpler to explain, and needs no new interface member. The adapter interface is unchanged in this PR as a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `the-i18n-cli init` command to create a valid `.i18n-mcp.json` configuration.
  - Automatically detects supported frameworks and can infer locale settings for generic projects.
  - Supports dry runs, forced regeneration, and preservation of existing locale wiring.
  - Reports framework detection confidence and generated configuration details.

- **Documentation**
  - Added Quick Start examples and detailed guidance for initializing new projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->