### PR TITLE
fix(cli): register scan so it can actually be invoked

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,7 @@ the-i18n-cli check                           # Find used-but-undefined keys (non
 | `remove-orphans` | Find and remove keys not referenced in source code (dry-run by default) |
 | `check` | Find keys referenced in code but defined in no consumed locale layer — the inverse of `remove-orphans`. Exits non-zero when any are found, so it can gate CI. Dynamically built keys are reported as uncertain, never as hard findings |
 | `find-duplicates` | Find keys defined in both a shared layer and a consuming child layer (with divergence detection) |
+| `scan` | Find where translation keys are referenced in source, with file and line — use before renaming or removing a key |
 | `scaffold` | Create empty locale files for new languages |
 
 Run `the-i18n-cli <command> --help` for per-command options.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,8 +3,16 @@ import { defineCommand, runCommand, runMain } from 'citty'
 import { commands as allCommands } from './commands/index.js'
 import { emitErrorResult } from './commands/_shared.js'
 
-// Diagnostic commands kept out of the public CLI surface
-const hiddenCommands = new Set(['detect', 'list-dirs', 'empty', 'scan'])
+/**
+ * Diagnostic commands kept out of the public CLI surface.
+ *
+ * Note this removes them from the *executed* map, not just from `--help`, so a
+ * name listed here cannot be invoked at all. `scan` is deliberately absent:
+ * key-usage scanning has no other route on either surface — `discover` covers
+ * `detect` and `list-dirs`, but nothing covers this — so filtering it made a
+ * documented command unreachable (#307). The remaining three are #252.
+ */
+const hiddenCommands = new Set(['detect', 'list-dirs', 'empty'])
 const commands = Object.fromEntries(
   Object.entries(allCommands).filter(([key]) => !hiddenCommands.has(key)),
 )

--- a/packages/cli/tests/cli/command-registration.test.ts
+++ b/packages/cli/tests/cli/command-registration.test.ts
@@ -1,0 +1,86 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { commands } from '../../src/commands/index.js'
+
+const execFileAsync = promisify(execFile)
+const binPath = resolve(import.meta.dirname, '../../dist/bin.js')
+
+/**
+ * `scan` was documented, implemented, tested and unreachable: cli.ts filtered
+ * it out of the map handed to citty, so it was absent from the *executed*
+ * commands too, not merely from --help (#307).
+ *
+ * Unit tests of a command module cannot see that — the module is fine. Only
+ * the real binary can, so this drives it. Requires a built dist.
+ */
+async function runBin(args: string[], cwd?: string): Promise<{ stdout: string, code: number }> {
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [binPath, ...args], { cwd })
+    return { stdout, code: 0 }
+  } catch (error) {
+    const e = error as { stdout?: string, code?: number }
+    return { stdout: e.stdout ?? '', code: e.code ?? 1 }
+  }
+}
+
+/** Kept out of --help; #252 restores them. */
+const stillHidden = new Set(['detect', 'list-dirs', 'empty'])
+
+describe('every public command is invocable through the binary', () => {
+  const publicCommands = Object.keys(commands).filter(name => !stillHidden.has(name))
+
+  it.each(publicCommands)('%s', async (name) => {
+    const { stdout, code } = await runBin([name, '--help'])
+
+    expect(code).toBe(0)
+    expect(stdout).toContain('USAGE')
+  })
+
+  it('lists them all in the root help', async () => {
+    const { stdout } = await runBin(['--help'])
+
+    for (const name of publicCommands) {
+      expect(stdout).toContain(name)
+    }
+  })
+})
+
+describe('scan', () => {
+  let projectDir: string
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'i18n-scan-'))
+    await mkdir(join(projectDir, 'locales'), { recursive: true })
+    await mkdir(join(projectDir, 'src'), { recursive: true })
+    await writeFile(
+      join(projectDir, '.i18n-mcp.json'),
+      JSON.stringify({ defaultLocale: 'en', localeDirs: ['locales'], locales: ['en'] }),
+    )
+    await writeFile(join(projectDir, 'locales/en.json'), JSON.stringify({ a: { b: 'x' } }))
+    await writeFile(join(projectDir, 'src/app.ts'), `const x = t('a.b')\n`)
+  })
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('reports where a key is used, with file and line', async () => {
+    const { stdout, code } = await runBin(['scan', '--keys', 'a.b'], projectDir)
+
+    expect(code).toBe(0)
+    expect(JSON.parse(stdout)).toMatchObject({
+      usages: { 'a.b': [{ file: 'src/app.ts', line: 1, callee: 't' }] },
+      summary: { uniqueKeysFound: 1, totalReferences: 1 },
+    })
+  })
+
+  it('auto-emits JSON when stdout is not a TTY, like the rest of the surface', async () => {
+    const { stdout } = await runBin(['scan'], projectDir)
+
+    expect(() => JSON.parse(stdout)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Closes #307.

`scan` was documented, implemented, tested — and impossible to run:

```
$ the-i18n-cli scan --keys a.b
{ "error": { "code": "E_UNKNOWN_COMMAND", "message": "Unknown command scan" } }
```

`cli.ts` filtered four "diagnostic" commands out of the map before handing it to citty. The intent was to keep them out of `--help`; the effect was to remove them from the **executed** map as well, so the code shipped and was unreachable.

## Why scan specifically, and not all four

Key-usage scanning is the only member of that set with no other route on either surface. `discover` covers `detect` and `list-dirs`, and `empty` has a documented alternative — but nothing answers "where is this key referenced?" before a rename or a removal. Hiding it made a documented capability unreachable rather than merely undiscoverable.

The other three stay filtered pending #252, which restores them together with the MCP tools they need.

Registration and visibility are now separable in principle — the comment on `hiddenCommands` says plainly that a name listed there cannot be invoked at all, which was the trap.

## The test guards the class, not the instance

A unit test of `commands/scan.ts` could never have caught this: the module was correct, the wiring was not. So the new test drives the **real binary** across every public command, asserting each is invocable and listed in root help. Unregistering any of them in future fails the build.

Plus two behavioural cases for `scan`: that it reports file and line, and that it auto-emits JSON off a TTY like the rest of the surface.

883 CLI tests pass. Lint, typecheck and the Fallow gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)