### PR TITLE
chore(cli): type the public operation results, fix the drift it exposed

### DIFF
--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -176,8 +176,9 @@ async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
     }))
 }
 
-function extractDefaultLocale(projectDir: string): string | null {
+function extractDefaultLocale(_projectDir: string): string | null {
   // Stub: default-locale extraction from Vue project config is not
-  // implemented — callers fall back to the first discovered locale.
+  // implemented — callers fall back to the first discovered locale, which is
+  // why `defaultLocale` cannot be pinned for this adapter (#296).
   return null
 }

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -27,6 +27,13 @@ export function createCommand(opts: {
    * spec with an entry in `args`.
    */
   gates?: GateSpec[]
+  /**
+   * Receives citty's parsed args. `any` is deliberate: each command declares
+   * its own `args` shape and citty does not thread that type through to the
+   * handler, so narrowing here only moves the cast into all nineteen command
+   * modules. The shape is validated by citty against the `args` above.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
   run: (args: any) => Promise<unknown>
 }): CommandDef {
   return defineCommand({
@@ -46,7 +53,7 @@ export function createCommand(opts: {
         process.exitCode = EXIT_RUN_FAILED
       }
     },
-  }) as any
+  }) as CommandDef
 }
 
 /** The run succeeded and no gate tripped. */

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -36,10 +36,11 @@ export default createCommand({
       translateFn,
     })
 
-    // CLI-owned guidance: agent mode here just means no provider was given
-    const summary = result.summary as Record<string, unknown> | undefined
-    if (summary?.mode === 'agent') {
-      summary.message = 'No provider configured — nothing was translated. Pass --provider and --model '
+    // CLI-owned guidance: agent mode here just means no provider was given.
+    // Single-layer and all-layers results both carry summary.mode, so this
+    // needs no narrowing.
+    if (result.summary.mode === 'agent') {
+      result.summary.message = 'No provider configured — nothing was translated. Pass --provider and --model '
         + '(API key via --apiKey or the OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env vars) '
         + 'to translate automatically.'
     }

--- a/packages/cli/src/core/ops-orphans.ts
+++ b/packages/cli/src/core/ops-orphans.ts
@@ -14,6 +14,7 @@ import { getLeafKeys, removeNestedValue } from '../io/key-operations.js'
 import { scanSourceFiles, toRelativePath, findOrphanKeysForConfig } from '../scanner/code-scanner.js'
 import type { OrphanScanPlan, OrphanScanResult } from '../scanner/code-scanner.js'
 import { getPatternSet } from '../scanner/patterns.js'
+import type { FindOrphanKeysResult, RemoveOrphanKeysResult, CodeUsageResult } from './types.js'
 import { ToolError } from '../utils/errors.js'
 
 import { log } from '../utils/logger.js'
@@ -144,7 +145,7 @@ async function runOrphanScan(
  * (e.g. keyed "lang" when the adapter names the layer "root") silently drops
  * its ignorePatterns, so warn on stderr listing the valid names (#265).
  */
-export function warnUnknownOrphanScanLayers(config: I18nConfig): void {
+function warnUnknownOrphanScanLayers(config: I18nConfig): void {
   const orphanScan = config.projectConfig?.orphanScan
   if (!orphanScan) return
   const layerNames = config.localeDirs.map(d => d.layer)
@@ -235,7 +236,7 @@ export async function findOrphanKeys(opts: {
   excludeDirs?: string[]
   projectDir?: string
   outputFile?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<FindOrphanKeysResult> {
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -276,7 +277,7 @@ export async function findOrphanKeys(opts: {
   }
 
   const misplacedCount = orphanResult.misplacedUsages.length
-  const output: Record<string, unknown> = {
+  const output: FindOrphanKeysResult = {
     orphanKeys: sortedByLayer,
     uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
     misplacedUsages: misplacedCount > 0 ? orphanResult.misplacedUsages : undefined,
@@ -314,7 +315,7 @@ export async function findOrphanKeys(opts: {
 
   const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'find_orphan_keys')
   if (reportPath) {
-    await writeReportFile(reportPath, output, {
+    await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
       tool: 'find_orphan_keys',
       args: { layer, locale, scanDirs, excludeDirs },
     })
@@ -333,7 +334,7 @@ export async function scanCodeUsage(opts: {
   excludeDirs?: string[]
   projectDir?: string
   outputFile?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<CodeUsageResult> {
   const { keys, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -373,7 +374,7 @@ export async function scanCodeUsage(opts: {
     ? keys.filter(k => !byKey[k])
     : []
 
-  const output: Record<string, unknown> = {
+  const output: CodeUsageResult = {
     usages: sortedByKey,
     summary: {
       uniqueKeysFound: Object.keys(sortedByKey).length,
@@ -397,7 +398,7 @@ export async function scanCodeUsage(opts: {
 
   const reportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'scan_code_usage')
   if (reportPath) {
-    await writeReportFile(reportPath, output, {
+    await writeReportFile(reportPath, output as unknown as Record<string, unknown>, {
       tool: 'scan_code_usage',
       args: { keys, scanDirs, excludeDirs },
     })
@@ -421,7 +422,7 @@ export async function removeOrphanKeys(opts: {
   outputFile?: string
   /** Also write the orphan findings as a GitLab Code Quality JSON array to this path. */
   codequalityOutput?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<RemoveOrphanKeysResult> {
   const { layer, locale, scanDirs, excludeDirs } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -449,7 +450,7 @@ export async function removeOrphanKeys(opts: {
     const emptyOutput = { orphanKeys: {}, removed: {}, summary: { totalKeys: 0, orphanCount: 0, message: 'No translation keys found.' } }
     const emptyReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (emptyReportPath) {
-      await writeReportFile(emptyReportPath, emptyOutput, {
+      await writeReportFile(emptyReportPath, emptyOutput as unknown as Record<string, unknown>, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
       })
@@ -478,7 +479,7 @@ export async function removeOrphanKeys(opts: {
     if (orphanResult.uncertainCount > 0) messageParts.push(`${orphanResult.uncertainCount} uncertain key(s) were excluded because they overlap with dynamic translation patterns.`)
     if (misplacedCount > 0) messageParts.push(`${misplacedCount} key(s) are referenced only outside their layer's scope (see misplacedUsages).`)
     if (dynamicMatchedCount === 0 && ignoredCount === 0 && orphanResult.uncertainCount === 0 && misplacedCount === 0) messageParts.push('All translation keys are referenced in code.')
-    const zeroOutput: Record<string, unknown> = {
+    const zeroOutput: RemoveOrphanKeysResult = {
       orphanKeys: {},
       uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
       misplacedUsages,
@@ -487,7 +488,7 @@ export async function removeOrphanKeys(opts: {
     }
     const zeroReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (zeroReportPath) {
-      await writeReportFile(zeroReportPath, zeroOutput, {
+      await writeReportFile(zeroReportPath, zeroOutput as unknown as Record<string, unknown>, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
       })
@@ -498,7 +499,7 @@ export async function removeOrphanKeys(opts: {
 
   // Dry run — just report
   if (isDryRun) {
-    const output: Record<string, unknown> = {
+    const output: RemoveOrphanKeysResult = {
       orphanKeys: orphansByLayer,
       uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
       misplacedUsages,
@@ -532,7 +533,7 @@ export async function removeOrphanKeys(opts: {
     }
     const dryRunReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
     if (dryRunReportPath) {
-      await writeReportFile(dryRunReportPath, output, {
+      await writeReportFile(dryRunReportPath, output as unknown as Record<string, unknown>, {
         tool: 'remove_orphan_keys',
         args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
       })
@@ -565,7 +566,7 @@ export async function removeOrphanKeys(opts: {
     removedByLayer[layerName] = orphans
   }
 
-  const removalOutput: Record<string, unknown> = {
+  const removalOutput: RemoveOrphanKeysResult = {
     removed: removedByLayer,
     uncertainKeys: orphanResult.uncertainCount > 0 ? orphanResult.uncertainByLayer : undefined,
     misplacedUsages,
@@ -587,7 +588,7 @@ export async function removeOrphanKeys(opts: {
 
   const removalReportPath = resolveOutputFile(dir, opts.outputFile) ?? resolveReportFilePath(config, dir, 'remove_orphan_keys')
   if (removalReportPath) {
-    await writeReportFile(removalReportPath, removalOutput, {
+    await writeReportFile(removalReportPath, removalOutput as unknown as Record<string, unknown>, {
       tool: 'remove_orphan_keys',
       args: { layer, locale, scanDirs, excludeDirs, dryRun: opts.dryRun },
     })

--- a/packages/cli/src/core/ops-read.ts
+++ b/packages/cli/src/core/ops-read.ts
@@ -12,7 +12,7 @@ import { readLocaleData, readLocaleDataIfPresent, resolveLocaleEntries } from '.
 import { getNestedValue, getLeafKeys } from '../io/key-operations.js'
 import { ToolError } from '../utils/errors.js'
 
-import type { LocaleDirInfo, SearchMatch } from './types.js'
+import type { LocaleDirInfo, SearchMatch, MissingTranslationsResult, EmptyTranslationsResult } from './types.js'
 import { findLayerOrThrow, findReferenceLocaleOrThrow, findLocaleImpl, localeRefInfo, resolveLayersToScan } from './shared.js'
 import { resolveOutputFile, resolveReportFilePath } from './report.js'
 
@@ -166,7 +166,7 @@ export async function getMissingTranslations(opts: {
   locales?: string[]
   projectDir?: string
   outputFile?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<MissingTranslationsResult> {
   const { layer } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -248,7 +248,7 @@ export async function findEmptyTranslations(opts: {
   locale?: string
   projectDir?: string
   outputFile?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<EmptyTranslationsResult> {
   const { layer, locale } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)

--- a/packages/cli/src/core/ops-translate.ts
+++ b/packages/cli/src/core/ops-translate.ts
@@ -29,6 +29,10 @@ import type {
   TranslateMissingLocaleResult,
   PlaceholderValidationResult,
   TranslateKeyResult,
+  TranslateMissingResult,
+  TranslateMissingOutcome,
+  TranslateAllLayersResult,
+  TranslateAllLayersSummary,
 } from './types.js'
 import { findWritableLayerOrThrow, findReferenceLocaleOrThrow, findLocaleImpl, findLocaleOrThrow, localeRefInfo } from './shared.js'
 
@@ -461,7 +465,7 @@ export async function translateMissing(opts: {
   progressFn?: ProgressFn
   /** Called once after the pre-scan with the computed total number of progress steps. */
   onProgressTotal?: (total: number) => void
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<TranslateMissingOutcome> {
   if (opts.layer === undefined) return translateMissingAllLayers(opts)
   const layer = opts.layer
   const dir = opts.projectDir ?? process.cwd()
@@ -758,7 +762,7 @@ export async function translateMissing(opts: {
   const totalSkipped = Object.values(results).reduce((sum, r) => sum + r.skipped.length, 0)
   const totalWouldTranslate = Object.values(results).reduce((sum, r) => sum + (r.wouldTranslate?.length ?? 0), 0)
 
-  const summary: Record<string, unknown> = {
+  const summary: TranslateMissingResult['summary'] = {
     mode,
     totalTranslated,
     totalFailed,
@@ -796,7 +800,7 @@ export async function translateMissing(opts: {
     }
   }
 
-  const output: Record<string, unknown> = { results, summary }
+  const output: TranslateMissingResult = { results, summary }
   if (hasFallbackContexts) {
     output.fallbackContexts = fallbackContexts
   }
@@ -814,7 +818,7 @@ export async function translateMissing(opts: {
  */
 async function translateMissingAllLayers(
   opts: Omit<Parameters<typeof translateMissing>[0], 'layer'>,
-): Promise<Record<string, unknown>> {
+): Promise<TranslateAllLayersResult> {
   const config = await detectI18nConfig(opts.projectDir ?? process.cwd())
   const layerNames = collectTranslatableLayers(config)
   if (layerNames.length === 0) {
@@ -845,13 +849,14 @@ function collectTranslatableLayers(config: I18nConfig): string[] {
 async function runLayerTranslations(
   layerNames: string[],
   opts: Omit<Parameters<typeof translateMissing>[0], 'layer'>,
-): Promise<{ layers: Record<string, Record<string, unknown>>, byLayer: TranslateLayerTotals[] }> {
-  const layers: Record<string, Record<string, unknown>> = {}
+): Promise<{ layers: Record<string, TranslateMissingResult>, byLayer: TranslateLayerTotals[] }> {
+  const layers: Record<string, TranslateMissingResult> = {}
   const byLayer: TranslateLayerTotals[] = []
   for (const layerName of layerNames) {
-    let layerResult: Record<string, unknown>
+    let layerResult: TranslateMissingResult
     try {
-      layerResult = await translateMissing({ ...opts, layer: layerName })
+      // A named layer always takes the single-layer branch.
+      layerResult = await translateMissing({ ...opts, layer: layerName }) as TranslateMissingResult
     } catch (error) {
       // A layer without reference-locale data has nothing to drive
       // translation — skip it so one sparse layer cannot fail the run for
@@ -868,7 +873,7 @@ async function runLayerTranslations(
   return { layers, byLayer }
 }
 
-function layerTotals(layerName: string, layerResult: Record<string, unknown>): TranslateLayerTotals {
+function layerTotals(layerName: string, layerResult: TranslateMissingResult): TranslateLayerTotals {
   const layerSummary = layerResult.summary as {
     totalTranslated: number
     totalFailed: number
@@ -885,17 +890,17 @@ function layerTotals(layerName: string, layerResult: Record<string, unknown>): T
 }
 
 function buildAllLayersSummary(
-  layers: Record<string, Record<string, unknown>>,
+  layers: Record<string, TranslateMissingResult>,
   byLayer: TranslateLayerTotals[],
   opts: Omit<Parameters<typeof translateMissing>[0], 'layer'>,
-): Record<string, unknown> {
+): TranslateAllLayersSummary {
   const isDryRun = opts.dryRun ?? false
   const total = (pick: (l: TranslateLayerTotals) => number): number =>
     byLayer.reduce((sum, l) => sum + pick(l), 0)
   // Locales are project-global, so mode, reference locale, and target set are
   // identical across layers — hoist them from the first translated layer.
-  const first = Object.values(layers)[0]?.summary as Record<string, unknown> | undefined
-  const summary: Record<string, unknown> = {
+  const first = Object.values(layers)[0]?.summary
+  const summary: TranslateAllLayersSummary = {
     mode: isDryRun ? 'dry-run' : opts.translateFn ? 'provider' : 'agent',
     totalTranslated: total(l => l.totalTranslated),
     totalFailed: total(l => l.totalFailed),

--- a/packages/cli/src/core/ops-write.ts
+++ b/packages/cli/src/core/ops-write.ts
@@ -28,6 +28,8 @@ import type {
   ScaffoldLocaleFileInfo,
   PlaceholderValidationResult,
   UnresolvedLocaleRef,
+  RemoveTranslationsResult,
+  RenameTranslationKeyResult,
 } from './types.js'
 import { findWritableLayerOrThrow, findLocaleImpl, findLocaleSuggestion, resolveLocaleRef } from './shared.js'
 import type { LocaleRefAmbiguity } from './shared.js'
@@ -353,7 +355,7 @@ export async function removeTranslations(opts: {
   keys: string[]
   dryRun?: boolean
   projectDir?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<RemoveTranslationsResult> {
   const { layer, keys } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)
@@ -402,7 +404,11 @@ export async function removeTranslations(opts: {
     }
   }
 
-  const uniqueRemoved = [...new Set(removed.map(r => r.split(':')[1]))]
+  // Entries are "locale:key"; guard the split so a malformed entry cannot
+  // put undefined into a string[] the type promises is dense.
+  const uniqueRemoved = [...new Set(
+    removed.map(r => r.split(':')[1]).filter((k): k is string => k !== undefined),
+  )]
   return {
     removed: uniqueRemoved,
     removedPerLocale: removed,
@@ -420,7 +426,7 @@ export async function renameTranslationKey(opts: {
   newKey: string
   dryRun?: boolean
   projectDir?: string
-}): Promise<Record<string, unknown>> { // TODO: use specific result type from types.ts
+}): Promise<RenameTranslationKeyResult> {
   const { layer, oldKey, newKey } = opts
   const dir = opts.projectDir ?? process.cwd()
   const config = await detectI18nConfig(dir)

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -198,7 +198,8 @@ export interface InitProjectConfigResult {
 // ─── get_missing_translations ────────────────────────────────────
 
 export interface MissingTranslationsResult {
-  missing: Record<string, Record<string, string[]>>
+  /** Absent when the full report went to `reportFile` instead. */
+  missing?: Record<string, Record<string, string[]>>
   summary: {
     referenceLocale: string | LocaleRefInfo
     targetLocales: Array<string | LocaleRefInfo>
@@ -257,7 +258,8 @@ export interface TranslationStatusResult {
 // ─── find_empty_translations ─────────────────────────────────────
 
 export interface EmptyTranslationsResult {
-  emptyKeys: Record<string, Record<string, string[]>>
+  /** Absent when the full report went to `reportFile` instead. */
+  emptyKeys?: Record<string, Record<string, string[]>>
   summary: {
     totalEmpty: number
     localesChecked: string[]
@@ -365,10 +367,27 @@ export interface TranslateMissingLocaleResult {
   placeholderValidation?: PlaceholderValidationResult
 }
 
+/** One locale's digest in compact mode: counts rather than key lists. */
+export interface TranslateMissingCompactEntry {
+  locale: string
+  mode: TranslateMode
+  missing: number
+  translated: number
+  failed: number
+  skipped: number
+  wouldTranslate?: number
+  batches?: number
+  model?: string
+  writeError?: string
+}
+
 export interface TranslateMissingResult {
-  results: Record<string, TranslateMissingLocaleResult>
+  /** Absent in compact mode, which returns `summary.byLocale` instead. */
+  results?: Record<string, TranslateMissingLocaleResult>
   fallbackContexts?: Record<string, Record<string, unknown>>
   summary: {
+    /** Compact mode only: a per-locale digest in place of full `results`. */
+    byLocale?: TranslateMissingCompactEntry[]
     mode: TranslateMode
     totalTranslated: number
     totalFailed: number
@@ -389,6 +408,36 @@ export interface TranslateMissingResult {
  * with the same accessors. `totalWouldTranslate` is always present (0 outside
  * dry runs).
  */
+/** Aggregated summary across every locale-backed layer. */
+export interface TranslateAllLayersSummary {
+  mode: TranslateMode
+  totalTranslated: number
+  totalFailed: number
+  totalSkipped: number
+  totalWouldTranslate?: number
+  /** Layer names that were translated. */
+  layers: string[]
+  byLayer: TranslateLayerTotals[]
+  dryRun: boolean
+  referenceLocale?: string | LocaleRefInfo
+  targetLocales?: Array<string | LocaleRefInfo>
+  /** Surface-owned guidance (set by the CLI command or MCP tool). */
+  message?: string
+}
+
+/**
+ * All-layers mode (`--layer` omitted): one result per layer plus an aggregated
+ * summary. Discriminate with `'layers' in result` — both members carry a
+ * `summary`, and both summaries carry `mode`, so mode checks need no narrowing.
+ */
+export interface TranslateAllLayersResult {
+  layers: Record<string, TranslateMissingResult>
+  summary: TranslateAllLayersSummary
+}
+
+/** What translateMissing returns: depends on whether a layer was named. */
+export type TranslateMissingOutcome = TranslateMissingResult | TranslateAllLayersResult
+
 export interface TranslateLayerTotals {
   layer: string
   totalTranslated: number
@@ -427,10 +476,20 @@ export interface TranslateKeyResult {
 
 // ─── find_orphan_keys ────────────────────────────────────────────
 
+/** A key referenced only from apps outside its layer's consumption scope. */
+export interface MisplacedUsageRef {
+  key: string
+  /** Layer the key is defined in. */
+  layer: string
+  /** Out-of-scope scan units (apps or layers) where the key was found. */
+  usingApps: string[]
+}
+
 export interface DynamicKeyRef {
   expression: string
-  file: string
-  line: number
+  /** Absent for context-free bare candidates, which have no single call site. */
+  file?: string
+  line?: number
 }
 
 export interface UnresolvedKeyWarningRef {
@@ -442,18 +501,24 @@ export interface UnresolvedKeyWarningRef {
 }
 
 export interface FindOrphanKeysResult {
-  orphanKeys: Record<string, string[]>
+  /** Absent when the full report went to `reportFile` instead. */
+  orphanKeys?: Record<string, string[]>
   uncertainKeys?: Record<string, string[]>
+  /** Keys used only from apps that do not consume the owning layer. */
+  misplacedUsages?: MisplacedUsageRef[]
+  misplacedUsageNote?: string
   summary: {
     totalKeys: number
     orphanCount: number
     uncertainCount?: number
+    misplacedCount?: number
     dynamicMatchedCount?: number
     ignoredCount?: number
     usedCount?: number
     filesScanned: number
     layersChecked?: string[]
     dirsScanned?: string[]
+    scanScope?: Record<string, string[]>
     locale?: string
     message?: string
   }
@@ -465,6 +530,25 @@ export interface FindOrphanKeysResult {
 }
 
 // ─── scan_code_usage ─────────────────────────────────────────────
+
+/** Where each requested key is referenced in source. */
+export interface CodeUsageResult {
+  /** Absent when the full report went to `reportFile` instead. */
+  usages?: Record<string, CodeUsageRef[]>
+  /** Requested keys with no reference anywhere in the scanned source. */
+  notFoundInCode?: string[]
+  /** Dynamic expressions that could reach the requested keys. */
+  dynamicKeys?: DynamicKeyRef[]
+  summary: {
+    uniqueKeysFound: number
+    totalReferences: number
+    filesScanned: number
+    dirsScanned?: string[]
+    message?: string
+  }
+  /** Present when the full report went to a file instead. */
+  reportFile?: string
+}
 
 export interface CodeUsageRef {
   file: string
@@ -492,18 +576,25 @@ export interface RemoveOrphanKeysResult {
   orphanKeys?: Record<string, string[]>
   removed?: Record<string, string[]>
   uncertainKeys?: Record<string, string[]>
+  misplacedUsages?: MisplacedUsageRef[]
+  misplacedUsageNote?: string
   summary: {
     dryRun?: boolean
     totalKeys: number
     orphanCount?: number
     removedCount?: number
     uncertainCount?: number
+    misplacedCount?: number
     dynamicMatchedCount?: number
     ignoredCount?: number
     usedCount?: number
     remainingCount?: number
     filesScanned?: number
     filesWritten?: number
+    layersChecked?: string[]
+    dirsScanned?: string[]
+    scanScope?: Record<string, string[]>
+    locale?: string
     message?: string
   }
   dynamicKeyWarning?: string

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -618,7 +618,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       inputSchema: z.object({
         layer: z
           .string()
-          .describe('Layer name from discover to translate (e.g., "root", "app-admin"). Call discover to discover available layers.'),
+          .optional()
+          .describe('Layer name from discover to translate (e.g., "root", "app-admin"). Omit to translate every locale-backed layer in one call — the recommended default for layered projects, which returns a result per layer plus an aggregated summary.'),
         referenceLocale: z
           .string()
           .optional()
@@ -685,8 +686,15 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
           onProgressTotal: (total) => { progressTotal = total },
         })
 
-        // MCP-owned guidance for agent mode
-        if (result.fallbackContexts && result.summary) {
+        // MCP-owned guidance for agent mode. All-layers mode (no `layer`
+        // argument, the default for layered projects since #292) nests the
+        // fallback contexts per layer, so checking only the top level would
+        // skip the guidance in exactly the case an agent is most likely to hit.
+        const hasFallbacks = 'layers' in result
+          ? Object.values(result.layers).some(l => l.fallbackContexts)
+          : Boolean(result.fallbackContexts)
+
+        if (hasFallbacks && result.summary) {
           (result.summary as Record<string, unknown>).message
             = 'Agent mode — no provider configured on the server. Use the fallbackContexts to translate '
             + 'inline, then call write_translations (mode: "upsert") to write the results. To enable '

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -226,6 +226,16 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(json?.filesWritten).toBe(2)
   })
 
+  // All-layers mode nests fallbackContexts per layer, so a top-level check
+  // skipped the agent-mode guidance in exactly the mode layered projects use.
+  it('translate_missing still returns agent guidance without a layer argument', async () => {
+    const { json } = await callTool('translate_missing', { projectDir })
+
+    expect(json?.layers).toBeDefined()
+    expect(json?.summary.mode).toBe('agent')
+    expect(json?.summary.message).toContain('write_translations')
+  })
+
   it('get_translation_status reports coverage in one call', async () => {
     const { json } = await callTool('get_translation_status', { projectDir })
 


### PR DESCRIPTION
A polish round before the Nuxt module. The headline is API, not cosmetics.

## Eight public operations had no return type

`findOrphanKeys`, `removeOrphanKeys`, `scanCodeUsage`, `getMissingTranslations`, `findEmptyTranslations`, `translateMissing`, `removeTranslations` and `renameTranslationKey` all returned `Promise<Record<string, unknown>>` behind a `// TODO: use specific result type from types.ts` — while fully-formed interfaces sat unused in `types.ts`.

So a library consumer got **no type information from half the public API**, and the MCP server cast at every call site. All eight are wired now and the TODOs are gone.

## Wiring them found six lies in the published types

Each would have actively misled a typed consumer:

| | |
|---|---|
| `reportFile` mode | Every large-output op returns `{ reportFile, summary }` when `outputFile` is set, dropping the detail — but `orphanKeys`, `missing`, `emptyKeys` and `usages` were all declared **required** |
| `FindOrphanKeysResult` | Missing `misplacedUsages`, `misplacedCount`, `scanScope` — added by the layer-scope work, never declared |
| `DynamicKeyRef` | `file` and `line` declared required; bare candidates carry neither, having no single call site |
| `TranslateMissingResult` | No `byLocale`, which compact mode returns *instead of* `results` |
| `translateMissing` | Returns a structurally different shape in all-layers mode and nothing said so |
| `CodeUsageResult` | Did not exist at all |

`translateMissing` is now a `TranslateMissingOutcome` union that callers discriminate with `'layers' in result`. Both members carry `summary`, and both summaries carry `mode`, so mode checks still need no narrowing.

## Two real defects fell out

**The MCP `translate_missing` tool required `layer`.** So the all-layers mode the CLI has had since #292 was **unreachable over MCP** — a surface divergence the kit's own contract explicitly forbids (#246, story 43). Now optional. Its agent-mode guidance also checked a top-level `fallbackContexts` that all-layers mode never sets, nesting them per layer instead; it now reads the right place. Regression test added.

**`removeTranslations`** built a `string[]` from `split(':')[1]`, which is `string | undefined`. A malformed entry would have put `undefined` into an array the type promises is dense.

## Also

Three lint warnings and one unused export cleared. The remaining `any` in `createCommand` is now **documented rather than unexplained** — I tried narrowing it and it just moves the cast into all nineteen command modules, because citty doesn't thread per-command arg types to the handler. A justified exception beats a silent warning.

## Not in this PR

`fallow health` still reports 28 complexity findings (4 CRITICAL: `translateOneLocale` at 191 lines / 119 cognitive, `translateKey` at 232) and 88 clone groups at 5.8% duplication. Those are real, but they are a refactor of `translate`, `orphans` and `write` — the riskiest code in the repo — and each deserves its own PR against the 899 tests rather than a sweep immediately before starting a new package. Happy to take them one at a time.

899 CLI + 31 MCP tests pass. Lint clean, dead-code clean, audit gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `translate_missing` tool can now process all translation layers when no layer is specified.
  * All-layer results include per-layer and aggregated summaries.
  * Reports support more concise output while retaining key scan and translation details.

* **Bug Fixes**
  * Improved detection of agent-mode guidance in layered translation results.
  * Malformed translation-removal entries are now safely ignored.

* **Tests**
  * Added coverage for all-layer translation results and related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->