### PR TITLE
feat(cli): gate translate on partial failures, and stop them being silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ Turn findings into exit codes with opt-in gates, so a pipeline blocks a merge wi
 ```bash
 the-i18n-cli missing --fail-on-missing          # exit 2 when any key is missing
 the-i18n-cli remove-orphans --fail-on-orphans   # exit 2 when any orphan is found
+the-i18n-cli translate --fail-on-failed         # exit 2 when the run lost keys
 ```
+
+`translate` needs its own gate: exit `1` means the run translated *nothing*, so a
+run that writes most keys and loses the rest counts as a success and commits the
+partial result. The lost keys stay missing and a re-run retries them.
 
 | Code | Meaning |
 |------|---------|
@@ -337,6 +342,7 @@ Pushing back to the branch requires either the GitLab ≥ 17.2 project setting *
 | `I18N_KEYS` | — | all missing | Comma-separated keys |
 | `I18N_BATCH_SIZE` | — | `50` | Keys per LLM call |
 | `I18N_DRY_RUN` | — | `false` | Preview without writing |
+| `I18N_FAIL_ON_FAILED` | — | `false` | `"true"` adds `--fail-on-failed`, so the job exits `2` when any key failed to translate. Off by default: the run still commits what succeeded, and the failed keys stay missing for the next run to retry |
 | `I18N_CLI_VERSION` | — | `latest` | Pin the-i18n-cli (npm version or dist-tag) |
 | `I18N_INSTALL_PEER_DEPS` | — | — | Extra npm packages installed alongside the CLI |
 | `I18N_PUSH_TOKEN` | — | — | Project access token (`write_repository`) — push alternative to the job token |

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Preview translations without writing files'
     required: false
     default: 'false'
+  fail_on_failed:
+    description: 'Fail the step (exit 2) when any key failed to translate. Off by default: a partly failed run still writes what succeeded, and the failed keys stay missing for the next run to retry.'
+    required: false
+    default: 'false'
   working_directory:
     description: 'Project root directory (default: github.workspace)'
     required: false
@@ -141,6 +145,9 @@ runs:
         if [ "${{ inputs.dry_run }}" = "true" ]; then
           args+=(--dry-run)
         fi
+        if [ "${{ inputs.fail_on_failed }}" = "true" ]; then
+          args+=(--fail-on-failed)
+        fi
 
         # The CLI owns the pass/fail decision and reports it as an exit code:
         # 0 success, 1 the run itself failed, 2 a requested gate tripped. Parsing
@@ -179,7 +186,7 @@ runs:
         esac
 
         if [ "$failed" -gt 0 ]; then
-          echo "::warning::$failed keys failed to translate ($count succeeded)."
+          echo "::warning::$failed keys failed to translate ($count succeeded). They are still missing, so re-running retries them. Set fail_on_failed: true to make this fail the step instead."
         fi
 
     - name: Create PR with translations

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -142,6 +142,11 @@
     I18N_KEYS: ""             # comma-separated keys (default: all missing)
     I18N_BATCH_SIZE: "50"     # keys per LLM call
     I18N_DRY_RUN: "false"     # preview without writing files
+    I18N_FAIL_ON_FAILED: ""   # set "true" to add --fail-on-failed → exit 2 when any key
+                              # failed. Off by default: a partly failed run still
+                              # writes and commits what succeeded, and the keys that
+                              # failed stay missing for the next run to retry. Pair
+                              # with `allow_failure: false` to make it block.
 
     # Optional — dependencies
     I18N_CLI_VERSION: "latest"  # pin the-i18n-cli (npm version or dist-tag)
@@ -209,6 +214,7 @@
       [ -n "$I18N_SOURCE_LOCALE" ] && args="$args --ref $I18N_SOURCE_LOCALE"
       [ -n "$I18N_KEYS" ]          && args="$args --keys $I18N_KEYS"
       [ "$I18N_DRY_RUN" = "true" ] && args="$args --dry-run"
+      [ "${I18N_FAIL_ON_FAILED:-}" = "true" ] && args="$args --fail-on-failed"
 
       mkdir -p .i18n-reports
       # The CLI owns the pass/fail decision and reports it as an exit code:
@@ -228,6 +234,9 @@
       TRANSLATED=$(jq -r '(.summary.totalTranslated // 0) + (.summary.totalWouldTranslate // 0)' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       FAILED=$(jq -r '.summary.totalFailed // 0' .i18n-reports/translate-output.json 2>/dev/null || echo "?")
       echo "Translated: $TRANSLATED, failed: $FAILED"
+      # No branch on $FAILED here on purpose: the CLI reports a partial failure
+      # as summary.message in the payload printed above, naming the affected
+      # locales. Branching on a parsed count is what this template stopped doing.
 
       case "$STATUS" in
         0) ;;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,13 +81,21 @@ Gates are opt-in flags, so every invocation without one keeps the exit code it h
 |------|---------|-----------|
 | `--fail-on-missing` | `missing` | Any key is missing in a target locale |
 | `--fail-on-orphans` | `remove-orphans` | Any orphan key is found (dry-run still applies) |
+| `--fail-on-failed` | `translate` | Any key failed to translate |
 | `--fail-under <n>` | `status` | Overall completion is below `n` percent |
 
 ```bash
 the-i18n-cli missing --fail-on-missing          # exit 2 blocks the merge
 the-i18n-cli remove-orphans --fail-on-orphans   # dry-run, but non-zero on findings
+the-i18n-cli translate --fail-on-failed         # exit 2 when the run lost keys
 the-i18n-cli status --fail-under 90             # ratchet coverage like test coverage
 ```
+
+`translate` needs its own gate because exit `1` is reserved for a run that
+translated *nothing*. A run that writes 795 keys and loses 141 is a success by
+that measure: it exits `0`, and the partial result is committed like any other.
+The failed keys are still missing, so re-running retries them — the gate is for
+noticing that you need to.
 
 Gates compose on one invocation, and a failed run outranks a tripped gate — exit `1` wins over exit `2`. When a gate trips, the JSON result gains a `gatesTripped` array naming it and reporting the observed value against the threshold; nothing else in the result changes, so existing consumers keep working:
 

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -1,5 +1,29 @@
 import { createCommand, splitList, providerArgs, resolveProviderTranslateFn } from './_shared.js'
 import { translateMissing } from '../core/operations.js'
+import type { TranslateMissingOutcome, TranslateMissingResult } from '../core/types.js'
+
+/**
+ * Locales that lost at least one key, sorted for a stable message.
+ * A bare `totalFailed: 141` says nothing about which languages shipped
+ * incomplete — this is what makes the count actionable in a CI log.
+ * Reads the full and the compact shapes, since either may reach here.
+ */
+export function localesWithFailures(result: TranslateMissingOutcome): string[] {
+  const perLayer: TranslateMissingResult[] = 'layers' in result
+    ? Object.values(result.layers)
+    : [result]
+
+  const locales = new Set<string>()
+  for (const layer of perLayer) {
+    for (const [locale, entry] of Object.entries(layer.results ?? {})) {
+      if (entry.failed.length > 0) locales.add(locale)
+    }
+    for (const entry of layer.summary.byLocale ?? []) {
+      if (entry.failed > 0) locales.add(entry.locale)
+    }
+  }
+  return [...locales].sort()
+}
 
 export default createCommand({
   name: 'translate',
@@ -12,7 +36,14 @@ export default createCommand({
     batchSize: { type: 'string', description: 'Batch size (default: 50)' },
     ...providerArgs,
     dryRun: { type: 'boolean', description: 'Preview what would be translated', default: false },
+    failOnFailed: { type: 'boolean', description: 'Exit 2 when any key failed to translate (CI gate)', default: false },
   },
+  // Without this gate a partly failed run is indistinguishable from a clean one:
+  // isTotalFailure only reports exit 1 when NOTHING was translated, so a run that
+  // wrote 795 keys and lost 141 exits 0 and its partial result gets committed.
+  // Opt-in rather than default, because providers fail transiently and a red
+  // pipeline on every flake is a red pipeline nobody reads.
+  gates: [{ flag: 'failOnFailed', counter: 'totalFailed', threshold: 0 }],
   async run(args) {
     let batchSize: number | undefined
     if (args.batchSize) {
@@ -43,6 +74,15 @@ export default createCommand({
       result.summary.message = 'No provider configured — nothing was translated. Pass --provider and --model '
         + '(API key via --apiKey or the OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY env vars) '
         + 'to translate automatically.'
+    } else if (result.summary.totalFailed > 0) {
+      // A partial failure exits 0 unless --fail-on-failed was passed, so without
+      // this the only trace of it is a count nobody reads. Re-running is the
+      // fix: the keys are still missing, so the next run retries them.
+      const affected = localesWithFailures(result)
+      result.summary.message = `${result.summary.totalFailed} key(s) failed to translate`
+        + (affected.length > 0 ? ` (locales: ${affected.join(', ')})` : '')
+        + '. Those keys remain missing — re-run to retry them. '
+        + 'Pass --fail-on-failed to make this exit 2 in CI.'
     }
     return result
   },

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -142,12 +142,21 @@ describe('gitlab-ci.yml job scripts, executed', () => {
    * short of the git and push stages that follow it.
    */
   describe('.i18n-translate STATUS branching', () => {
-    async function runTranslate(stubResult: string, stubExit: number): Promise<Run> {
+    /** The stub records the args it was handed, so flag wiring is observable. */
+    async function runTranslate(
+      stubResult: string,
+      stubExit: number,
+      env: Record<string, string> = {},
+    ): Promise<Run & { args: string }> {
       const dir = await mkdtemp(join(tmpdir(), 'i18n-tpl-translate-'))
       const stubBin = join(dir, '.bin')
       await mkdir(stubBin, { recursive: true })
       const shim = join(stubBin, 'the-i18n-cli')
-      await writeFile(shim, `#!/bin/sh\ncat <<'JSON'\n${stubResult}\nJSON\nexit ${stubExit}\n`)
+      const argsFile = join(dir, 'args.txt')
+      await writeFile(
+        shim,
+        `#!/bin/sh\nprintf '%s ' "$@" > '${argsFile}'\ncat <<'JSON'\n${stubResult}\nJSON\nexit ${stubExit}\n`,
+      )
       await chmod(shim, 0o755)
 
       const run = await runScript(await jobScript('.i18n-translate'), dir, {
@@ -160,10 +169,12 @@ describe('gitlab-ci.yml job scripts, executed', () => {
         I18N_KEYS: '',
         I18N_BATCH_SIZE: '50',
         I18N_DRY_RUN: 'true',
+        ...env,
       }, stubBin)
 
+      const args = existsSync(argsFile) ? await readFile(argsFile, 'utf-8') : ''
       await rm(dir, { recursive: true, force: true })
-      return run
+      return { ...run, args }
     }
 
     it('exits 0 on a successful run', async () => {
@@ -195,6 +206,32 @@ describe('gitlab-ci.yml job scripts, executed', () => {
       const failLooking = JSON.stringify({ summary: { totalTranslated: 0, totalFailed: 9 } })
 
       expect((await runTranslate(failLooking, 0)).code).toBe(0)
+    })
+
+    it('requests the partial-failure gate only when asked', async () => {
+      const clean = JSON.stringify({ summary: { totalTranslated: 3, totalFailed: 0 } })
+
+      expect((await runTranslate(clean, 0)).args).not.toContain('--fail-on-failed')
+      expect((await runTranslate(clean, 0, { I18N_FAIL_ON_FAILED: 'true' })).args)
+        .toContain('--fail-on-failed')
+    })
+
+    // The gate is opt-in, so the ungated run is the one most projects get. Its
+    // only trace of a partial failure is the CLI's own summary.message, which
+    // the job must surface without parsing it — the counts stay display-only.
+    it('surfaces the CLI guidance on a partial failure it does not gate on', async () => {
+      const partial = JSON.stringify({
+        summary: {
+          totalTranslated: 795,
+          totalFailed: 141,
+          message: '141 key(s) failed to translate (locales: da-DK, fr-FR). Those keys remain missing — re-run to retry them.',
+        },
+      })
+      const run = await runTranslate(partial, 0)
+
+      expect(run.code).toBe(0)
+      expect(run.stdout).toContain('Translated: 795, failed: 141')
+      expect(run.stdout).toContain('Those keys remain missing')
     })
   })
 

--- a/packages/cli/tests/cli/translate-partial-failure.test.ts
+++ b/packages/cli/tests/cli/translate-partial-failure.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import { localesWithFailures } from '../../src/commands/translate.js'
+import { resolveExitCode } from '../../src/commands/_shared.js'
+import type { TranslateMissingOutcome } from '../../src/core/types.js'
+
+/**
+ * A translate run that writes most keys and loses the rest exits 0: exit 1 is
+ * reserved for a run that translated nothing (isTotalFailure). That is why the
+ * partial case needs its own opt-in gate — without it, 141 lost keys out of 936
+ * are indistinguishable from a clean run, and the partial result is committed.
+ */
+
+const failedGate = {
+  name: 'fail-on-failed',
+  counter: 'totalFailed',
+  direction: 'above' as const,
+  threshold: 0,
+}
+
+describe('the --fail-on-failed gate', () => {
+  it('trips on a partial failure, which no other signal reports', () => {
+    const partial = { summary: { totalTranslated: 795, totalFailed: 141 } }
+
+    // The shape of the anny-ui run: green pipeline, 141 keys unwritten.
+    expect(resolveExitCode(partial, []).code).toBe(0)
+    expect(resolveExitCode(partial, [failedGate]).code).toBe(2)
+  })
+
+  it('names the observed count against the threshold when it trips', () => {
+    const decision = resolveExitCode(
+      { summary: { totalTranslated: 795, totalFailed: 141 } },
+      [failedGate],
+    )
+
+    expect(decision.tripped).toEqual([{ ...failedGate, observed: 141 }])
+  })
+
+  it('stays quiet on a clean run', () => {
+    const decision = resolveExitCode(
+      { summary: { totalTranslated: 936, totalFailed: 0 } },
+      [failedGate],
+    )
+
+    expect(decision.code).toBe(0)
+    expect(decision.tripped).toEqual([])
+  })
+
+  // A total failure is a broken run, not a findings gate — CI must tell them
+  // apart, so exit 1 outranks exit 2.
+  it('yields to a total failure rather than reporting a gate', () => {
+    const decision = resolveExitCode(
+      { summary: { totalTranslated: 0, totalFailed: 141 } },
+      [failedGate],
+      true,
+    )
+
+    expect(decision.code).toBe(1)
+    expect(decision.tripped).toEqual([])
+  })
+})
+
+describe('naming the locales that lost keys', () => {
+  it('reads the all-layers shape, deduplicating across layers', () => {
+    const result = {
+      layers: {
+        'app-admin': {
+          results: {
+            'da-DK': { failed: [{ key: 'a' }, { key: 'b' }] },
+            'fr-FR': { failed: [{ key: 'c' }] },
+            'en-GB': { failed: [] },
+          },
+          summary: {},
+        },
+        'app-shop': {
+          results: {
+            'da-DK': { failed: [{ key: 'd' }] },
+            'uk-UA': { failed: [{ key: 'e' }] },
+          },
+          summary: {},
+        },
+      },
+      summary: { totalFailed: 5 },
+    } as unknown as TranslateMissingOutcome
+
+    expect(localesWithFailures(result)).toEqual(['da-DK', 'fr-FR', 'uk-UA'])
+  })
+
+  it('reads the single-layer shape', () => {
+    const result = {
+      results: {
+        de: { failed: [] },
+        lv: { failed: [{ key: 'x' }] },
+      },
+      summary: { totalFailed: 1 },
+    } as unknown as TranslateMissingOutcome
+
+    expect(localesWithFailures(result)).toEqual(['lv'])
+  })
+
+  // Compact mode returns counts in summary.byLocale instead of `results`, so
+  // reading only one of the two would report no locales for half the runs.
+  it('reads the compact shape, where failures are counts rather than lists', () => {
+    const result = {
+      summary: {
+        totalFailed: 3,
+        byLocale: [
+          { locale: 'nb', failed: 0 },
+          { locale: 'ga', failed: 3 },
+        ],
+      },
+    } as unknown as TranslateMissingOutcome
+
+    expect(localesWithFailures(result)).toEqual(['ga'])
+  })
+
+  it('returns nothing when no locale failed', () => {
+    const result = {
+      results: { de: { failed: [] } },
+      summary: { totalFailed: 0 },
+    } as unknown as TranslateMissingOutcome
+
+    expect(localesWithFailures(result)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #316.

A translate run that wrote 795 keys and lost 141 exited 0. CI committed the partial result and went green; four locales shipped incomplete and nothing reported it.

`isTotalFailure` only reports exit 1 when *nothing* was translated — the right meaning for "the run fell over", but it leaves the partial case with no signal at all. And `translate` declared no gates, so there was no flag a project could set instead.

## What changed

**`--fail-on-failed`** on `translate`, opt-in like `--fail-on-missing` and `--fail-on-orphans`, exiting 2 when `totalFailed > 0`. Opt-in rather than default because providers fail transiently, and a red pipeline on every flake is a red pipeline nobody reads. Plumbed through both templates as `I18N_FAIL_ON_FAILED` and `fail_on_failed`.

**The ungated path stops being silent.** That is the path most projects are on, and `totalFailed: 141` says nothing about which languages are incomplete. A partial failure now sets `summary.message` naming the affected locales, stating the keys are still missing, and pointing at the re-run that retries them.

Reading the affected locales has to handle three shapes — all-layers, single-layer, and compact mode, where failures are counts in `summary.byLocale` rather than key lists. Handling only one would report no locales for a large fraction of runs.

## One thing the existing tests caught

My first version had the GitLab template print the retry hint behind `if [ "$FAILED" != "0" ]`. The guard test in `template-gate-execution.test.ts` rejects exactly that — counts parsed for display must never feed a comparison — which is the #254 coupling this template was cleaned of.

That was the right call and the better design: the CLI owns the guidance, the template prints the payload, and there is no second place that needs to know what `totalFailed` means. The template now carries a comment saying why the branch is absent, so it does not get re-added.

## Verification

- 909 CLI tests pass (10 new), 31 MCP tests pass
- New unit tests cover the gate on a partial failure, a clean run, and a total failure outranking it, plus locale extraction across all three result shapes
- The template tests execute the real job script under `dash`: `--fail-on-failed` is passed only when requested, and the CLI's message reaches the log
- `npx fallow audit` — no issues in 7 changed files

## Not in scope

`.i18n-translate` still sets `allow_failure: true`, so a consumer wanting this to block also needs `allow_failure: false` — documented rather than changed, since flipping it would turn every existing consumer's flaky run red on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
