### PR TITLE
feat(nuxt): publish the layer graph and locale table from inside the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Agent changes wording for an existing key
 |---------|---------|-------------|
 | [**the-i18n-cli**](./packages/cli) | [![npm](https://img.shields.io/npm/v/the-i18n-cli?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-cli) | CLI + core library — install globally |
 | [**the-i18n-mcp**](./packages/mcp) | [![npm](https://img.shields.io/npm/v/the-i18n-mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-mcp) | MCP server for AI agents |
+| [**@the-i18n-kit/nuxt**](./packages/nuxt) | [![npm](https://img.shields.io/npm/v/@the-i18n-kit/nuxt?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/nuxt) | Nuxt module — publishes the layer graph and locale table Nuxt already resolved |
 
 ---
 
@@ -423,6 +424,12 @@ All tools work immediately.
 ## Project Config
 
 Drop a `.i18n-mcp.json` at your project root to give agents (and the CLI) project context:
+
+> **Nuxt:** install [`@the-i18n-kit/nuxt`](./packages/nuxt) and the derived half of this
+> file goes away. The module publishes the locale table and layer graph Nuxt already
+> resolved, so `locales`, `localeDirs` and `defaultLocale` stop being restated by hand —
+> and `protectedLocales` entries that match nothing, or match several locales, fail the
+> build instead of failing quietly.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -192,9 +192,13 @@ Human-maintained locales can be excluded from automatic translation via `protect
 
 ```json
 {
-  "protectedLocales": ["en-US", "en-GB", "de-DE-formal"]
+  "protectedLocales": ["en-us", "en", "de-formal"]
 }
 ```
+
+Address locales by **code**. A ref may also be a language tag or a file name (with its
+extension), but codes are the only form guaranteed to be unique — see
+[Referring to Locales](./packages/cli/README.md#referring-to-locales).
 
 Protected locales are excluded from the default target set of both translate operations and reported as `skipped` with reason `protected-locale`. Explicitly naming a protected locale in `targetLocales` overrides the protection with a warning. `discover` lists the resolved protected locales.
 
@@ -444,7 +448,7 @@ Drop a `.i18n-mcp.json` at your project root to give agents (and the CLI) projec
     "de": "Informal German (du)",
     "de-formal": "Formal German (Sie)"
   },
-  "protectedLocales": ["en-US", "de-DE-formal"]
+  "protectedLocales": ["en-us", "de-formal"]
 }
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -324,7 +324,7 @@ Drop a `.i18n-mcp.json` at your project root for project-specific context:
     "de": "Informal German (du)",
     "de-formal": "Formal German (Sie)"
   },
-  "protectedLocales": ["en-US", "de-DE-formal"]
+  "protectedLocales": ["en-us", "de-formal"]
 }
 ```
 

--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -7,6 +7,8 @@ import { findNuxtConfig, discoverNuxtApps, deriveLayerName } from '../../config/
 import { loadKit } from '../../config/nuxt-loader'
 import { loadProjectConfig } from '../../config/project-config'
 import { applyLocaleOverride } from '../../config/locale-override'
+import { normalizeFallbackLocale } from '../../config/fallback-locale'
+import { artifactToConfig, readArtifact } from '../../config/artifact'
 import { log } from '../../utils/logger'
 import { ConfigError, toErrorMessage } from '../../utils/errors'
 import { claimLocaleDir } from './layer-dedup'
@@ -52,7 +54,7 @@ export class NuxtAdapter implements FrameworkAdapter {
 
     const [soleAppDir] = appDirs
     if (appDirs.length === 1 && soleAppDir !== undefined) {
-      const config = await loadSingleApp(soleAppDir, projectDir)
+      const config = await loadApp(soleAppDir, projectDir)
       if (soleAppDir !== projectDir) {
         config.rootDir = projectDir
         const rootApp = config.apps[0]
@@ -69,6 +71,20 @@ export class NuxtAdapter implements FrameworkAdapter {
     log.info(`Detected ${config.locales.length} locales, ${config.localeDirs.length} locale directories from ${appDirs.length} app(s)`)
     return config
   }
+}
+
+/**
+ * One app's config, preferring what @the-i18n-kit/nuxt published from inside
+ * the build over reconstructing it from outside. The artifact is additive: any
+ * reason not to trust it falls through to loading the app exactly as before,
+ * so a project without the module — or with a stale one — behaves as it always
+ * has.
+ */
+async function loadApp(appDir: string, discoveryRoot: string): Promise<I18nConfig> {
+  const artifact = await readArtifact(appDir)
+  if (!artifact) return loadSingleApp(appDir, discoveryRoot)
+
+  return artifactToConfig(artifact, appDir, discoveryRoot, await loadProjectConfig(discoveryRoot))
 }
 
 async function loadSingleApp(appDir: string, discoveryRoot: string): Promise<I18nConfig> {
@@ -131,7 +147,7 @@ async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promi
     log.info(`Loading Nuxt app: ${relative(discoveryRoot, appDir) || '.'}`)
     let appConfig: I18nConfig
     try {
-      appConfig = await loadSingleApp(appDir, discoveryRoot)
+      appConfig = await loadApp(appDir, discoveryRoot)
     }
     catch (error) {
       log.warn(`Failed to load app at ${appDir}: ${toErrorMessage(error)}`)
@@ -244,7 +260,7 @@ async function extractI18nConfig(
     )
   }
 
-  const fallbackLocale = extractFallbackLocale(i18nOptions)
+  const fallbackLocale = normalizeFallbackLocale(i18nOptions.fallbackLocale, defaultLocale)
   const localeDirs = await discoverLocaleDirs(layers, i18nOptions, discoveryRoot)
 
   const layerRootDirs = [...new Set(layers.map(l => l.config.rootDir))]
@@ -267,36 +283,6 @@ async function extractI18nConfig(
     projectConfig: projectConfig ?? undefined,
     apps: [appInfo],
   }
-}
-
-function extractFallbackLocale(
-  i18nOptions: Record<string, unknown>,
-): Record<string, string[]> {
-  const fallback = i18nOptions.fallbackLocale
-
-  if (typeof fallback === 'string') {
-    return { default: [fallback] }
-  }
-
-  if (Array.isArray(fallback)) {
-    return { default: (fallback as unknown[]).map(String) }
-  }
-
-  if (fallback && typeof fallback === 'object') {
-    const result: Record<string, string[]> = {}
-    for (const [key, value] of Object.entries(fallback as Record<string, unknown>)) {
-      if (Array.isArray(value)) {
-        result[key] = value.map(String)
-      }
-      else if (typeof value === 'string') {
-        result[key] = [value]
-      }
-    }
-    return result
-  }
-
-  const defaultLocale = (i18nOptions.defaultLocale as string) ?? 'en'
-  return { default: [defaultLocale] }
 }
 
 async function discoverLocaleDirs(

--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -84,7 +84,18 @@ async function loadApp(appDir: string, discoveryRoot: string): Promise<I18nConfi
   const artifact = await readArtifact(appDir)
   if (!artifact) return loadSingleApp(appDir, discoveryRoot)
 
-  return artifactToConfig(artifact, appDir, discoveryRoot, await loadProjectConfig(discoveryRoot))
+  const config = await artifactToConfig(artifact, appDir, discoveryRoot, await loadProjectConfig(discoveryRoot))
+
+  // An artifact describing no locale directory leaves nothing to read, which
+  // the fallback path reports as a ConfigError naming what is missing. Silently
+  // returning an empty config instead would make installing the module turn a
+  // clear error into no output at all.
+  if (config.localeDirs.length === 0) {
+    log.warn(`The artifact for ${appDir} describes no locale directories — loading the app instead.`)
+    return loadSingleApp(appDir, discoveryRoot)
+  }
+
+  return config
 }
 
 async function loadSingleApp(appDir: string, discoveryRoot: string): Promise<I18nConfig> {

--- a/packages/cli/src/config/artifact.ts
+++ b/packages/cli/src/config/artifact.ts
@@ -1,0 +1,169 @@
+import { existsSync, statSync } from 'node:fs'
+import { readFile, realpath } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { z } from 'zod'
+import type { AppInfo, I18nConfig, LocaleDefinition, LocaleDir, ProjectConfig } from './types.js'
+import { deriveLayerName, findNuxtConfig } from './discovery.js'
+import { applyLocaleOverride } from './locale-override.js'
+import { normalizeFallbackLocale } from './fallback-locale.js'
+import { claimLocaleDir } from '../adapters/nuxt/layer-dedup.js'
+import { log } from '../utils/logger.js'
+
+/** Where @the-i18n-kit/nuxt publishes what Nuxt resolved, relative to an app. */
+const ARTIFACT_PATH = '.nuxt/i18n-kit.json'
+
+const localeSchema = z.object({
+  code: z.string().min(1),
+  language: z.string(),
+  file: z.string().min(1),
+  name: z.string().optional(),
+})
+
+const layerSchema = z.object({
+  rootDir: z.string().min(1),
+  localeDir: z.string().min(1).optional(),
+})
+
+const artifactSchema = z.object({
+  version: z.literal(1),
+  generator: z.string(),
+  appDir: z.string().min(1),
+  defaultLocale: z.string().min(1),
+  // As Nuxt resolved it, in any of the three shapes @nuxtjs/i18n accepts.
+  // Normalising it here rather than in the module keeps one implementation.
+  fallbackLocale: z.union([
+    z.string(),
+    z.array(z.string()),
+    z.record(z.string(), z.union([z.string(), z.array(z.string())])),
+    z.null(),
+  ]),
+  localeFileFormat: z.literal('json'),
+  locales: z.array(localeSchema).min(1),
+  layers: z.array(layerSchema).min(1),
+})
+
+export type I18nKitArtifact = z.infer<typeof artifactSchema>
+
+/**
+ * Read an app's artifact, or null when there isn't a usable one.
+ *
+ * Never throws: every failure here — absent, malformed, a version this CLI
+ * does not know, or older than the config it claims to describe — means
+ * falling back to loading the app through Nuxt, which is what happens today
+ * anyway. A module that cannot be trusted must not be able to break a project
+ * that worked without it.
+ */
+export async function readArtifact(appDir: string): Promise<I18nKitArtifact | null> {
+  const path = resolve(appDir, ARTIFACT_PATH)
+  if (!existsSync(path)) return null
+
+  if (isStale(appDir, path)) {
+    log.warn(
+      `Ignoring ${path}: the Nuxt config has changed since it was generated. `
+      + 'Run `nuxt prepare` to refresh it — falling back to loading the app.',
+    )
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf-8'))
+  }
+  catch (error) {
+    log.warn(`Ignoring ${path}: ${error instanceof Error ? error.message : String(error)}`)
+    return null
+  }
+
+  const result = artifactSchema.safeParse(parsed)
+  if (!result.success) {
+    const [issue] = result.error.issues
+    const where = issue?.path.join('.') || '(root)'
+    log.warn(`Ignoring ${path}: not a shape this CLI understands (${where}: ${issue?.message}).`)
+    return null
+  }
+
+  log.info(`Using the layer graph published by ${result.data.generator}`)
+  return result.data
+}
+
+/**
+ * An artifact older than the config it describes is a lie about the current
+ * project, and a quiet one. Cheaper to distrust it than to explain later why
+ * a renamed locale never took effect.
+ */
+function isStale(appDir: string, artifactPath: string): boolean {
+  const configFile = findNuxtConfig(appDir)
+  if (!configFile) return false
+
+  try {
+    return statSync(resolve(appDir, configFile)).mtimeMs > statSync(artifactPath).mtimeMs
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Turn one app's artifact into the config shape every command consumes.
+ *
+ * Layer *names* are derived here rather than read from the artifact: they
+ * depend on the directory the CLI was pointed at, which the module cannot
+ * know. Deriving them in one place is what keeps the artifact path and the
+ * fallback path producing the same names for the same project.
+ */
+export async function artifactToConfig(
+  artifact: I18nKitArtifact,
+  appDir: string,
+  discoveryRoot: string,
+  projectConfig: ProjectConfig | null,
+): Promise<I18nConfig> {
+  const localeDirs: LocaleDir[] = []
+  const claimed = new Map<string, { layer: string, layerRootDir: string }>()
+  const usedLayerNames = new Set<string>()
+
+  for (const layer of artifact.layers) {
+    // Named before the locale-dir check, and unconditionally: a layer without
+    // translations still consumes its name, so that layers with translations
+    // get the same names they would on the fallback path.
+    const layerName = deriveLayerName(layer.rootDir, discoveryRoot, usedLayerNames)
+    usedLayerNames.add(layerName)
+
+    if (!layer.localeDir) continue
+
+    const realDir = await realpath(layer.localeDir).catch(() => layer.localeDir!)
+    claimLocaleDir(
+      localeDirs,
+      claimed,
+      { path: layer.localeDir, layer: layerName, layerRootDir: layer.rootDir },
+      realDir,
+    )
+  }
+
+  const layerRootDirs = [...new Set(artifact.layers.map(l => l.rootDir))]
+  if (layerRootDirs.length === 0) layerRootDirs.push(appDir)
+
+  const namesForApp = new Set<string>()
+  const app: AppInfo = {
+    name: deriveLayerName(appDir, discoveryRoot, new Set()),
+    rootDir: appDir,
+    layers: artifact.layers.map(l => deriveLayerName(l.rootDir, discoveryRoot, namesForApp)),
+  }
+
+  const locales: LocaleDefinition[] = artifact.locales.map(l => ({
+    code: l.code,
+    language: l.language,
+    file: l.file,
+    ...(l.name === undefined ? {} : { name: l.name }),
+  }))
+
+  return {
+    rootDir: appDir,
+    defaultLocale: artifact.defaultLocale,
+    fallbackLocale: normalizeFallbackLocale(artifact.fallbackLocale, artifact.defaultLocale),
+    locales: applyLocaleOverride(locales, projectConfig?.locales),
+    localeDirs,
+    layerRootDirs,
+    projectConfig: projectConfig ?? undefined,
+    apps: [app],
+  }
+}

--- a/packages/cli/src/config/artifact.ts
+++ b/packages/cli/src/config/artifact.ts
@@ -57,14 +57,6 @@ export async function readArtifact(appDir: string): Promise<I18nKitArtifact | nu
   const path = resolve(appDir, ARTIFACT_PATH)
   if (!existsSync(path)) return null
 
-  if (isStale(appDir, path)) {
-    log.warn(
-      `Ignoring ${path}: the Nuxt config has changed since it was generated. `
-      + 'Run `nuxt prepare` to refresh it — falling back to loading the app.',
-    )
-    return null
-  }
-
   let parsed: unknown
   try {
     parsed = JSON.parse(await readFile(path, 'utf-8'))
@@ -82,25 +74,56 @@ export async function readArtifact(appDir: string): Promise<I18nKitArtifact | nu
     return null
   }
 
+  // Staleness is checked after parsing so the layers can be checked too: a
+  // layer's own config decides that layer's locales, and an app config that
+  // has not changed says nothing about the layers it extends.
+  const changed = staleAgainst(result.data, path)
+  if (changed) {
+    log.warn(
+      `Ignoring ${path}: ${changed} has changed since it was generated. `
+      + 'Run `nuxt prepare` to refresh it — falling back to loading the app.',
+    )
+    return null
+  }
+
   log.info(`Using the layer graph published by ${result.data.generator}`)
   return result.data
 }
 
 /**
- * An artifact older than the config it describes is a lie about the current
- * project, and a quiet one. Cheaper to distrust it than to explain later why
- * a renamed locale never took effect.
+ * An artifact older than any config it describes is a lie about the current
+ * project, and a quiet one. Cheaper to distrust it than to explain later why a
+ * renamed locale never took effect.
+ *
+ * Returns the config that outdates it, for the message; undefined when the
+ * artifact is current, when no config can be found, or when a stat fails —
+ * unreadable timestamps are not evidence of staleness.
  */
-function isStale(appDir: string, artifactPath: string): boolean {
-  const configFile = findNuxtConfig(appDir)
-  if (!configFile) return false
-
+function staleAgainst(artifact: I18nKitArtifact, artifactPath: string): string | undefined {
+  let artifactMtime: number
   try {
-    return statSync(resolve(appDir, configFile)).mtimeMs > statSync(artifactPath).mtimeMs
+    artifactMtime = statSync(artifactPath).mtimeMs
   }
   catch {
-    return false
+    return undefined
   }
+
+  const dirs = [artifact.appDir, ...artifact.layers.map(l => l.rootDir)]
+
+  for (const dir of new Set(dirs)) {
+    const configFile = findNuxtConfig(dir)
+    if (!configFile) continue
+
+    const configPath = resolve(dir, configFile)
+    try {
+      if (statSync(configPath).mtimeMs > artifactMtime) return configPath
+    }
+    catch {
+      continue
+    }
+  }
+
+  return undefined
 }
 
 /**

--- a/packages/cli/src/config/fallback-locale.ts
+++ b/packages/cli/src/config/fallback-locale.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalise `@nuxtjs/i18n`'s `fallbackLocale` — a string, an array, or a
+ * per-locale map — into the single map shape the rest of the CLI reads.
+ *
+ * Shared by both paths on purpose. The Nuxt module publishes this value exactly
+ * as Nuxt resolved it rather than normalising it itself: two implementations of
+ * the same normalisation, in two packages that do not depend on each other, is
+ * precisely the drift the module exists to remove.
+ */
+export function normalizeFallbackLocale(
+  fallback: unknown,
+  defaultLocale: string,
+): Record<string, string[]> {
+  if (typeof fallback === 'string') {
+    return { default: [fallback] }
+  }
+
+  if (Array.isArray(fallback)) {
+    return { default: (fallback as unknown[]).map(String) }
+  }
+
+  if (fallback && typeof fallback === 'object') {
+    const result: Record<string, string[]> = {}
+    for (const [key, value] of Object.entries(fallback as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        result[key] = value.map(String)
+      }
+      else if (typeof value === 'string') {
+        result[key] = [value]
+      }
+    }
+    return result
+  }
+
+  return { default: [defaultLocale] }
+}

--- a/packages/cli/tests/config/artifact.test.ts
+++ b/packages/cli/tests/config/artifact.test.ts
@@ -1,0 +1,186 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { artifactToConfig, readArtifact } from '../../src/config/artifact.js'
+import type { I18nKitArtifact } from '../../src/config/artifact.js'
+
+/**
+ * The artifact is additive: it is preferred when trustworthy and ignored
+ * otherwise, and being ignored must never be louder than a warning. A module
+ * that cannot be trusted must not break a project that worked without it.
+ */
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'i18n-artifact-'))
+  await mkdir(join(dir, '.nuxt'), { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+function validArtifact(overrides: Partial<I18nKitArtifact> = {}): I18nKitArtifact {
+  return {
+    version: 1,
+    generator: '@the-i18n-kit/nuxt@0.1.1',
+    appDir: dir,
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['de'] },
+    localeFileFormat: 'json',
+    locales: [
+      { code: 'de', language: 'de-DE', file: 'de-DE.json', name: 'Deutsch' },
+      { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+    ],
+    layers: [{ rootDir: dir, localeDir: join(dir, 'i18n', 'locales') }],
+    ...overrides,
+  }
+}
+
+async function writeArtifact(content: unknown): Promise<void> {
+  await writeFile(
+    join(dir, '.nuxt', 'i18n-kit.json'),
+    typeof content === 'string' ? content : JSON.stringify(content),
+  )
+}
+
+describe('reading an artifact', () => {
+  it('returns it when it is well formed', async () => {
+    await writeArtifact(validArtifact())
+
+    expect(await readArtifact(dir)).toMatchObject({ defaultLocale: 'de' })
+  })
+
+  it('returns null when there is none', async () => {
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  it('returns null rather than throwing on malformed JSON', async () => {
+    await writeArtifact('{ not json')
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  // A future version may mean anything; guessing is how a consumer silently
+  // reads a shape that no longer means what it thinks.
+  it('returns null on a version this CLI does not know', async () => {
+    await writeArtifact({ ...validArtifact(), version: 2 })
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  it('returns null when a required field is missing', async () => {
+    const { defaultLocale: _dropped, ...withoutDefault } = validArtifact()
+    await writeArtifact(withoutDefault)
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  it('returns null when it describes no locales at all', async () => {
+    await writeArtifact(validArtifact({ locales: [] }))
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  // An artifact older than the config it describes is a lie about the current
+  // project, and a quiet one.
+  it('returns null when the Nuxt config is newer than the artifact', async () => {
+    await writeArtifact(validArtifact())
+    await writeFile(join(dir, 'nuxt.config.ts'), 'export default {}')
+
+    const future = new Date(Date.now() + 60_000)
+    await utimes(join(dir, 'nuxt.config.ts'), future, future)
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
+  it('accepts an artifact newer than the config', async () => {
+    await writeFile(join(dir, 'nuxt.config.ts'), 'export default {}')
+    await writeArtifact(validArtifact())
+
+    const past = new Date(Date.now() - 60_000)
+    await utimes(join(dir, 'nuxt.config.ts'), past, past)
+
+    expect(await readArtifact(dir)).not.toBeNull()
+  })
+})
+
+describe('converting an artifact to a config', () => {
+  const root = '/repo'
+
+  it('names layers relative to the directory the CLI was pointed at', async () => {
+    const artifact = validArtifact({
+      appDir: '/repo/app-admin',
+      layers: [
+        { rootDir: '/repo/app-admin', localeDir: '/repo/app-admin/i18n/locales' },
+        { rootDir: '/repo/app-admin/layers/dashboard-next' },
+        { rootDir: '/repo', localeDir: '/repo/i18n/locales' },
+      ],
+    })
+
+    const config = await artifactToConfig(artifact, '/repo/app-admin', root, null)
+
+    // Not 'root' — a module inside app-admin cannot know it is app-admin from
+    // the repo's point of view, which is why names are derived here.
+    expect(config.apps).toEqual([
+      { name: 'app-admin', rootDir: '/repo/app-admin', layers: ['app-admin', 'dashboard-next', 'root'] },
+    ])
+    expect(config.localeDirs.map(d => d.layer)).toEqual(['app-admin', 'root'])
+  })
+
+  it('keeps a layer without translations out of localeDirs but in layerRootDirs', async () => {
+    const artifact = validArtifact({
+      appDir: '/repo/app-admin',
+      layers: [
+        { rootDir: '/repo/app-admin', localeDir: '/repo/app-admin/i18n/locales' },
+        { rootDir: '/repo/app-admin/layers/dashboard-next' },
+      ],
+    })
+
+    const config = await artifactToConfig(artifact, '/repo/app-admin', root, null)
+
+    expect(config.localeDirs).toHaveLength(1)
+    expect(config.layerRootDirs).toEqual(['/repo/app-admin', '/repo/app-admin/layers/dashboard-next'])
+  })
+
+  it('carries the locale table through unchanged', async () => {
+    const config = await artifactToConfig(validArtifact(), dir, root, null)
+
+    expect(config.locales).toEqual([
+      { code: 'de', language: 'de-DE', file: 'de-DE.json', name: 'Deutsch' },
+      { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+    ])
+  })
+
+  it('still applies the locales override from .i18n-mcp.json', async () => {
+    const config = await artifactToConfig(validArtifact(), dir, root, { locales: ['en'] })
+
+    expect(config.locales.map(l => l.code)).toEqual(['en'])
+  })
+
+  it('carries the default locale', async () => {
+    const config = await artifactToConfig(validArtifact({ defaultLocale: 'en' }), dir, root, null)
+
+    expect(config.defaultLocale).toBe('en')
+  })
+
+  // The module publishes fallbackLocale exactly as Nuxt resolved it, in any of
+  // the three shapes @nuxtjs/i18n accepts. Normalising it here rather than in
+  // the module keeps one implementation across both paths.
+  it.each([
+    ['a bare string', 'en', { default: ['en'] }],
+    ['an array', ['en', 'de'], { default: ['en', 'de'] }],
+    ['a per-locale map', { 'de-formal': ['de'], 'default': 'en' }, { 'de-formal': ['de'], 'default': ['en'] }],
+    ['nothing at all', null, { default: ['de'] }],
+  ])('normalises %s', async (_label, fallbackLocale, expected) => {
+    const artifact = validArtifact({ fallbackLocale: fallbackLocale as never })
+
+    const config = await artifactToConfig(artifact, dir, root, null)
+
+    expect(config.fallbackLocale).toEqual(expected)
+  })
+})

--- a/packages/cli/tests/config/artifact.test.ts
+++ b/packages/cli/tests/config/artifact.test.ts
@@ -98,6 +98,22 @@ describe('reading an artifact', () => {
     expect(await readArtifact(dir)).toBeNull()
   })
 
+  // A layer's own config decides that layer's locales, so an unchanged app
+  // config says nothing about the layers it extends.
+  it("returns null when a layer's config is newer than the artifact", async () => {
+    const layerDir = join(dir, 'layers', 'nested')
+    await mkdir(layerDir, { recursive: true })
+    await writeArtifact(validArtifact({
+      layers: [{ rootDir: dir, localeDir: join(dir, 'i18n', 'locales') }, { rootDir: layerDir }],
+    }))
+    await writeFile(join(layerDir, 'nuxt.config.ts'), 'export default {}')
+
+    const future = new Date(Date.now() + 60_000)
+    await utimes(join(layerDir, 'nuxt.config.ts'), future, future)
+
+    expect(await readArtifact(dir)).toBeNull()
+  })
+
   it('accepts an artifact newer than the config', async () => {
     await writeFile(join(dir, 'nuxt.config.ts'), 'export default {}')
     await writeArtifact(validArtifact())
@@ -145,6 +161,21 @@ describe('converting an artifact to a config', () => {
 
     expect(config.localeDirs).toHaveLength(1)
     expect(config.layerRootDirs).toEqual(['/repo/app-admin', '/repo/app-admin/layers/dashboard-next'])
+  })
+
+  // The adapter treats this as unusable and loads the app instead: the fallback
+  // path reports a ConfigError naming what is missing, and installing the module
+  // must not turn that into an empty result.
+  it('yields no locale directories when no layer has one', async () => {
+    const artifact = validArtifact({
+      appDir: '/repo/app-admin',
+      layers: [{ rootDir: '/repo/app-admin' }, { rootDir: '/repo' }],
+    })
+
+    const config = await artifactToConfig(artifact, '/repo/app-admin', root, null)
+
+    expect(config.localeDirs).toEqual([])
+    expect(config.layerRootDirs).toEqual(['/repo/app-admin', '/repo'])
   })
 
   it('carries the locale table through unchanged', async () => {

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -2,18 +2,14 @@
 
 Nuxt module for [the i18n kit](https://github.com/fabkho/the-i18n-kit).
 
-**Status: skeleton — this module does not do anything yet.** The package exists so
-that the npm name, build tooling and release wiring are settled before the
-implementation lands. Installing it today is a no-op.
+Nuxt already resolves your layer graph and your locale table. Without this module,
+`.i18n-mcp.json` restates both by hand and the CLI re-derives them from outside by
+loading `nuxt.config.ts` — two descriptions of the same thing, with nothing that
+notices when they disagree.
 
-## What it will do
-
-Nuxt already resolves your layer graph and your locale table. Today every consumer
-restates both in `.i18n-mcp.json`, and the two descriptions drift. This module will
-publish what Nuxt resolved as a build artifact that the CLI reads in preference to
-hand-written config, so the derived half of the config stops being written twice.
-
-Tracked in [#305](https://github.com/fabkho/the-i18n-kit/issues/305).
+This module publishes what Nuxt resolved, as a build artifact the CLI reads in
+preference to hand-written config. The derived half of your config stops being
+written twice.
 
 ## Install
 
@@ -24,19 +20,54 @@ pnpm add -D @the-i18n-kit/nuxt
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
-  modules: ['@the-i18n-kit/nuxt'],
+  modules: ['@nuxtjs/i18n', '@the-i18n-kit/nuxt'],
 })
 ```
 
+Then remove `locales`, `localeDirs` and `defaultLocale` from `.i18n-mcp.json` —
+the module derives them, and declaring them in both places is now an error rather
+than a silent override.
+
+In a monorepo with several Nuxt apps, install it in each app. Every app publishes
+its own artifact and the CLI merges them, exactly as it merges apps today.
+
+## What it does
+
+On `nuxt prepare`, `nuxt dev` and `nuxt build`, it writes `.nuxt/i18n-kit.json`
+describing this app: its locale table, its layers, and which of those layers carry
+translations. `.nuxt` is already gitignored and already wiped by `nuxt cleanup`, so
+the artifact is never a review artifact and cannot be merged.
+
+It also checks, at build time, two things that used to fail silently:
+
+- **`protectedLocales` entries that resolve to nothing.** `de-DE-formal` matches no
+  locale when the code is `de-formal`, so it protected nothing while looking like it
+  did. That is now a build error naming the valid codes.
+- **`protectedLocales` entries that resolve to several locales.** `de-DE` is ambiguous
+  when both `de` and `de-formal` declare it. Reported with all candidates.
+
+A ref that resolves by language tag or file name rather than by code is a warning:
+it works today, but a locale added later with the same tag would make it ambiguous
+without anyone touching the line that wrote it.
+
 ## Options
 
-Configured under the `i18nKit` key. Accepted and validated today; they take effect
-once artifact generation lands.
+Configured under the `i18nKit` key.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `enabled` | `true` | Set to `false` to skip artifact generation. The CLI then falls back to adapter detection, exactly as without the module. |
+| `enabled` | `true` | Set to `false` to skip generation. The CLI falls back to adapter detection, exactly as without the module. |
 | `artifact` | `'i18n-kit.json'` | Artifact path, relative to the Nuxt build dir. |
+| `failOnInvalidConfig` | `true` | Set to `false` to report configuration problems without failing the build. |
+
+## Removing it is safe
+
+The CLI prefers the artifact when it is present, parseable, of a version it knows,
+and not older than the `nuxt.config` it describes. Any other case falls back to
+loading the app through Nuxt — which is what it does today, for every project.
+
+So adding this module changes nothing except where the facts come from, and removing
+it degrades rather than breaks.
 
 ## Development
 
@@ -44,7 +75,8 @@ once artifact generation lands.
 
 ```bash
 pnpm --filter @the-i18n-kit/nuxt build   # or `dev` for the stub build
-pnpm --filter playground dev
+pnpm --filter playground exec nuxt prepare
+cat playground/nuxt/.nuxt/i18n-kit.json
 ```
 
 ## License

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -57,13 +57,17 @@ Configured under the `i18nKit` key.
 | Option | Default | Description |
 | --- | --- | --- |
 | `enabled` | `true` | Set to `false` to skip generation. The CLI falls back to adapter detection, exactly as without the module. |
-| `artifact` | `'i18n-kit.json'` | Artifact path, relative to the Nuxt build dir. |
 | `failOnInvalidConfig` | `true` | Set to `false` to report configuration problems without failing the build. |
+
+The artifact path is fixed at `<app>/.nuxt/i18n-kit.json`. The CLI looks there without
+loading your Nuxt config — that is the point — so it cannot follow a renamed file or a
+custom `buildDir`. With a custom `buildDir` the CLI simply falls back to loading the app,
+as it does without this module.
 
 ## Removing it is safe
 
 The CLI prefers the artifact when it is present, parseable, of a version it knows,
-and not older than the `nuxt.config` it describes. Any other case falls back to
+and not older than any `nuxt.config` it describes — the app's or any layer's. Any other case falls back to
 loading the app through Nuxt — which is what it does today, for every project.
 
 So adding this module changes nothing except where the facts come from, and removing

--- a/packages/nuxt/src/artifact.ts
+++ b/packages/nuxt/src/artifact.ts
@@ -1,0 +1,148 @@
+import { existsSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+/** One locale, addressable by any of the three ref forms the kit accepts. */
+export interface ArtifactLocale {
+  code: string
+  language: string
+  file: string
+  name?: string
+}
+
+/**
+ * One Nuxt layer. `localeDir` is absent for layers that carry source code but
+ * no translations — a real case (anny-ui's `app-admin/layers/dashboard-next`),
+ * and the reason layers and locale directories cannot be derived from one
+ * another: dropping such a layer silently removes it from source scanning,
+ * which surfaces as false orphans rather than as an error.
+ */
+export interface ArtifactLayer {
+  rootDir: string
+  localeDir?: string
+}
+
+/**
+ * What one Nuxt app publishes about itself.
+ *
+ * Layer *names* are deliberately absent. The CLI derives them relative to the
+ * directory it was pointed at, and a module cannot know that directory — a
+ * module inside `app-admin` would name its own layer `root` where the CLI
+ * (run from the repo root) names it `app-admin`. Emitting raw directories and
+ * letting the consumer name them keeps one naming implementation instead of
+ * two that must agree.
+ */
+export interface I18nKitArtifact {
+  version: 1
+  generator: string
+  appDir: string
+  defaultLocale: string
+  /**
+   * Exactly as Nuxt resolved it — a string, an array or a per-locale map. The
+   * CLI owns the normalisation, so that one implementation serves both the
+   * artifact path and the fallback path instead of two that must agree.
+   */
+  fallbackLocale: string | string[] | Record<string, string | string[]> | null
+  localeFileFormat: 'json'
+  locales: ArtifactLocale[]
+  /** Ordered as Nuxt resolved them: the app's own layer first, then what it extends. */
+  layers: ArtifactLayer[]
+}
+
+interface NuxtLayerLike {
+  config: {
+    rootDir: string
+    i18n?: Record<string, unknown>
+  }
+}
+
+export interface ArtifactInput {
+  appDir: string
+  i18n: Record<string, unknown>
+  layers: NuxtLayerLike[]
+  generator: string
+}
+
+export async function buildArtifact(input: ArtifactInput): Promise<I18nKitArtifact> {
+  return {
+    version: 1,
+    generator: input.generator,
+    appDir: input.appDir,
+    defaultLocale: (input.i18n.defaultLocale as string) ?? 'en',
+    fallbackLocale: (input.i18n.fallbackLocale ?? null) as I18nKitArtifact['fallbackLocale'],
+    localeFileFormat: 'json',
+    locales: readLocales(input.i18n),
+    layers: await readLayers(input.layers, input.i18n),
+  }
+}
+
+/**
+ * Order is preserved, not sorted: it is precedence, and the CLI's own fallback
+ * path reads the same array in the same order. Sorting would make the artifact
+ * tidier and the two paths disagree.
+ *
+ * Deduplicated by code, though. A layered app sees each locale once per layer
+ * that declares it — anny-ui's `app-admin` reports 60 entries for 30 locales,
+ * every duplicate identical to the first — and a published table that repeats
+ * itself invites consumers to count it.
+ *
+ * This mirrors the CLI's own locale reading, and the duplication is deliberate.
+ * `fallbackLocale` avoids it by publishing what Nuxt resolved and normalising
+ * once in the CLI; the locale table cannot, because the artifact is required to
+ * carry `code`, `language`, `file` and `name` per entry (#305) so that any
+ * consumer can resolve a ref without knowing @nuxtjs/i18n's legacy field names.
+ * Sharing the code instead would mean depending on the CLI from a Nuxt module,
+ * which couples their release cycles for eight lines.
+ */
+function readLocales(i18n: Record<string, unknown>): ArtifactLocale[] {
+  const raw = (i18n.locales ?? []) as Array<Record<string, unknown>>
+  const seen = new Set<string>()
+
+  return raw
+    .filter(l => typeof l === 'object' && l !== null)
+    .map(l => ({
+      code: String(l.code ?? ''),
+      language: String(l.language ?? l.iso ?? ''),
+      file: String(l.file ?? ''),
+      ...(l.name ? { name: String(l.name) } : {}),
+    }))
+    .filter((l) => {
+      if (!l.code || !l.file || seen.has(l.code)) return false
+      seen.add(l.code)
+      return true
+    })
+}
+
+/**
+ * A layer's locale directory is reported only when it exists and holds JSON,
+ * matching what the CLI's own discovery accepts. An empty or absent directory
+ * leaves the layer in the list without one, rather than dropping the layer.
+ */
+async function readLayers(
+  layers: NuxtLayerLike[],
+  appI18n: Record<string, unknown>,
+): Promise<ArtifactLayer[]> {
+  const result: ArtifactLayer[] = []
+
+  for (const layer of layers) {
+    const rootDir = layer.config.rootDir
+    const i18n = layer.config.i18n ?? appI18n
+    const langDir = (i18n.langDir as string) ?? 'locales'
+    const restructureDir = (i18n.restructureDir as string) ?? 'i18n'
+    const localeDir = resolve(rootDir, restructureDir, langDir)
+
+    result.push({ rootDir, ...(await holdsLocales(localeDir) ? { localeDir } : {}) })
+  }
+
+  return result
+}
+
+async function holdsLocales(dir: string): Promise<boolean> {
+  if (!existsSync(dir)) return false
+  try {
+    return (await readdir(dir)).some(f => f.endsWith('.json'))
+  }
+  catch {
+    return false
+  }
+}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -11,18 +11,24 @@ import type { Diagnostic } from './validate'
 
 const CONFIG_FILENAME = '.i18n-mcp.json'
 
+/**
+ * Fixed, not configurable. The CLI looks for `<app>/.nuxt/i18n-kit.json` without
+ * loading your Nuxt config — that is the point of the artifact — so it cannot
+ * follow a renamed file. A configurable producer with a fixed consumer is a
+ * setting that silently stops the two from meeting.
+ *
+ * The same reasoning applies to a custom `buildDir`: the CLI will not find the
+ * artifact there and falls back to loading the app, as it does without this
+ * module.
+ */
+const ARTIFACT_FILENAME = 'i18n-kit.json'
+
 export interface ModuleOptions {
   /**
    * Set to false to skip artifact generation entirely. The CLI then falls back
    * to adapter detection, exactly as it behaves without the module installed.
    */
   enabled?: boolean
-
-  /**
-   * Where the artifact is written, relative to the Nuxt build dir.
-   * Only change this if something else already owns the default path.
-   */
-  artifact?: string
 
   /**
    * Report configuration problems without failing the build. The problems are
@@ -42,7 +48,6 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     enabled: true,
-    artifact: 'i18n-kit.json',
     failOnInvalidConfig: true,
   },
   setup(options, nuxt) {
@@ -82,18 +87,28 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
       report(diagnostics, logger, options.failOnInvalidConfig ?? true)
 
+      // Nothing to publish, and an empty table is worse than no artifact: the
+      // CLI would have to decide whether it means "no locales" or "not built".
+      if (artifact.locales.length === 0) {
+        logger.warn(
+          'No locales resolved from your i18n configuration, so nothing was published. '
+          + 'The CLI will fall back to loading this app itself.',
+        )
+        return
+      }
+
       // A template rather than a plain write: Nuxt owns the build dir, wipes it
       // during prepare and regenerates it in dev. Writing directly here races
       // that — the file lands and is then cleaned away before the build ends.
       addTemplate({
-        filename: options.artifact ?? 'i18n-kit.json',
+        filename: ARTIFACT_FILENAME,
         write: true,
         getContents: () => `${JSON.stringify(artifact, null, 2)}\n`,
       })
 
       logger.success(
         `Published ${artifact.locales.length} locale(s) across ${artifact.layers.length} layer(s) `
-        + `to ${join(nuxt.options.buildDir, options.artifact ?? 'i18n-kit.json')}`,
+        + `to ${join(nuxt.options.buildDir, ARTIFACT_FILENAME)}`,
       )
     })
   },

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,5 +1,15 @@
-import { defineNuxtModule } from '@nuxt/kit'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { addTemplate, defineNuxtModule, useLogger } from '@nuxt/kit'
 import type { NuxtModule } from '@nuxt/schema'
+
+import { version } from '../package.json'
+import { buildArtifact } from './artifact'
+import { checkOwnedKeys, checkProtectedLocales } from './validate'
+import type { Diagnostic } from './validate'
+
+const CONFIG_FILENAME = '.i18n-mcp.json'
 
 export interface ModuleOptions {
   /**
@@ -13,13 +23,18 @@ export interface ModuleOptions {
    * Only change this if something else already owns the default path.
    */
   artifact?: string
+
+  /**
+   * Report configuration problems without failing the build. The problems are
+   * still printed — this only decides whether they stop you.
+   */
+  failOnInvalidConfig?: boolean
 }
 
-// Annotated rather than inferred: under pnpm's non-hoisted layout the inferred
-// type cannot be named without pointing at a versioned @nuxt/schema path (TS2742).
 const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@the-i18n-kit/nuxt',
+    version,
     configKey: 'i18nKit',
     compatibility: {
       nuxt: '>=3.0.0',
@@ -28,14 +43,111 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
   defaults: {
     enabled: true,
     artifact: 'i18n-kit.json',
+    failOnInvalidConfig: true,
   },
-  setup(options) {
+  setup(options, nuxt) {
     if (!options.enabled) return
 
-    // Artifact generation lands in #305. This package exists first so the
-    // npm name, build tooling and release wiring are settled before there is
-    // anything worth publishing.
+    const logger = useLogger('i18n-kit')
+
+    // modules:done, not setup: @nuxtjs/i18n normalises nuxt.options.i18n during
+    // its own setup, and module order is not ours to assume. Reading it here
+    // means reading what Nuxt resolved rather than what was typed.
+    nuxt.hook('modules:done', async () => {
+      // @nuxtjs/i18n augments NuxtOptions with its own `i18n` key when it is
+      // installed. This module works without it installed, so the key is read
+      // structurally rather than declared as a dependency on its types.
+      const i18n = (nuxt.options as unknown as Record<string, unknown>).i18n as Record<string, unknown> | undefined
+
+      if (!i18n) {
+        logger.warn(
+          'No i18n configuration found, so nothing was published. '
+          + 'Install and configure @nuxtjs/i18n, or remove this module.',
+        )
+        return
+      }
+
+      const artifact = await buildArtifact({
+        appDir: nuxt.options.rootDir,
+        i18n,
+        layers: nuxt.options._layers as unknown as Array<{ config: { rootDir: string, i18n?: Record<string, unknown> } }>,
+        generator: `@the-i18n-kit/nuxt@${version}`,
+      })
+
+      const projectConfig = await readProjectConfig(nuxt.options.rootDir, logger)
+      const diagnostics = [
+        ...checkOwnedKeys(projectConfig),
+        ...checkProtectedLocales(projectConfig?.protectedLocales as string[] | undefined, artifact.locales),
+      ]
+
+      report(diagnostics, logger, options.failOnInvalidConfig ?? true)
+
+      // A template rather than a plain write: Nuxt owns the build dir, wipes it
+      // during prepare and regenerates it in dev. Writing directly here races
+      // that — the file lands and is then cleaned away before the build ends.
+      addTemplate({
+        filename: options.artifact ?? 'i18n-kit.json',
+        write: true,
+        getContents: () => `${JSON.stringify(artifact, null, 2)}\n`,
+      })
+
+      logger.success(
+        `Published ${artifact.locales.length} locale(s) across ${artifact.layers.length} layer(s) `
+        + `to ${join(nuxt.options.buildDir, options.artifact ?? 'i18n-kit.json')}`,
+      )
+    })
   },
 })
 
 export default module
+
+interface LoggerLike {
+  warn: (message: string) => void
+  error: (message: string) => void
+  success: (message: string) => void
+}
+
+function report(diagnostics: Diagnostic[], logger: LoggerLike, failOnInvalidConfig: boolean): void {
+  const errors = diagnostics.filter(d => d.level === 'error')
+
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.level === 'error') logger.error(diagnostic.message)
+    else logger.warn(diagnostic.message)
+  }
+
+  // Failing the build is the whole point of checking at build time: a warning
+  // to stderr is what let de-DE-formal protect nothing for months.
+  if (errors.length > 0 && failOnInvalidConfig) {
+    throw new Error(
+      `${CONFIG_FILENAME} does not agree with your Nuxt config (${errors.length} problem(s), listed above). `
+      + 'Set i18nKit.failOnInvalidConfig to false to report without failing.',
+    )
+  }
+}
+
+/**
+ * Nearest `.i18n-mcp.json` walking up from the app, the same way the CLI finds
+ * it — in a layered repo the config sits at the root while each app builds from
+ * its own directory.
+ */
+async function readProjectConfig(
+  startDir: string,
+  logger: LoggerLike,
+): Promise<Record<string, unknown> | null> {
+  let dir = startDir
+  for (;;) {
+    const candidate = join(dir, CONFIG_FILENAME)
+    if (existsSync(candidate)) {
+      try {
+        return JSON.parse(await readFile(candidate, 'utf-8')) as Record<string, unknown>
+      }
+      catch (error) {
+        logger.warn(`Could not read ${candidate}: ${error instanceof Error ? error.message : String(error)}`)
+        return null
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}

--- a/packages/nuxt/src/validate.ts
+++ b/packages/nuxt/src/validate.ts
@@ -42,7 +42,11 @@ export function checkProtectedLocales(
   locales: ArtifactLocale[],
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
-  const codes = locales.map(l => l.code).join(', ')
+  // "Available codes: " with nothing after it reads as a broken message rather
+  // than as the finding it is — that no locales resolved at all.
+  const available = locales.length > 0
+    ? `Available codes: ${locales.map(l => l.code).join(', ')}`
+    : 'No locales resolved from your i18n configuration at all.'
 
   for (const ref of protectedLocales ?? []) {
     const found = match(locales, ref)
@@ -50,7 +54,7 @@ export function checkProtectedLocales(
     if (!found) {
       diagnostics.push({
         level: 'error',
-        message: `protectedLocales: "${ref}" matches no locale, so it protects nothing. Available codes: ${codes}`,
+        message: `protectedLocales: "${ref}" matches no locale, so it protects nothing. ${available}`,
       })
       continue
     }

--- a/packages/nuxt/src/validate.ts
+++ b/packages/nuxt/src/validate.ts
@@ -1,0 +1,97 @@
+import type { ArtifactLocale } from './artifact'
+
+/**
+ * Same precedence the CLI resolves with (#301): an exact `code` outranks a
+ * `language` tag, which outranks a `file` name. Codes are unique by
+ * construction; language tags are not — two locales can both declare `de-DE`.
+ */
+const MATCH_FIELDS = ['code', 'language', 'file'] as const
+type MatchField = typeof MATCH_FIELDS[number]
+
+/** Keys Nuxt already answers. Declaring them again is a second source of truth. */
+const MODULE_OWNED_KEYS = ['locales', 'localeDirs', 'defaultLocale'] as const
+
+export interface Diagnostic {
+  level: 'error' | 'warn'
+  message: string
+}
+
+interface Match {
+  field: MatchField
+  candidates: ArtifactLocale[]
+}
+
+function match(locales: ArtifactLocale[], ref: string): Match | undefined {
+  for (const field of MATCH_FIELDS) {
+    const candidates = locales.filter(locale => locale[field] === ref)
+    if (candidates.length > 0) return { field, candidates }
+  }
+  return undefined
+}
+
+/**
+ * Check `protectedLocales` against the locale table Nuxt actually resolved.
+ *
+ * This is the check that would have caught `de-DE-formal` on the day it was
+ * written: it matches no locale, so the CLI warned to stderr and carried on,
+ * and formal German sat in the machine-translation target list for months
+ * while appearing protected.
+ */
+export function checkProtectedLocales(
+  protectedLocales: string[] | undefined,
+  locales: ArtifactLocale[],
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = []
+  const codes = locales.map(l => l.code).join(', ')
+
+  for (const ref of protectedLocales ?? []) {
+    const found = match(locales, ref)
+
+    if (!found) {
+      diagnostics.push({
+        level: 'error',
+        message: `protectedLocales: "${ref}" matches no locale, so it protects nothing. Available codes: ${codes}`,
+      })
+      continue
+    }
+
+    if (found.candidates.length > 1) {
+      diagnostics.push({
+        level: 'error',
+        message: `protectedLocales: "${ref}" is ambiguous — it matches ${found.candidates.length} locales `
+          + `by ${found.field} (${found.candidates.map(c => c.code).join(', ')}). Use one of those codes instead.`,
+      })
+      continue
+    }
+
+    // Unambiguous today, but only because no second locale declares this tag
+    // yet. The failure mode is silent: adding one turns this ref ambiguous
+    // without touching the line that wrote it.
+    const [only] = found.candidates
+    if (found.field !== 'code' && only) {
+      diagnostics.push({
+        level: 'warn',
+        message: `protectedLocales: "${ref}" matched by ${found.field} rather than code. `
+          + `Prefer "${only.code}" — a locale added later with the same ${found.field} would make this ambiguous.`,
+      })
+    }
+  }
+
+  return diagnostics
+}
+
+/**
+ * Keys the module derives must not also be declared by hand. Silent precedence
+ * between the two is how the drift this module exists to remove began.
+ */
+export function checkOwnedKeys(projectConfig: Record<string, unknown> | null): Diagnostic[] {
+  if (!projectConfig) return []
+
+  return MODULE_OWNED_KEYS
+    .filter(key => projectConfig[key] !== undefined)
+    .map(key => ({
+      level: 'error' as const,
+      message: `.i18n-mcp.json declares "${key}", which this module derives from your Nuxt config. `
+        + `Remove it from .i18n-mcp.json — keeping both means two sources of truth and no way to tell which won.`,
+    }))
+}

--- a/packages/nuxt/tests/artifact.test.ts
+++ b/packages/nuxt/tests/artifact.test.ts
@@ -1,0 +1,159 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildArtifact } from '../src/artifact'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'i18n-kit-artifact-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+/** A layer directory that holds locale JSON, as Nuxt would resolve it. */
+async function layerWithLocales(name: string): Promise<string> {
+  const rootDir = join(dir, name)
+  await mkdir(join(rootDir, 'i18n', 'locales'), { recursive: true })
+  await writeFile(join(rootDir, 'i18n', 'locales', 'en.json'), '{}')
+  return rootDir
+}
+
+async function layerWithoutLocales(name: string): Promise<string> {
+  const rootDir = join(dir, name)
+  await mkdir(rootDir, { recursive: true })
+  return rootDir
+}
+
+const build = (i18n: Record<string, unknown>, layers: Array<{ config: { rootDir: string, i18n?: Record<string, unknown> } }>) =>
+  buildArtifact({ appDir: dir, i18n, layers, generator: 'test' })
+
+describe('the locale table', () => {
+  it('carries all four ref forms, so any of them can be resolved', async () => {
+    const artifact = await build(
+      { locales: [{ code: 'de', language: 'de-DE', file: 'de-DE.json', name: 'Deutsch' }] },
+      [],
+    )
+
+    expect(artifact.locales).toEqual([
+      { code: 'de', language: 'de-DE', file: 'de-DE.json', name: 'Deutsch' },
+    ])
+  })
+
+  // A layered app sees each locale once per layer that declares it: anny-ui's
+  // app-admin reports 60 entries for 30 locales, every duplicate identical.
+  it('deduplicates by code, keeping the first', async () => {
+    const artifact = await build({
+      locales: [
+        { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+        { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+        { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+      ],
+    }, [])
+
+    expect(artifact.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
+
+  // Order is precedence, and the CLI's fallback path reads the same array in
+  // the same order. Sorting would make the two paths disagree.
+  it('preserves declaration order rather than sorting', async () => {
+    const artifact = await build({
+      locales: [
+        { code: 'nb', language: 'nb-NO', file: 'nb.json' },
+        { code: 'da', language: 'da-DK', file: 'da.json' },
+        { code: 'bg', language: 'bg-BG', file: 'bg.json' },
+      ],
+    }, [])
+
+    expect(artifact.locales.map(l => l.code)).toEqual(['nb', 'da', 'bg'])
+  })
+
+  it('drops entries without a code or a file, which cannot be addressed', async () => {
+    const artifact = await build({
+      locales: [
+        { code: 'de', file: 'de.json' },
+        { code: 'no-file' },
+        { file: 'no-code.json' },
+      ],
+    }, [])
+
+    expect(artifact.locales.map(l => l.code)).toEqual(['de'])
+  })
+
+  it('reads the legacy iso field as the language tag', async () => {
+    const artifact = await build({ locales: [{ code: 'de', iso: 'de-DE', file: 'de.json' }] }, [])
+
+    expect(artifact.locales[0]?.language).toBe('de-DE')
+  })
+})
+
+describe('the layer list', () => {
+  it('reports a layer that has no locale directory of its own', async () => {
+    const withLocales = await layerWithLocales('app-admin')
+    const sourceOnly = await layerWithoutLocales('dashboard-next')
+
+    const artifact = await build({ locales: [{ code: 'de', file: 'de.json' }] }, [
+      { config: { rootDir: withLocales } },
+      { config: { rootDir: sourceOnly } },
+    ])
+
+    // Dropping the second would remove it from source scanning, which surfaces
+    // as false orphans rather than as an error.
+    expect(artifact.layers).toEqual([
+      { rootDir: withLocales, localeDir: join(withLocales, 'i18n', 'locales') },
+      { rootDir: sourceOnly },
+    ])
+  })
+
+  it('ignores a locale directory that exists but holds no JSON', async () => {
+    const rootDir = join(dir, 'empty')
+    await mkdir(join(rootDir, 'i18n', 'locales'), { recursive: true })
+    await writeFile(join(rootDir, 'i18n', 'locales', 'README.md'), '')
+
+    const artifact = await build({ locales: [{ code: 'de', file: 'de.json' }] }, [
+      { config: { rootDir } },
+    ])
+
+    expect(artifact.layers).toEqual([{ rootDir }])
+  })
+
+  it('honours a layer that relocates its own locale directory', async () => {
+    const rootDir = join(dir, 'custom')
+    await mkdir(join(rootDir, 'translations'), { recursive: true })
+    await writeFile(join(rootDir, 'translations', 'de.json'), '{}')
+
+    const artifact = await build({ locales: [{ code: 'de', file: 'de.json' }] }, [
+      { config: { rootDir, i18n: { langDir: 'translations', restructureDir: '.' } } },
+    ])
+
+    expect(artifact.layers[0]?.localeDir).toBe(join(rootDir, 'translations'))
+  })
+})
+
+describe('the fallback chain', () => {
+  // Published exactly as Nuxt resolved it. The CLI normalises the three shapes
+  // @nuxtjs/i18n accepts, so that one implementation serves both the artifact
+  // path and the fallback path rather than two that have to agree.
+  it.each([
+    ['a bare string', 'en'],
+    ['an array', ['en', 'de']],
+    ['a per-locale map', { 'de-formal': ['de'], 'default': 'en' }],
+  ])('passes %s through untouched', async (_label, fallbackLocale) => {
+    const artifact = await build(
+      { locales: [{ code: 'de', file: 'de.json' }], defaultLocale: 'de', fallbackLocale },
+      [],
+    )
+
+    expect(artifact.fallbackLocale).toEqual(fallbackLocale)
+  })
+
+  it('reports null when nothing is configured, rather than inventing a chain', async () => {
+    const artifact = await build({ locales: [{ code: 'de', file: 'de.json' }], defaultLocale: 'de' }, [])
+
+    expect(artifact.fallbackLocale).toBeNull()
+  })
+})

--- a/packages/nuxt/tests/validate.test.ts
+++ b/packages/nuxt/tests/validate.test.ts
@@ -52,6 +52,16 @@ describe('protectedLocales against the real locale table', () => {
     expect(diagnostic?.message).toContain('Prefer "en-us"')
   })
 
+  // "Available codes: " with nothing after it reads as a broken message rather
+  // than as the finding it is.
+  it('says so plainly when no locales resolved at all', () => {
+    const [diagnostic] = checkProtectedLocales(['de'], [])
+
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain('No locales resolved')
+    expect(diagnostic?.message).not.toContain('Available codes:')
+  })
+
   it('has nothing to say when protectedLocales is absent', () => {
     expect(checkProtectedLocales(undefined, locales)).toEqual([])
   })

--- a/packages/nuxt/tests/validate.test.ts
+++ b/packages/nuxt/tests/validate.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkOwnedKeys, checkProtectedLocales } from '../src/validate'
+import type { ArtifactLocale } from '../src/artifact'
+
+/** anny-ui's real shape: two German locales sharing one language tag. */
+const locales: ArtifactLocale[] = [
+  { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+  { code: 'de-formal', language: 'de-DE', file: 'de-DE-formal.json' },
+  { code: 'en', language: 'en-GB', file: 'en-GB.json' },
+  { code: 'en-us', language: 'en-US', file: 'en-US.json' },
+]
+
+describe('protectedLocales against the real locale table', () => {
+  // The bug this module exists to catch: the code is `de-formal`, so
+  // `de-DE-formal` protected nothing while appearing to protect formal German.
+  it('errors on a ref that matches nothing, naming the valid codes', () => {
+    const [diagnostic, ...rest] = checkProtectedLocales(['de-DE-formal'], locales)
+
+    expect(rest).toEqual([])
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain('"de-DE-formal" matches no locale')
+    expect(diagnostic?.message).toContain('de, de-formal, en, en-us')
+  })
+
+  it('errors on a ref that matches several, naming all of them', () => {
+    const [diagnostic] = checkProtectedLocales(['de-DE'], locales)
+
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain('ambiguous')
+    expect(diagnostic?.message).toContain('de, de-formal')
+  })
+
+  it('accepts an exact code without comment', () => {
+    expect(checkProtectedLocales(['de-formal'], locales)).toEqual([])
+  })
+
+  // Unambiguous today only because no second locale declares en-GB. Adding one
+  // would turn this ref ambiguous without touching the line that wrote it.
+  it('warns when a ref resolves by language tag rather than by code', () => {
+    const [diagnostic] = checkProtectedLocales(['en-GB'], locales)
+
+    expect(diagnostic?.level).toBe('warn')
+    expect(diagnostic?.message).toContain('matched by language rather than code')
+    expect(diagnostic?.message).toContain('Prefer "en"')
+  })
+
+  it('warns the same way for a file name', () => {
+    const [diagnostic] = checkProtectedLocales(['en-US.json'], locales)
+
+    expect(diagnostic?.level).toBe('warn')
+    expect(diagnostic?.message).toContain('Prefer "en-us"')
+  })
+
+  it('has nothing to say when protectedLocales is absent', () => {
+    expect(checkProtectedLocales(undefined, locales)).toEqual([])
+  })
+})
+
+describe('keys the module derives', () => {
+  it.each(['locales', 'localeDirs', 'defaultLocale'])('errors when .i18n-mcp.json declares %s', (key) => {
+    const [diagnostic, ...rest] = checkOwnedKeys({ [key]: 'anything' })
+
+    expect(rest).toEqual([])
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain(`declares "${key}"`)
+  })
+
+  it('reports every conflict rather than only the first', () => {
+    const diagnostics = checkOwnedKeys({ locales: [], defaultLocale: 'de', glossary: {} })
+
+    expect(diagnostics).toHaveLength(2)
+  })
+
+  it('leaves the keys Nuxt cannot know alone', () => {
+    const config = {
+      glossary: { anny: 'never translate' },
+      translationPrompt: 'be concise',
+      protectedLocales: ['de-formal'],
+      orphanScan: {},
+      context: 'a booking platform',
+    }
+
+    expect(checkOwnedKeys(config)).toEqual([])
+  })
+
+  it('has nothing to say when there is no config file', () => {
+    expect(checkOwnedKeys(null)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #305. Builds on the scaffold from #314.

`.i18n-mcp.json` restates what Nuxt already resolved, and the CLI re-derives the same facts from outside by loading `nuxt.config.ts`. Two descriptions of one thing, nothing that notices when they disagree. This publishes what Nuxt resolved and has the CLI read that instead.

## What it does

The module writes `.nuxt/i18n-kit.json` on `prepare`, `dev` and `build`, describing its app: the locale table with `code`, `language`, `file` and `name` per entry; the ordered layer list; and which layers carry translations. The CLI prefers it **per app** and merges as it merges apps today, so a monorepo can adopt it one app at a time — and a project with no module behaves exactly as before.

Two checks that used to be a stderr warning now fail the build:

- a `protectedLocales` entry matching **no** locale — `de-DE-formal`, which protected nothing for months while looking like it did
- a `protectedLocales` entry matching **several** — `de-DE`, which both `de` and `de-formal` declare

A ref that resolves by language tag or file name rather than by code is a warning: it works today, but a locale added later with the same tag makes it ambiguous without anyone touching the line that wrote it. That warning goes beyond the acceptance criteria; it closes the mode that produced the original bug.

Declaring `locales`, `localeDirs` or `defaultLocale` in `.i18n-mcp.json` is now an error naming the conflict, not a silent merge.

## Verification on the real project

Ran against anny-ui — 7 apps, 30 locales, `admin-next/head`:

| | with artifacts | without |
|---|---|---|
| `missing` | identical | identical |
| `remove-orphans` | 8612 keys / 1272 orphans | 8612 keys / 1272 orphans |
| `remove-orphans` wall time | **0.8s** | 3.9s |

Byte-identical output both ways, which is the acceptance criterion. The speedup is a side effect: nothing loads Nuxt seven times.

The playground covers the mixed case — one app with the module, one without — and is byte-identical too.

## Three things the real project decided, not the spec

**Layer names are not published.** They depend on the directory the CLI was pointed at, which a module cannot know: a module inside `app-admin` sees its own layer as `root`, where the CLI run from the repo root calls it `app-admin`. The artifact carries directories; the CLI names them. One implementation, so the two paths cannot drift apart.

**Locale order is preserved, not sorted.** My contract comment on #305 proposed sorting for determinism. That was wrong: order is precedence, and the fallback path reads the same array in the same order. Sorting would have made the artifact tidier and the two paths disagree.

**`fallbackLocale` is published raw.** Normalising the three shapes `@nuxtjs/i18n` accepts in the module *and* in the CLI would be one rule implemented twice in packages that deliberately don't depend on each other — the exact drift this issue is about. The CLI now normalises both paths through one function.

The locale table does not get the same treatment, and the duplication check flags it (6 lines, warn, audit passes). Deliberate: the artifact is required to carry the four ref fields per entry, so it cannot publish `@nuxtjs/i18n`'s raw objects with their legacy field names. Sharing the code instead would mean a Nuxt module depending on the CLI — coupling their release cycles for eight lines. Noted in the source at the duplicate.

## Adopting it in anny-ui will fail the build once, on purpose

`.i18n-mcp.json` there declares all 30 `locales`. That is now a conflict, so the first build after installing the module errors until the key is removed. That is the intended migration: the config shrinks by the 30-entry array and the layer restatement.

## Verification

- 926 CLI tests (17 new), 26 module tests (24 new), 31 MCP tests
- lint, typecheck, `npx fallow audit` (exit 0)
- module tests cover the duplicate-locale case (anny-ui's 60-for-30), a layer with source but no translations (`dashboard-next`), a relocated `langDir`, and every `protectedLocales` outcome
- CLI tests cover absent, malformed, unknown-version, incomplete and stale artifacts — all of which fall back silently rather than throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Nuxt integration that automatically generates locale and layer configuration for the CLI.
  - Added support for fallback locales, locale overrides, custom locale directories, and monorepo layers.
  - Added validation for unmatched or ambiguous protected locales and conflicting configuration keys.
  - Added `failOnInvalidConfig` to optionally stop builds when configuration errors are detected.

- **Bug Fixes**
  - Improved CLI loading of Nuxt configuration with validated artifact support and fallback behavior.

- **Documentation**
  - Expanded setup, validation, troubleshooting, and protected-locale guidance, including locale-code examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->