### PR TITLE
refactor(cli): give merging Nuxt apps its own home

### DIFF
--- a/packages/cli/src/adapters/nuxt/index.ts
+++ b/packages/cli/src/adapters/nuxt/index.ts
@@ -12,6 +12,7 @@ import { artifactToConfig, readArtifact } from '../../config/artifact'
 import { log } from '../../utils/logger'
 import { ConfigError, toErrorMessage } from '../../utils/errors'
 import { claimLocaleDir } from './layer-dedup'
+import { AppMerger } from './merge-apps'
 
 export class NuxtAdapter implements FrameworkAdapter {
   readonly name = 'nuxt'
@@ -143,90 +144,37 @@ async function loadSingleApp(appDir: string, discoveryRoot: string): Promise<I18
 
 async function loadAndMergeApps(appDirs: string[], discoveryRoot: string): Promise<I18nConfig> {
   const projectConfig = await loadProjectConfig(discoveryRoot)
-
-  const allLocaleDirs: LocaleDir[] = []
-  const allLocales: LocaleDefinition[] = []
-  const allLayerRootDirs: string[] = []
-  const allApps: AppInfo[] = []
-  const seenLocalePaths = new Map<string, { layer: string, layerRootDir: string }>()
-  const seenLocaleCodes = new Set<string>()
-  const usedLayerNames = new Set<string>()
-  let defaultLocale = 'en'
-  let fallbackLocale: Record<string, string[]> = { default: ['en'] }
+  const merger = new AppMerger()
 
   for (const appDir of appDirs) {
     log.info(`Loading Nuxt app: ${relative(discoveryRoot, appDir) || '.'}`)
+
     let appConfig: I18nConfig
     try {
       appConfig = await loadApp(appDir, discoveryRoot)
     }
     catch (error) {
+      // One unloadable app must not take the others with it: a monorepo where
+      // a single app fails to build still has translations worth managing.
       log.warn(`Failed to load app at ${appDir}: ${toErrorMessage(error)}`)
       continue
     }
 
-    if (allLocaleDirs.length === 0) {
-      defaultLocale = appConfig.defaultLocale
-      fallbackLocale = appConfig.fallbackLocale
-    }
-
-    const layerNameRemap = new Map<string, string>()
-
-    for (const dir of appConfig.localeDirs) {
-      const realPath = await realpath(dir.path).catch(() => dir.path)
-
-      let claimDir = dir
-      if (!seenLocalePaths.has(realPath)) {
-        let layerName = dir.layer
-        if (usedLayerNames.has(layerName)) {
-          layerName = deriveLayerName(dir.layerRootDir, discoveryRoot, usedLayerNames)
-        }
-        if (layerName !== dir.layer) {
-          layerNameRemap.set(dir.layer, layerName)
-        }
-        usedLayerNames.add(layerName)
-        claimDir = { ...dir, layer: layerName }
-      }
-
-      claimLocaleDir(allLocaleDirs, seenLocalePaths, claimDir, realPath)
-    }
-
-    for (const locale of appConfig.locales) {
-      if (!seenLocaleCodes.has(locale.code)) {
-        seenLocaleCodes.add(locale.code)
-        allLocales.push(locale)
-      }
-    }
-
-    for (const rootDir of appConfig.layerRootDirs) {
-      if (!allLayerRootDirs.includes(rootDir)) {
-        allLayerRootDirs.push(rootDir)
-      }
-    }
-
-    for (const appInfo of appConfig.apps) {
-      const remappedLayers = appInfo.layers.map(name => layerNameRemap.get(name) ?? name)
-      allApps.push({ ...appInfo, layers: remappedLayers })
-    }
+    await merger.add(appConfig, discoveryRoot)
   }
 
-  if (allLocaleDirs.length === 0) {
+  if (merger.localeDirs.length === 0) {
     throw new ConfigError(
       `No locale directories found in any Nuxt app under ${discoveryRoot}. `
       + 'Make sure your Nuxt apps have i18n/locales/ directories with JSON files.',
     )
   }
 
-  return {
-    rootDir: discoveryRoot,
-    defaultLocale,
-    fallbackLocale,
-    locales: applyLocaleOverride(allLocales, projectConfig?.locales),
-    localeDirs: allLocaleDirs,
-    layerRootDirs: allLayerRootDirs,
-    projectConfig: projectConfig ?? undefined,
-    apps: allApps,
-  }
+  return merger.toConfig(
+    discoveryRoot,
+    projectConfig ?? undefined,
+    applyLocaleOverride(merger.locales, projectConfig?.locales),
+  )
 }
 
 async function extractI18nConfig(

--- a/packages/cli/src/adapters/nuxt/merge-apps.ts
+++ b/packages/cli/src/adapters/nuxt/merge-apps.ts
@@ -1,0 +1,109 @@
+import { realpath } from 'node:fs/promises'
+import type { AppInfo, I18nConfig, LocaleDefinition, LocaleDir } from '../../config/types'
+import { deriveLayerName } from '../../config/discovery'
+import { claimLocaleDir } from './layer-dedup'
+
+/**
+ * Folds several Nuxt apps into one project config.
+ *
+ * A monorepo's apps overlap: they extend the same root layer, sometimes alias
+ * each other's locale directories, and each reports the full locale table its
+ * layers declare. Merging them is therefore four separate reconciliations —
+ * directories claimed once by real path, locales deduplicated by code, layer
+ * roots kept unique, and app→layer edges rewritten to whatever the directory
+ * ended up being called. Keeping that state in one place stops the caller from
+ * having to hold all four in its head at once.
+ */
+export class AppMerger {
+  readonly localeDirs: LocaleDir[] = []
+  readonly locales: LocaleDefinition[] = []
+  readonly layerRootDirs: string[] = []
+  readonly apps: AppInfo[] = []
+
+  defaultLocale = 'en'
+  fallbackLocale: Record<string, string[]> = { default: ['en'] }
+
+  private readonly claimedPaths = new Map<string, { layer: string, layerRootDir: string }>()
+  private readonly seenLocaleCodes = new Set<string>()
+  private readonly usedLayerNames = new Set<string>()
+
+  async add(appConfig: I18nConfig, discoveryRoot: string): Promise<void> {
+    // The first app to be merged sets the project defaults. Checked against the
+    // directories rather than a flag, so an app that contributed none does not
+    // get to claim them.
+    if (this.localeDirs.length === 0) {
+      this.defaultLocale = appConfig.defaultLocale
+      this.fallbackLocale = appConfig.fallbackLocale
+    }
+
+    const renamedLayers = await this.claimDirs(appConfig, discoveryRoot)
+    this.collectLocales(appConfig)
+    this.collectLayerRoots(appConfig)
+    this.collectApps(appConfig, renamedLayers)
+  }
+
+  toConfig(discoveryRoot: string, projectConfig: I18nConfig['projectConfig'], locales: LocaleDefinition[]): I18nConfig {
+    return {
+      rootDir: discoveryRoot,
+      defaultLocale: this.defaultLocale,
+      fallbackLocale: this.fallbackLocale,
+      locales,
+      localeDirs: this.localeDirs,
+      layerRootDirs: this.layerRootDirs,
+      projectConfig,
+      apps: this.apps,
+    }
+  }
+
+  /**
+   * Claim each of this app's locale directories, renaming a layer whose name is
+   * already taken by a different directory. Returns the renames, because the
+   * app's own layer list still refers to the old names.
+   */
+  private async claimDirs(appConfig: I18nConfig, discoveryRoot: string): Promise<Map<string, string>> {
+    const renamed = new Map<string, string>()
+
+    for (const dir of appConfig.localeDirs) {
+      const realPath = await realpath(dir.path).catch(() => dir.path)
+
+      // An already-claimed path keeps the name its first claimant gave it;
+      // claimLocaleDir records this app as an alias of that layer.
+      let claim = dir
+      if (!this.claimedPaths.has(realPath)) {
+        const layer = this.uniqueLayerName(dir, discoveryRoot)
+        if (layer !== dir.layer) renamed.set(dir.layer, layer)
+        this.usedLayerNames.add(layer)
+        claim = { ...dir, layer }
+      }
+
+      claimLocaleDir(this.localeDirs, this.claimedPaths, claim, realPath)
+    }
+
+    return renamed
+  }
+
+  private uniqueLayerName(dir: LocaleDir, discoveryRoot: string): string {
+    if (!this.usedLayerNames.has(dir.layer)) return dir.layer
+    return deriveLayerName(dir.layerRootDir, discoveryRoot, this.usedLayerNames)
+  }
+
+  private collectLocales(appConfig: I18nConfig): void {
+    for (const locale of appConfig.locales) {
+      if (this.seenLocaleCodes.has(locale.code)) continue
+      this.seenLocaleCodes.add(locale.code)
+      this.locales.push(locale)
+    }
+  }
+
+  private collectLayerRoots(appConfig: I18nConfig): void {
+    for (const rootDir of appConfig.layerRootDirs) {
+      if (!this.layerRootDirs.includes(rootDir)) this.layerRootDirs.push(rootDir)
+    }
+  }
+
+  private collectApps(appConfig: I18nConfig, renamedLayers: Map<string, string>): void {
+    for (const app of appConfig.apps) {
+      this.apps.push({ ...app, layers: app.layers.map(name => renamedLayers.get(name) ?? name) })
+    }
+  }
+}


### PR DESCRIPTION
`loadAndMergeApps` was the one complexity hotspot on the Nuxt module's path — 17 cyclomatic, 33 cognitive, 87 lines, CRAP 79.4 — and the last piece of the #305 work the handoff paired with it.

## What was hard about it

It held four reconciliations at once, interleaved in a single loop body over a scattering of accumulators:

- locale directories claimed once by **real path**, so an app that symlinks another's directory becomes an alias rather than a second copy
- locales deduplicated by **code**, because every app reports the full table its layers declare
- layer root directories kept unique
- app→layer edges **rewritten** when a layer had to be renamed to avoid a collision

The renaming is what made it genuinely tangled: a directory's name is decided while claiming it, but the app's own layer list still refers to the old name, so the loop had to thread a remap through to the end.

## What it looks like now

Those four are an `AppMerger` that owns the state, and the function reads as what it is: load each app, fold it in, fail if nothing had translations. Each reconciliation is a named method that does one of them.

`loadAndMergeApps` no longer appears in the complexity report at all.

## Behaviour is unchanged, and checked rather than assumed

- the same 928 CLI tests pass, untouched
- `missing` and `remove-orphans` on anny-ui — 7 apps, 30 locales, including the `app-outlook` → `app-shop` alias and the `dashboard-next` layer with no translations — produce **byte-identical** output through the fallback path this touches
- `npx fallow audit` exit 0

## Not in scope

The four CRITICAL findings in the translate and orphan operations (`translateOneLocale`, `translateKey`, `removeOrphanKeys`, `applyTranslations`) stay as they are. No defect this month came from them, they are the most heavily tested code in the repo, and refactoring them buys a metric rather than an outcome. If they are ever taken, one PR each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
