### PR TITLE
feat(nuxt): declare the kit's config in nuxt.config.ts, typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,11 +429,12 @@ All tools work immediately.
 
 Drop a `.i18n-mcp.json` at your project root to give agents (and the CLI) project context:
 
-> **Nuxt:** install [`@the-i18n-kit/nuxt`](./packages/nuxt) and the derived half of this
-> file goes away. The module publishes the locale table and layer graph Nuxt already
-> resolved, so `locales`, `localeDirs` and `defaultLocale` stop being restated by hand —
-> and `protectedLocales` entries that match nothing, or match several locales, fail the
-> build instead of failing quietly.
+> **Nuxt:** install [`@the-i18n-kit/nuxt`](./packages/nuxt) and this file becomes optional.
+> The module publishes the locale table and layer graph Nuxt already resolved, so
+> `locales`, `localeDirs` and `defaultLocale` stop being restated by hand, and the rest —
+> glossary, tone notes, protected locales — can be declared under `i18nKit` in
+> `nuxt.config.ts`, typed and checked at build time. `protectedLocales` entries that match
+> nothing, or match several locales, fail the build instead of failing quietly.
 
 ```json
 {

--- a/packages/cli/src/adapters/nuxt/merge-apps.ts
+++ b/packages/cli/src/adapters/nuxt/merge-apps.ts
@@ -23,6 +23,14 @@ export class AppMerger {
   defaultLocale = 'en'
   fallbackLocale: Record<string, string[]> = { default: ['en'] }
 
+  /**
+   * Authoring policy contributed by the apps themselves — each app's artifact
+   * may carry what its nuxt.config declared. Accumulated first-wins, then
+   * overlaid by .i18n-mcp.json, which is the source a reader can see without
+   * building.
+   */
+  private readonly policy: Record<string, unknown> = {}
+
   private readonly claimedPaths = new Map<string, { layer: string, layerRootDir: string }>()
   private readonly seenLocaleCodes = new Set<string>()
   private readonly usedLayerNames = new Set<string>()
@@ -36,6 +44,7 @@ export class AppMerger {
       this.fallbackLocale = appConfig.fallbackLocale
     }
 
+    this.collectPolicy(appConfig)
     const renamedLayers = await this.claimDirs(appConfig, discoveryRoot)
     this.collectLocales(appConfig)
     this.collectLayerRoots(appConfig)
@@ -43,6 +52,10 @@ export class AppMerger {
   }
 
   toConfig(discoveryRoot: string, projectConfig: I18nConfig['projectConfig'], locales: LocaleDefinition[]): I18nConfig {
+    const merged = Object.keys(this.policy).length > 0
+      ? { ...this.policy, ...projectConfig } as I18nConfig['projectConfig']
+      : projectConfig
+
     return {
       rootDir: discoveryRoot,
       defaultLocale: this.defaultLocale,
@@ -50,7 +63,7 @@ export class AppMerger {
       locales,
       localeDirs: this.localeDirs,
       layerRootDirs: this.layerRootDirs,
-      projectConfig,
+      projectConfig: merged,
       apps: this.apps,
     }
   }
@@ -85,6 +98,12 @@ export class AppMerger {
   private uniqueLayerName(dir: LocaleDir, discoveryRoot: string): string {
     if (!this.usedLayerNames.has(dir.layer)) return dir.layer
     return deriveLayerName(dir.layerRootDir, discoveryRoot, this.usedLayerNames)
+  }
+
+  private collectPolicy(appConfig: I18nConfig): void {
+    for (const [key, value] of Object.entries(appConfig.projectConfig ?? {})) {
+      if (value !== undefined && this.policy[key] === undefined) this.policy[key] = value
+    }
   }
 
   private collectLocales(appConfig: I18nConfig): void {

--- a/packages/cli/src/config/artifact.ts
+++ b/packages/cli/src/config/artifact.ts
@@ -24,6 +24,14 @@ const layerSchema = z.object({
   localeDir: z.string().min(1).optional(),
 })
 
+/**
+ * Authoring policy declared in nuxt.config.ts. Deliberately permissive: the
+ * shape is owned by ProjectConfig's own schema, which validates it once the two
+ * sources are merged. Re-stating it here would be a second definition to keep
+ * in step.
+ */
+const policySchema = z.record(z.string(), z.unknown())
+
 const artifactSchema = z.object({
   version: z.literal(1),
   generator: z.string(),
@@ -40,6 +48,7 @@ const artifactSchema = z.object({
   localeFileFormat: z.literal('json'),
   locales: z.array(localeSchema).min(1),
   layers: z.array(layerSchema).min(1),
+  policy: policySchema.optional(),
 })
 
 export type I18nKitArtifact = z.infer<typeof artifactSchema>
@@ -140,6 +149,7 @@ export async function artifactToConfig(
   discoveryRoot: string,
   projectConfig: ProjectConfig | null,
 ): Promise<I18nConfig> {
+  const merged = mergePolicy(artifact.policy, projectConfig)
   const localeDirs: LocaleDir[] = []
   const claimed = new Map<string, { layer: string, layerRootDir: string }>()
   const usedLayerNames = new Set<string>()
@@ -183,10 +193,35 @@ export async function artifactToConfig(
     rootDir: appDir,
     defaultLocale: artifact.defaultLocale,
     fallbackLocale: normalizeFallbackLocale(artifact.fallbackLocale, artifact.defaultLocale),
-    locales: applyLocaleOverride(locales, projectConfig?.locales),
+    locales: applyLocaleOverride(locales, merged?.locales),
     localeDirs,
     layerRootDirs,
-    projectConfig: projectConfig ?? undefined,
+    projectConfig: merged,
     apps: [app],
   }
+}
+
+/**
+ * Fold the policy declared in nuxt.config.ts into the policy read from
+ * .i18n-mcp.json.
+ *
+ * The file wins on a collision, which should never happen: the module fails the
+ * build when a key is declared in both. This is the belt to that braces — an
+ * artifact generated before the check existed, or by a newer module, cannot
+ * quietly override a value someone can see in their repository.
+ */
+function mergePolicy(
+  policy: Record<string, unknown> | undefined,
+  projectConfig: ProjectConfig | null,
+): ProjectConfig | undefined {
+  if (!policy || Object.keys(policy).length === 0) return projectConfig ?? undefined
+
+  const declared = Object.keys(policy).filter(key => (projectConfig as Record<string, unknown> | null)?.[key] !== undefined)
+  if (declared.length > 0) {
+    log.warn(
+      `Ignoring ${declared.join(', ')} from the Nuxt artifact: also declared in .i18n-mcp.json, which wins.`,
+    )
+  }
+
+  return { ...policy, ...projectConfig } as ProjectConfig
 }

--- a/packages/cli/tests/adapters/merge-apps.test.ts
+++ b/packages/cli/tests/adapters/merge-apps.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { AppMerger } from '../../src/adapters/nuxt/merge-apps.js'
+import type { I18nConfig } from '../../src/config/types.js'
+
+/**
+ * Policy declared in an app's nuxt.config arrives on that app's config, so the
+ * merge has to carry it across. It did not at first: every app's policy was
+ * folded in and then thrown away when the merged config took its projectConfig
+ * from the file alone, and a locale marked protected in nuxt.config was
+ * translated anyway.
+ */
+
+function appConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+  return {
+    rootDir: '/repo/app-admin',
+    defaultLocale: 'de',
+    fallbackLocale: { default: ['de'] },
+    locales: [{ code: 'de', language: 'de-DE', file: 'de.json' }],
+    localeDirs: [{ path: '/repo/app-admin/i18n/locales', layer: 'app-admin', layerRootDir: '/repo/app-admin' }],
+    layerRootDirs: ['/repo/app-admin'],
+    apps: [{ name: 'app-admin', rootDir: '/repo/app-admin', layers: ['app-admin'] }],
+    ...overrides,
+  }
+}
+
+describe('merging apps', () => {
+  it('carries policy an app contributed into the merged config', async () => {
+    const merger = new AppMerger()
+    await merger.add(appConfig({ projectConfig: { protectedLocales: ['de-formal'] } }), '/repo')
+
+    const config = merger.toConfig('/repo', undefined, merger.locales)
+
+    expect(config.projectConfig?.protectedLocales).toEqual(['de-formal'])
+  })
+
+  it('lets .i18n-mcp.json override what an app contributed', async () => {
+    const merger = new AppMerger()
+    await merger.add(appConfig({ projectConfig: { context: 'from the artifact' } }), '/repo')
+
+    const config = merger.toConfig('/repo', { context: 'from the file' }, merger.locales)
+
+    expect(config.projectConfig?.context).toBe('from the file')
+  })
+
+  it('takes the first app to declare a key when apps disagree', async () => {
+    const merger = new AppMerger()
+    await merger.add(appConfig({ projectConfig: { context: 'from app-admin' } }), '/repo')
+    await merger.add(appConfig({
+      rootDir: '/repo/app-shop',
+      localeDirs: [{ path: '/repo/app-shop/i18n/locales', layer: 'app-shop', layerRootDir: '/repo/app-shop' }],
+      layerRootDirs: ['/repo/app-shop'],
+      apps: [{ name: 'app-shop', rootDir: '/repo/app-shop', layers: ['app-shop'] }],
+      projectConfig: { context: 'from app-shop' },
+    }), '/repo')
+
+    const config = merger.toConfig('/repo', undefined, merger.locales)
+
+    expect(config.projectConfig?.context).toBe('from app-admin')
+  })
+
+  it('leaves projectConfig untouched when no app contributed any', async () => {
+    const merger = new AppMerger()
+    await merger.add(appConfig(), '/repo')
+
+    expect(merger.toConfig('/repo', undefined, merger.locales).projectConfig).toBeUndefined()
+    expect(merger.toConfig('/repo', { context: 'x' }, merger.locales).projectConfig).toEqual({ context: 'x' })
+  })
+
+  it('deduplicates locales by code across apps', async () => {
+    const merger = new AppMerger()
+    await merger.add(appConfig(), '/repo')
+    await merger.add(appConfig({
+      locales: [
+        { code: 'de', language: 'de-DE', file: 'de.json' },
+        { code: 'en', language: 'en-GB', file: 'en.json' },
+      ],
+    }), '/repo')
+
+    expect(merger.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
+})

--- a/packages/cli/tests/config/artifact.test.ts
+++ b/packages/cli/tests/config/artifact.test.ts
@@ -215,3 +215,43 @@ describe('converting an artifact to a config', () => {
     expect(config.fallbackLocale).toEqual(expected)
   })
 })
+
+describe('authoring policy carried by the artifact', () => {
+  const root = '/repo'
+
+  it('reaches the resolved config, so nuxt.config can declare it', async () => {
+    const artifact = validArtifact({ policy: { glossary: { anny: 'never translate' } } })
+
+    const config = await artifactToConfig(artifact, dir, root, null)
+
+    expect(config.projectConfig?.glossary).toEqual({ anny: 'never translate' })
+  })
+
+  it('merges with .i18n-mcp.json rather than replacing it', async () => {
+    const artifact = validArtifact({ policy: { glossary: { anny: 'never translate' } } })
+
+    const config = await artifactToConfig(artifact, dir, root, { context: 'a booking platform' })
+
+    expect(config.projectConfig).toEqual({
+      glossary: { anny: 'never translate' },
+      context: 'a booking platform',
+    })
+  })
+
+  // The module fails the build on a key declared twice, so this should never
+  // happen. If it does — an older artifact, a newer module — the file wins,
+  // because it is the source someone can read without building.
+  it('lets the file win a collision it should never have', async () => {
+    const artifact = validArtifact({ policy: { context: 'from the artifact' } })
+
+    const config = await artifactToConfig(artifact, dir, root, { context: 'from the file' })
+
+    expect(config.projectConfig?.context).toBe('from the file')
+  })
+
+  it('leaves the config alone when no policy was declared', async () => {
+    const config = await artifactToConfig(validArtifact(), dir, root, { context: 'x' })
+
+    expect(config.projectConfig).toEqual({ context: 'x' })
+  })
+})

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -50,9 +50,52 @@ A ref that resolves by language tag or file name rather than by code is a warnin
 it works today, but a locale added later with the same tag would make it ambiguous
 without anyone touching the line that wrote it.
 
-## Options
+## Configuring the kit from `nuxt.config.ts`
 
-Configured under the `i18nKit` key.
+Everything Nuxt *cannot* derive — your glossary, tone notes, protected locales —
+can be declared under `i18nKit`, typed and autocompleted, next to the i18n config
+it talks about:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n', '@the-i18n-kit/nuxt'],
+
+  i18nKit: {
+    context: 'A B2B booking platform.',
+    glossary: { anny: 'Brand name. NEVER translate.' },
+    localeNotes: { 'de-formal': 'Formal German (Sie).' },
+    protectedLocales: ['de-formal'],
+  },
+})
+```
+
+The module publishes it in the artifact and the CLI reads it, so `.i18n-mcp.json`
+becomes optional for Nuxt projects. Declaring the same key in both places is an
+error rather than a merge — silent precedence between two sources is the drift
+this module exists to end.
+
+Accepted keys: `context`, `glossary`, `translationPrompt`, `localeNotes`,
+`examples`, `layerRules`, `protectedLocales`, `orphanScan`, `reportOutput`,
+`localeFileFormat`, `providerBaseUrl`.
+
+> **Why not under `i18n`?** `@nuxtjs/i18n` types that key through a type alias
+> rather than an interface, so no other module can add to it —
+> [nuxt-modules/i18n#4138](https://github.com/nuxt-modules/i18n/issues/4138).
+> Unknown keys survive at runtime, but they do not type-check. If that is ever
+> fixed, reading them from `i18n` too is additive.
+
+### One thing to know about `protectedLocales`
+
+The CLI reads policy from the generated artifact, so policy declared **only** in
+`nuxt.config.ts` does not apply until something has built. For most keys that
+costs a little context. For `protectedLocales` and `orphanScan` — the ones that
+*suppress* work — it means an unbuilt checkout would translate locales you marked
+protected. The module warns when you declare either there and nowhere else.
+
+If that matters for your pipeline, keep those two in `.i18n-mcp.json`, which the
+CLI reads directly with no build required.
+
+## Module options
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/packages/nuxt/src/artifact.ts
+++ b/packages/nuxt/src/artifact.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
+import type { I18nKitPolicy } from './policy'
+
 /** One locale, addressable by any of the three ref forms the kit accepts. */
 export interface ArtifactLocale {
   code: string
@@ -47,6 +49,12 @@ export interface I18nKitArtifact {
   locales: ArtifactLocale[]
   /** Ordered as Nuxt resolved them: the app's own layer first, then what it extends. */
   layers: ArtifactLayer[]
+  /**
+   * Authoring policy declared in `nuxt.config.ts` under `i18nKit`. Absent when
+   * none was declared, so the CLI can tell "nothing declared here" from
+   * "declared as empty".
+   */
+  policy?: I18nKitPolicy
 }
 
 interface NuxtLayerLike {
@@ -61,6 +69,7 @@ export interface ArtifactInput {
   i18n: Record<string, unknown>
   layers: NuxtLayerLike[]
   generator: string
+  policy?: I18nKitPolicy
 }
 
 export async function buildArtifact(input: ArtifactInput): Promise<I18nKitArtifact> {
@@ -73,6 +82,7 @@ export async function buildArtifact(input: ArtifactInput): Promise<I18nKitArtifa
     localeFileFormat: 'json',
     locales: readLocales(input.i18n),
     layers: await readLayers(input.layers, input.i18n),
+    ...(input.policy && Object.keys(input.policy).length > 0 ? { policy: input.policy } : {}),
   }
 }
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -6,8 +6,10 @@ import type { NuxtModule } from '@nuxt/schema'
 
 import { version } from '../package.json'
 import { buildArtifact } from './artifact'
-import { checkOwnedKeys, checkProtectedLocales } from './validate'
+import { checkOwnedKeys, checkPolicyConflicts, checkProtectedLocales } from './validate'
 import type { Diagnostic } from './validate'
+import { readPolicy } from './policy'
+import type { I18nKitPolicy } from './policy'
 
 const CONFIG_FILENAME = '.i18n-mcp.json'
 
@@ -23,7 +25,7 @@ const CONFIG_FILENAME = '.i18n-mcp.json'
  */
 const ARTIFACT_FILENAME = 'i18n-kit.json'
 
-export interface ModuleOptions {
+export interface ModuleOptions extends I18nKitPolicy {
   /**
    * Set to false to skip artifact generation entirely. The CLI then falls back
    * to adapter detection, exactly as it behaves without the module installed.
@@ -72,17 +74,27 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
         return
       }
 
+      const policy = readPolicy(options as Record<string, unknown>)
+      const projectConfig = await readProjectConfig(nuxt.options.rootDir, logger)
+
       const artifact = await buildArtifact({
         appDir: nuxt.options.rootDir,
         i18n,
         layers: nuxt.options._layers as unknown as Array<{ config: { rootDir: string, i18n?: Record<string, unknown> } }>,
         generator: `@the-i18n-kit/nuxt@${version}`,
+        policy,
       })
 
-      const projectConfig = await readProjectConfig(nuxt.options.rootDir, logger)
+      // protectedLocales may come from either source; whichever declared it is
+      // checked against the locale table Nuxt actually resolved.
+      const protectedLocales = policy.protectedLocales
+        ?? (projectConfig?.protectedLocales as string[] | undefined)
+
       const diagnostics = [
         ...checkOwnedKeys(projectConfig),
-        ...checkProtectedLocales(projectConfig?.protectedLocales as string[] | undefined, artifact.locales),
+        ...checkPolicyConflicts(policy, projectConfig),
+        ...checkProtectedLocales(protectedLocales, artifact.locales),
+        ...warnUnreadablePolicy(policy, projectConfig),
       ]
 
       report(diagnostics, logger, options.failOnInvalidConfig ?? true)
@@ -138,6 +150,30 @@ function report(diagnostics: Diagnostic[], logger: LoggerLike, failOnInvalidConf
       + 'Set i18nKit.failOnInvalidConfig to false to report without failing.',
     )
   }
+}
+
+/**
+ * Policy declared only in `nuxt.config.ts` is invisible to the CLI until a build
+ * has produced an artifact. For most keys that costs a little context; for the
+ * ones that SUPPRESS work it is dangerous — an unbuilt checkout would translate
+ * locales you marked protected, which is the failure this module exists to
+ * prevent, arriving from the other side.
+ */
+function warnUnreadablePolicy(
+  policy: I18nKitPolicy,
+  projectConfig: Record<string, unknown> | null,
+): Diagnostic[] {
+  const suppressing = (['protectedLocales', 'orphanScan'] as const)
+    .filter(key => policy[key] !== undefined && projectConfig?.[key] === undefined)
+
+  if (suppressing.length === 0) return []
+
+  return [{
+    level: 'warn',
+    message: `${suppressing.join(' and ')} declared only in nuxt.config.ts. `
+      + 'The CLI reads it from the generated artifact, so a checkout that has not been built '
+      + `will not apply it. Keep it in ${CONFIG_FILENAME} if that matters — the CLI reads that directly.`,
+  }]
 }
 
 /**

--- a/packages/nuxt/src/policy.ts
+++ b/packages/nuxt/src/policy.ts
@@ -1,0 +1,82 @@
+/**
+ * The half of the kit's config Nuxt cannot derive: what you tell it about your
+ * project, rather than what it can see. Declaring it in `nuxt.config.ts` means
+ * it is typed, autocompleted and checked at build time, next to the i18n config
+ * it talks about.
+ *
+ * `.i18n-mcp.json` accepts all of it too, and still has to for non-Nuxt
+ * projects. Declaring the same key in both is an error rather than a merge —
+ * silent precedence between two sources is what this module exists to end.
+ */
+export interface I18nKitPolicy {
+  /** Free-form project background handed to the translation model. */
+  context?: string
+
+  /** Term dictionary — brand names to leave alone, terms to keep consistent. */
+  glossary?: Record<string, string>
+
+  /** System prompt for translation requests. */
+  translationPrompt?: string
+
+  /** Per-locale guidance: formal register, regional variants, tone. */
+  localeNotes?: Record<string, string>
+
+  /** Few-shot translation examples. */
+  examples?: Array<Record<string, string>>
+
+  /** Rules for deciding which layer a new key belongs in. */
+  layerRules?: Array<{ layer: string, description: string, when: string }>
+
+  /**
+   * Locales excluded from automatic translation. Address them by `code`: a ref
+   * that matches nothing, or matches several locales, fails the build.
+   */
+  protectedLocales?: string[]
+
+  /** Per-layer orphan-scan settings, keyed by layer name. */
+  orphanScan?: Record<string, { ignorePatterns?: string[] }>
+
+  /** Where diagnostic reports are written: true for `.i18n-reports/`, or a path. */
+  reportOutput?: string | boolean
+
+  /** Override the detected locale file format. */
+  localeFileFormat?: 'json' | 'php-array'
+
+  /** Base URL for the LLM provider — gateways, proxies, self-hosted servers. */
+  providerBaseUrl?: string
+}
+
+const POLICY_KEYS = [
+  'context',
+  'glossary',
+  'translationPrompt',
+  'localeNotes',
+  'examples',
+  'layerRules',
+  'protectedLocales',
+  'orphanScan',
+  'reportOutput',
+  'localeFileFormat',
+  'providerBaseUrl',
+] as const
+
+/** Everything declared in `nuxt.config.ts`, with the module's own knobs removed. */
+export function readPolicy(options: Record<string, unknown>): I18nKitPolicy {
+  const policy: Record<string, unknown> = {}
+  for (const key of POLICY_KEYS) {
+    if (options[key] !== undefined) policy[key] = options[key]
+  }
+  return policy as I18nKitPolicy
+}
+
+/**
+ * Keys declared in both places. Neither wins: the caller reports them and
+ * fails, because a reader cannot tell which one took effect.
+ */
+export function conflictingPolicyKeys(
+  policy: I18nKitPolicy,
+  fileConfig: Record<string, unknown> | null,
+): string[] {
+  if (!fileConfig) return []
+  return POLICY_KEYS.filter(key => policy[key] !== undefined && fileConfig[key] !== undefined)
+}

--- a/packages/nuxt/src/validate.ts
+++ b/packages/nuxt/src/validate.ts
@@ -1,4 +1,6 @@
 import type { ArtifactLocale } from './artifact'
+import { conflictingPolicyKeys } from './policy'
+import type { I18nKitPolicy } from './policy'
 
 /**
  * Same precedence the CLI resolves with (#301): an exact `code` outranks a
@@ -98,4 +100,20 @@ export function checkOwnedKeys(projectConfig: Record<string, unknown> | null): D
       message: `.i18n-mcp.json declares "${key}", which this module derives from your Nuxt config. `
         + `Remove it from .i18n-mcp.json — keeping both means two sources of truth and no way to tell which won.`,
     }))
+}
+
+/**
+ * The same key declared in `nuxt.config.ts` and in `.i18n-mcp.json`. Neither
+ * wins: silent precedence between two sources is the drift this module exists
+ * to end, and a reader cannot tell which one took effect.
+ */
+export function checkPolicyConflicts(
+  policy: I18nKitPolicy,
+  projectConfig: Record<string, unknown> | null,
+): Diagnostic[] {
+  return conflictingPolicyKeys(policy, projectConfig).map(key => ({
+    level: 'error' as const,
+    message: `"${key}" is declared both in nuxt.config.ts (i18nKit) and in .i18n-mcp.json. `
+      + 'Keep one — this module will not choose between them.',
+  }))
 }

--- a/packages/nuxt/tests/artifact.test.ts
+++ b/packages/nuxt/tests/artifact.test.ts
@@ -157,3 +157,31 @@ describe('the fallback chain', () => {
     expect(artifact.fallbackLocale).toBeNull()
   })
 })
+
+describe('the authoring policy', () => {
+  it('is published when nuxt.config declared any', async () => {
+    const artifact = await buildArtifact({
+      appDir: dir,
+      i18n: { locales: [{ code: 'de', file: 'de.json' }] },
+      layers: [],
+      generator: 'test',
+      policy: { glossary: { anny: 'never translate' } },
+    })
+
+    expect(artifact.policy).toEqual({ glossary: { anny: 'never translate' } })
+  })
+
+  // Absent rather than empty, so the CLI can tell "nothing declared here" from
+  // "declared as empty" without guessing.
+  it('is absent when nothing was declared', async () => {
+    const artifact = await buildArtifact({
+      appDir: dir,
+      i18n: { locales: [{ code: 'de', file: 'de.json' }] },
+      layers: [],
+      generator: 'test',
+      policy: {},
+    })
+
+    expect('policy' in artifact).toBe(false)
+  })
+})

--- a/packages/nuxt/tests/policy.test.ts
+++ b/packages/nuxt/tests/policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { conflictingPolicyKeys, readPolicy } from '../src/policy'
+import { checkPolicyConflicts } from '../src/validate'
+
+describe('reading policy off the module options', () => {
+  it('takes the authoring keys', () => {
+    const policy = readPolicy({
+      context: 'a booking platform',
+      glossary: { anny: 'never translate' },
+      protectedLocales: ['de-formal'],
+    })
+
+    expect(policy).toEqual({
+      context: 'a booking platform',
+      glossary: { anny: 'never translate' },
+      protectedLocales: ['de-formal'],
+    })
+  })
+
+  // enabled and failOnInvalidConfig configure the module itself; publishing
+  // them as project policy would put module plumbing in front of the agent.
+  it('leaves the module knobs out', () => {
+    expect(readPolicy({ enabled: true, failOnInvalidConfig: false })).toEqual({})
+  })
+
+  it('leaves out keys the module derives, so they cannot be smuggled back in', () => {
+    expect(readPolicy({ locales: ['de'], defaultLocale: 'de', localeDirs: ['x'] })).toEqual({})
+  })
+
+  it('distinguishes an absent key from a falsy one', () => {
+    const policy = readPolicy({ reportOutput: false, context: '' })
+
+    expect(policy).toEqual({ reportOutput: false, context: '' })
+  })
+})
+
+describe('the same key in both places', () => {
+  it('is reported rather than resolved', () => {
+    const conflicts = conflictingPolicyKeys(
+      { glossary: { anny: 'x' }, context: 'from nuxt.config' },
+      { context: 'from the json file', localeNotes: {} },
+    )
+
+    expect(conflicts).toEqual(['context'])
+  })
+
+  it('produces an error naming the key and both sources', () => {
+    const [diagnostic, ...rest] = checkPolicyConflicts(
+      { protectedLocales: ['de'] },
+      { protectedLocales: ['en'] },
+    )
+
+    expect(rest).toEqual([])
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain('"protectedLocales"')
+    expect(diagnostic?.message).toContain('nuxt.config.ts')
+    expect(diagnostic?.message).toContain('.i18n-mcp.json')
+  })
+
+  it('says nothing when the two sources describe different keys', () => {
+    expect(checkPolicyConflicts({ glossary: {} }, { context: 'x' })).toEqual([])
+  })
+
+  it('says nothing when there is no file at all', () => {
+    expect(checkPolicyConflicts({ glossary: {} }, null)).toEqual([])
+  })
+})


### PR DESCRIPTION
You wanted the kit's config in `nuxt.config.ts`. Here it is:

```ts
export default defineNuxtConfig({
  modules: ['@nuxtjs/i18n', '@the-i18n-kit/nuxt'],

  i18nKit: {
    context: 'A B2B booking platform.',
    glossary: { anny: 'Brand name. NEVER translate.' },
    localeNotes: { 'de-formal': 'Formal German (Sie).' },
    protectedLocales: ['de-formal'],
  },
})
```

Typed, autocompleted, checked by TypeScript, sitting directly under `i18n`. The module publishes it in the artifact and the CLI reads it, so `.i18n-mcp.json` becomes optional for Nuxt projects.

Accepted keys: `context`, `glossary`, `translationPrompt`, `localeNotes`, `examples`, `layerRules`, `protectedLocales`, `orphanScan`, `reportOutput`, `localeFileFormat`, `providerBaseUrl` — everything Nuxt cannot derive. The keys it *can* derive stay module-owned and are rejected here, so they cannot be smuggled back in.

Declaring the same key in both places is an error naming both sources, not a merge. Silent precedence between two sources is the drift this module exists to end.

## Not under the `i18n` key

That was the ask, and it is blocked upstream rather than by choice. `@nuxtjs/i18n` types the key through a type alias:

```ts
interface ModuleOptions extends UserNuxtI18nOptions {}    // augmentable
declare module '@nuxt/schema' {
  interface NuxtConfig { ['i18n']?: Partial<UserNuxtI18nOptions> }   // but this uses the alias
}
```

Unknown keys survive normalisation at runtime — verified — but do not type-check:

```
error TS2353: Object literal may only specify known properties,
and 'glossary' does not exist in type 'Partial<UserNuxtI18nOptions>'.
```

Filed as [nuxt-modules/i18n#4138](https://github.com/nuxt-modules/i18n/issues/4138) with a one-line fix. If it lands, reading the same keys off `i18n` is additive — same code path, no migration.

## One hazard documented rather than solved

The CLI reads policy from the generated artifact, so policy declared **only** in `nuxt.config.ts` does not apply until something has built.

For `context` and `glossary` that costs a little context in a prompt. For `protectedLocales` and `orphanScan` — the two that *suppress* work — an unbuilt checkout would translate a locale you marked protected. That is the `de-DE-formal` failure arriving from the other side, in a feature meant to prevent it.

The module warns when either is declared in `nuxt.config.ts` and nowhere else, and the README says to keep those two in `.i18n-mcp.json` if it matters. **Whether to make that a hard requirement is still open** — the alternative is a marker in a three-line `.i18n-mcp.json` that makes the CLI fail loudly instead of proceeding permissively. I did not want to pick that unilaterally.

## A real bug this found

End-to-end testing caught it: the multi-app merge folded each app's policy in and then **threw it away**, taking `projectConfig` from the file alone. A locale protected in `nuxt.config.ts` was translated anyway — visible only because I checked `translate --dry-run` targets rather than trusting the artifact contents.

Fixed in `AppMerger`, with a regression test at that seam, since the unit tests either side of it both passed while the whole was broken.

## Verification

- 937 CLI tests (+9), 37 module tests (+11), 31 MCP tests
- end to end in the playground: `protectedLocales: ['fr']` in `nuxt.config.ts` → `fr` drops out of the translate target set and is reported as skipped; remove the artifact and it comes back, which is exactly the hazard above
- anny-ui `missing` still byte-identical, so nothing changed for projects that don't use this
- lint, typecheck, `npx fallow audit` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
