### PR TITLE
fix(cli): salvage a translate response that ends mid-object

### DIFF
--- a/packages/cli/src/core/ops-translate.ts
+++ b/packages/cli/src/core/ops-translate.ts
@@ -408,7 +408,83 @@ export function extractJsonFromResponse(responseText: string): Record<string, un
     }
   }
 
+  // Tier 4: the object never closed. Salvage the pairs that did arrive.
+  //
+  // Observed in the wild on a real Gemini response: the complete, correct
+  // translation missing only its closing brace. Discarding the whole response
+  // over two absent characters left keys untranslated across repeated runs,
+  // and each rerun asked the model for them again.
+  if (start !== -1) {
+    const salvaged = salvageTruncatedObject(trimmed.slice(start))
+    if (salvaged) {
+      log.warn(
+        `Translate response ended mid-object — recovered ${Object.keys(salvaged).length} complete pair(s). `
+        + 'Remaining keys are reported as failed and can be retried.',
+      )
+      return salvaged
+    }
+
+    throw new Error(
+      `Response ended mid-object before any pair completed. Preview: ${trimmed.substring(0, 200)}`,
+    )
+  }
+
   throw new Error(`No valid JSON object found in response. Preview: ${trimmed.substring(0, 200)}`)
+}
+
+/**
+ * Close an object that was cut off, keeping the key/value pairs that arrived
+ * whole. Tries the string as-is first — a response missing only its brace is
+ * the common case — then falls back to the last pair that ended cleanly,
+ * dropping whatever was half-written after it.
+ */
+function salvageTruncatedObject(text: string): Record<string, unknown> | null {
+  for (const candidate of [text, text.slice(0, lastCompletePairEnd(text))]) {
+    if (!candidate) continue
+    try {
+      const parsed = JSON.parse(`${candidate}}`) as Record<string, unknown>
+      if (parsed && typeof parsed === 'object' && Object.keys(parsed).length > 0) return parsed
+    }
+    catch {
+      // Try the shorter cut.
+    }
+  }
+
+  return null
+}
+
+/**
+ * Index of the last top-level comma — the boundary after the last pair that
+ * completed. Commas inside strings do not count, which is why this scans
+ * rather than searching: a translated value may contain one.
+ */
+function lastCompletePairEnd(text: string): number {
+  let depth = 0
+  let inString = false
+  let escape = false
+  let lastComma = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (ch === '\\' && inString) {
+      escape = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+    if (ch === '{' || ch === '[') depth++
+    else if (ch === '}' || ch === ']') depth--
+    else if (ch === ',' && depth === 1) lastComma = i
+  }
+
+  return lastComma
 }
 
 function buildFallbackContext(

--- a/packages/cli/tests/tools/translate-and-prompts.test.ts
+++ b/packages/cli/tests/tools/translate-and-prompts.test.ts
@@ -305,6 +305,40 @@ describe('buildTranslationUserMessage', () => {
 })
 
 describe('extractJsonFromResponse', () => {
+  /**
+   * Captured from a real Gemini response on anny-ui !2070: the correct
+   * translation, complete, missing only its closing brace. The whole response
+   * was thrown away and the key reported as failed — five keys never got
+   * translated across repeated runs because of two absent characters.
+   */
+  const truncatedResponse = '{\n  "pages.organizations.locations.chooseYourLocation": "Roghnaigh do shu\u00edomh"'
+
+  it('recovers a response that ends mid-object', () => {
+    const result = extractJsonFromResponse(truncatedResponse)
+
+    expect(result).toEqual({
+      'pages.organizations.locations.chooseYourLocation': 'Roghnaigh do shuíomh',
+    })
+  })
+
+  it('keeps the pairs that did arrive when the last one is cut mid-value', () => {
+    const result = extractJsonFromResponse('{"a": "first", "b": "second", "c": "thir')
+
+    expect(result).toEqual({ a: 'first', b: 'second' })
+  })
+
+  it('keeps the pairs that did arrive when the cut lands mid-key', () => {
+    const result = extractJsonFromResponse('{"a": "first", "b": "second", "c')
+
+    expect(result).toEqual({ a: 'first', b: 'second' })
+  })
+
+  // Nothing usable arrived: still an error, because inventing an empty object
+  // would report every key as silently omitted rather than as failed.
+  it('still throws when the object was cut before any pair completed', () => {
+    expect(() => extractJsonFromResponse('{"a": "fir')).toThrow(/ended mid-object/)
+  })
+
   it('parses clean JSON directly', () => {
     const result = extractJsonFromResponse('{"key":"value"}')
     expect(result).toEqual({ key: 'value' })


### PR DESCRIPTION
Refs #325, which records the investigation.

A provider response missing **only its closing brace** was discarded entirely and every key in the batch reported as failed. On anny-ui five keys went untranslated across repeated runs because of two absent characters — and each rerun asked the model for them again.

The response, captured verbatim from a failing job:

```
{
  "pages.organizations.locations.chooseYourLocation": "Roghnaigh do shuíomh"
```

Complete, correct, unclosed. `extractJsonFromResponse` requires balanced braces, so tier 3 fell through to `No valid JSON object found in response` — a message that describes neither what arrived nor what to do about it.

## What changes

A fourth tier salvages what arrived:

- an object that ends mid-stream is closed and parsed, keeping the complete pairs
- a pair cut mid-value or mid-key is dropped, the rest kept — found by scanning for the last top-level comma, since a translated value may contain one
- keys that did not arrive stay reported as failed, so a rerun retries them
- when nothing completed, the error says the response **ended mid-object**

Behaviour for well-formed responses is untouched: tiers 1–3 run first and this only executes where the old code was about to throw.

## The cause is still unknown, deliberately

#325 has the full analysis. In short, it is **not** batch size (recurs at 25, with a single-key response), **not** the model or prompt (43 Irish keys through the real CLI against anny-ui: 0 failures), and **not** the token limit (`finishReason === 'MAX_TOKENS'` is checked *before* parsing and would have skipped it). Remaining suspects are environmental — most likely the `@google/genai` version CI installs.

This makes the symptom survivable whichever it turns out to be, and turns a total batch failure into a partial one that reports honestly.

## Verification

- 4 new regression tests, including the verbatim captured response
- 941 CLI tests pass
- lint and typecheck clean

Developed in a separate worktree because the main checkout was in use by another agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete translation responses by preserving complete key-value pairs when JSON is truncated.
  * Added clearer retry reporting for missing values and a specific error when no usable data can be recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->