### PR TITLE
feat(cli): typed config, and read the framework's own config instead of guessing

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -293,6 +293,8 @@ These files are executed, so a `next.config.js` wrapped in `withNextIntl(...)` o
 A value you declare yourself always wins over both. To pin the reference locale regardless of what any framework config says:
 
 ```ts
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
 export default defineI18nKitConfig({
   defaultLocale: 'en',
   localeDirs: ['src/locales'],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -277,13 +277,26 @@ Prefixes assembled in another scope defeat this even when they are literal — a
 
 Detection is confidence-scored: the highest-scoring adapter wins, and a `.i18n-mcp.json` carrying both `localeDirs` and `defaultLocale` outscores framework inference. Set `"framework": "vue"` (or any adapter name) to force one adapter.
 
-The Vue and React/Next adapters resolve a single locale directory and take the alphabetically first discovered locale as the default. To pin a different reference locale, use `localeDirs` + `defaultLocale`:
+### Read, not guessed
 
-```json
-{
-  "defaultLocale": "en",
-  "localeDirs": ["src/locales"]
-}
+Where a project already declares its locales, the adapter reads that file rather than inferring from directory order:
+
+| Setup | Read from | Gives |
+|---|---|---|
+| next-intl | `src/i18n/routing.ts` — `defineRouting({ ... })` | `locales`, `defaultLocale` |
+| next-translate | `i18n.js` | `locales`, `defaultLocale` |
+| Next.js Pages Router | `next.config.{ts,js,mjs}` — `i18n: { ... }` | `locales`, `defaultLocale` |
+| Vue + `@intlify/unplugin-vue-i18n` | `vite.config.{ts,js}` — the plugin's `include` | locale directories |
+
+These files are executed, so a `next.config.js` wrapped in `withNextIntl(...)` or `withSentryConfig(...)` may fail without the right environment. That is never fatal: the CLI warns and falls back to the directory probing above, exactly as it behaved before it could read them.
+
+A value you declare yourself always wins over both. To pin the reference locale regardless of what any framework config says:
+
+```ts
+export default defineI18nKitConfig({
+  defaultLocale: 'en',
+  localeDirs: ['src/locales'],
+})
 ```
 
 ## Programmatic API
@@ -309,7 +322,23 @@ await translateKey({
 
 ## Project Config
 
-Drop a `.i18n-mcp.json` at your project root for project-specific context:
+Project-specific context goes in `i18n-kit.config.ts` at your project root, where the editor checks it:
+
+```ts
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
+export default defineI18nKitConfig({
+  context: 'B2B SaaS booking platform',
+  glossary: {
+    Booking: "Core concept. Dutch: 'Boeking'.",
+  },
+  protectedLocales: ['en-us', 'de-formal'],
+})
+```
+
+Read directly, with no build step — a `protectedLocales` entry that only takes effect once something has been built is a locale that quietly goes unprotected in a fresh checkout. `.ts`, `.mts`, `.js`, `.mjs` and `.cjs` all work, and the file is looked up from the working directory upwards, the way `eslint` and `tsconfig` resolve theirs.
+
+`.i18n-mcp.json` accepts the same keys and remains supported:
 
 ```json
 {
@@ -327,6 +356,8 @@ Drop a `.i18n-mcp.json` at your project root for project-specific context:
   "protectedLocales": ["en-us", "de-formal"]
 }
 ```
+
+Use one or the other. Both may be present, but declaring the same key in both is an error naming both files rather than a silent precedence rule.
 
 See the [full config reference](https://github.com/fabkho/the-i18n-kit#project-config) for all options. `samplingPreferences` is deprecated and ignored (accepted for backward compatibility) — configure a provider instead.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./config": {
+      "import": "./dist/define-config.js",
+      "types": "./dist/define-config.d.ts"
     }
   },
   "files": [
@@ -46,6 +50,7 @@
   "dependencies": {
     "citty": "^0.2.2",
     "consola": "^3.4.2",
+    "jiti": "^2.7.0",
     "php-array-reader": "^2.1.3",
     "sort-keys": "^6.0.0",
     "tinyglobby": "^0.2.15",

--- a/packages/cli/src/adapters/react/index.ts
+++ b/packages/cli/src/adapters/react/index.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
+import { readNextI18n } from '../../config/framework/next'
 import { applyLocaleOverride } from '../../config/locale-override'
 import { ConfigError } from '../../utils/errors'
 import { loadPackageJson, collectDependencies, hasNuxtConfig, noLocaleDirError, buildSingleDirConfig } from '../shared'
@@ -63,10 +64,16 @@ export class ReactAdapter implements FrameworkAdapter {
       )
     }
 
+    // Declared first, then what the project already tells next-intl or Next
+    // itself, and only then directory order — which is not a statement about
+    // the default locale at all, merely the alphabet (#296).
+    const framework = await readNextI18n(projectDir)
+    const defaultLocale = projectConfig?.defaultLocale ?? framework?.defaultLocale ?? firstLocale.code
+
     return buildSingleDirConfig({
       projectDir,
       localeDir,
-      defaultLocale: firstLocale.code,
+      defaultLocale,
       locales: applyLocaleOverride(locales, projectConfig?.locales),
       projectConfig,
     })

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
@@ -53,21 +53,31 @@ export class VueAdapter implements FrameworkAdapter {
   async resolve(projectDir: string): Promise<I18nConfig> {
     const projectConfig = await loadProjectConfig(projectDir)
 
-    const localeDir = await resolveLocaleDir(projectDir)
-    const discovered = await requireLocales(localeDir)
+    const dirs = await resolveLocaleDirs(projectDir)
+    const discovered = await requireLocales(dirs)
     const locales = applyLocaleOverride(discovered, projectConfig?.locales)
 
     // Declared beats discovered. Falling through to the first locale is
     // alphabetical order dressed up as a decision (#296).
     const defaultLocale = projectConfig?.defaultLocale ?? locales[0]?.code ?? discovered[0].code
 
-    return buildSingleDirConfig({
-      projectDir,
-      localeDir,
+    // One directory keeps the shape it has always had, layer name and all.
+    if (dirs.length === 1) {
+      return buildSingleDirConfig({ projectDir, localeDir: dirs[0]!, defaultLocale, locales, projectConfig })
+    }
+
+    const localeDirs = dirs.map(path => ({ path, layer: layerNameFor(path, dirs), layerRootDir: projectDir }))
+
+    return {
+      rootDir: projectDir,
       defaultLocale,
+      fallbackLocale: { default: [defaultLocale] },
       locales,
-      projectConfig,
-    })
+      localeDirs,
+      layerRootDirs: [projectDir],
+      ...(projectConfig ? { projectConfig } : {}),
+      apps: [{ name: 'default', rootDir: projectDir, layers: localeDirs.map(d => d.layer) }],
+    }
   }
 }
 
@@ -105,21 +115,46 @@ async function computeScore(projectDir: string, deps: Record<string, unknown>): 
  * ahead of what the source looks like it means. `include` *is* where the
  * locale files are, by definition; the candidate list is a guess about where
  * people tend to put them.
+ *
+ * All of `include` is kept, not just the first entry — it is an array because
+ * projects do split their messages across directories, and dropping the rest
+ * would silently hide every key in them.
  */
-async function resolveLocaleDir(projectDir: string): Promise<string> {
+async function resolveLocaleDirs(projectDir: string): Promise<string[]> {
   const fromPlugin = await readVueI18nLocaleDirs(projectDir)
-  const localeDir = fromPlugin?.[0] ?? await findLocaleDir(projectDir)
+  if (fromPlugin?.length) return fromPlugin
+
+  const localeDir = await findLocaleDir(projectDir)
   if (!localeDir) throw noLocaleDirError(projectDir, COMMON_LOCALE_DIRS)
-  return localeDir
+  return [localeDir]
 }
 
-/** The locales in a directory, or an explanation of why there are none. */
-async function requireLocales(localeDir: string): Promise<[LocaleDefinition, ...LocaleDefinition[]]> {
-  const locales = await discoverLocales(localeDir)
+/**
+ * A layer name per directory: its own name, or enough of its path to tell it
+ * apart from a sibling of the same name (`messages` and `admin/messages`).
+ */
+function layerNameFor(path: string, all: string[]): string {
+  const name = basename(path)
+  const ambiguous = all.filter(other => basename(other) === name).length > 1
+  return ambiguous ? `${basename(dirname(path))}/${name}` : name
+}
+
+/** The locales across every directory, or an explanation of why there are none. */
+async function requireLocales(localeDirs: string[]): Promise<[LocaleDefinition, ...LocaleDefinition[]]> {
+  const byCode = new Map<string, LocaleDefinition>()
+  for (const dir of localeDirs) {
+    for (const locale of await discoverLocales(dir)) {
+      // First directory to define a locale owns its file name; the rest add
+      // their keys to it, the way a layer does.
+      if (!byCode.has(locale.code)) byCode.set(locale.code, locale)
+    }
+  }
+
+  const locales = [...byCode.values()]
   const [first] = locales
   if (first === undefined) {
     throw new ConfigError(
-      `No JSON locale files found in ${localeDir}. `
+      `No JSON locale files found in ${localeDirs.join(', ')}. `
       + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
     )
   }

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
+import { readVueI18nLocaleDirs } from '../../config/framework/vue'
 import { applyLocaleOverride } from '../../config/locale-override'
 import { ConfigError } from '../../utils/errors'
 import { loadPackageJson, collectDependencies, hasNuxtConfig, noLocaleDirError, buildSingleDirConfig } from '../shared'
@@ -52,22 +53,13 @@ export class VueAdapter implements FrameworkAdapter {
   async resolve(projectDir: string): Promise<I18nConfig> {
     const projectConfig = await loadProjectConfig(projectDir)
 
-    const localeDir = await findLocaleDir(projectDir)
-    if (!localeDir) {
-      throw noLocaleDirError(projectDir, COMMON_LOCALE_DIRS)
-    }
+    const localeDir = await resolveLocaleDir(projectDir)
+    const discovered = await requireLocales(localeDir)
+    const locales = applyLocaleOverride(discovered, projectConfig?.locales)
 
-    const rawLocales = await discoverLocales(localeDir)
-    const [firstRawLocale] = rawLocales
-    if (firstRawLocale === undefined) {
-      throw new ConfigError(
-        `No JSON locale files found in ${localeDir}. `
-        + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
-      )
-    }
-
-    const locales = applyLocaleOverride(rawLocales, projectConfig?.locales)
-    const defaultLocale = extractDefaultLocale(projectDir) ?? locales[0]?.code ?? firstRawLocale.code
+    // Declared beats discovered. Falling through to the first locale is
+    // alphabetical order dressed up as a decision (#296).
+    const defaultLocale = projectConfig?.defaultLocale ?? locales[0]?.code ?? discovered[0].code
 
     return buildSingleDirConfig({
       projectDir,
@@ -108,6 +100,38 @@ async function computeScore(projectDir: string, deps: Record<string, unknown>): 
 
 // ─── Resolution helpers ─────────────────────────────────────────
 
+/**
+ * Where this project keeps its locale files: what the build already knows,
+ * ahead of what the source looks like it means. `include` *is* where the
+ * locale files are, by definition; the candidate list is a guess about where
+ * people tend to put them.
+ */
+async function resolveLocaleDir(projectDir: string): Promise<string> {
+  const fromPlugin = await readVueI18nLocaleDirs(projectDir)
+  const localeDir = fromPlugin?.[0] ?? await findLocaleDir(projectDir)
+  if (!localeDir) throw noLocaleDirError(projectDir, COMMON_LOCALE_DIRS)
+  return localeDir
+}
+
+/** The locales in a directory, or an explanation of why there are none. */
+async function requireLocales(localeDir: string): Promise<[LocaleDefinition, ...LocaleDefinition[]]> {
+  const locales = await discoverLocales(localeDir)
+  const [first] = locales
+  if (first === undefined) {
+    throw new ConfigError(
+      `No JSON locale files found in ${localeDir}. `
+      + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
+    )
+  }
+  return [first, ...locales.slice(1)]
+}
+
+/**
+ * Detection-safe: pattern-matching only. `detect()` runs this for every
+ * project the CLI is pointed at, including ones this adapter will lose, so it
+ * must not execute anybody's config — that is `resolve()`'s business, once an
+ * adapter has been chosen.
+ */
 async function findLocaleDir(projectDir: string): Promise<string | null> {
   const fromConfig = await tryExtractFromConfig(projectDir)
   if (fromConfig) return fromConfig
@@ -174,11 +198,4 @@ async function discoverLocales(localeDir: string): Promise<LocaleDefinition[]> {
       language: f.replace(/\.json$/, ''),
       file: f,
     }))
-}
-
-function extractDefaultLocale(_projectDir: string): string | null {
-  // Stub: default-locale extraction from Vue project config is not
-  // implemented — callers fall back to the first discovered locale, which is
-  // why `defaultLocale` cannot be pinned for this adapter (#296).
-  return null
 }

--- a/packages/cli/src/config/framework/execute.ts
+++ b/packages/cli/src/config/framework/execute.ts
@@ -15,6 +15,7 @@
  */
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { toErrorMessage } from '../../utils/errors.js'
 import { log } from '../../utils/logger.js'
 
@@ -55,6 +56,27 @@ export async function executeConfig(
 export function firstExisting(projectDir: string, candidates: readonly string[]): string | null {
   for (const candidate of candidates) {
     const path = resolve(projectDir, candidate)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+/**
+ * Locate one of the stub modules in `./stubs/`, as a path jiti can be aliased
+ * to. Returns null when it cannot be found, which leaves normal resolution in
+ * place.
+ *
+ * A stub has to survive the build as a *file* — it is referred to by path and
+ * never imported, so it is declared as its own tsdown entry rather than
+ * bundled. That gives it two possible homes, and this resolves against the
+ * location of this module, which sits beside `stubs/` in the source tree and
+ * at the root of `dist/` in the bundle.
+ */
+export function resolveStub(name: string): string | null {
+  const candidates = [`./stubs/${name}.ts`, `./config/framework/stubs/${name}.js`]
+
+  for (const candidate of candidates) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url))
     if (existsSync(path)) return path
   }
   return null

--- a/packages/cli/src/config/framework/execute.ts
+++ b/packages/cli/src/config/framework/execute.ts
@@ -14,7 +14,7 @@
  * already follows for the Nuxt artifact, for the same reason.
  */
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { resolve } from 'node:path'
 import { toErrorMessage } from '../../utils/errors.js'
 import { log } from '../../utils/logger.js'
 
@@ -44,10 +44,17 @@ export async function executeConfig(
   }
 }
 
-/** The first of `candidates` that exists under `projectDir`, as a full path. */
+/**
+ * The first of `candidates` that exists under `projectDir`, as an absolute
+ * path.
+ *
+ * Absolute, not merely joined: `--projectDir playground/react` is a relative
+ * path, and a relative path handed to jiti is read as a bare module specifier
+ * and resolved against `node_modules`, where it is never found.
+ */
 export function firstExisting(projectDir: string, candidates: readonly string[]): string | null {
   for (const candidate of candidates) {
-    const path = join(projectDir, candidate)
+    const path = resolve(projectDir, candidate)
     if (existsSync(path)) return path
   }
   return null

--- a/packages/cli/src/config/framework/execute.ts
+++ b/packages/cli/src/config/framework/execute.ts
@@ -1,0 +1,78 @@
+/**
+ * Executing config files that belong to *other* tools.
+ *
+ * Where a project already declares its locales authoritatively — next-intl's
+ * `defineRouting`, next-translate's `i18n.js`, `next.config`'s `i18n` block —
+ * reading it beats guessing from directory order. The only reason the adapters
+ * ever guessed is that the CLI could not run TypeScript.
+ *
+ * The rule for everything in here: **never load-bearing**. A real
+ * `next.config.js` is wrapped in `withNextIntl(...)` or `withSentryConfig(...)`
+ * and throws without the right env or plugins installed. A file we cannot run
+ * means falling back to the heuristics that were the only behaviour until now,
+ * with a warning — never a failed command. This is the rule `config/artifact.ts`
+ * already follows for the Nuxt artifact, for the same reason.
+ */
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { toErrorMessage } from '../../utils/errors.js'
+import { log } from '../../utils/logger.js'
+
+/**
+ * Run one config file and hand back its exports, or null if anything at all
+ * went wrong. Callers treat null as "no information", not as an error.
+ */
+export async function executeConfig(
+  path: string,
+  options: { alias?: Record<string, string> } = {},
+): Promise<Record<string, unknown> | null> {
+  try {
+    const { createJiti } = await import('jiti')
+    const jiti = createJiti(import.meta.url, {
+      interopDefault: false,
+      ...(options.alias ? { alias: options.alias } : {}),
+    })
+    const module = await jiti.import(path)
+    return module && typeof module === 'object' ? module as Record<string, unknown> : null
+  }
+  catch (error) {
+    log.warn(
+      `Could not read ${path}: ${toErrorMessage(error)}. `
+      + 'Falling back to directory detection — declare the value in i18n-kit.config.ts to be sure of it.',
+    )
+    return null
+  }
+}
+
+/** The first of `candidates` that exists under `projectDir`, as a full path. */
+export function firstExisting(projectDir: string, candidates: readonly string[]): string | null {
+  for (const candidate of candidates) {
+    const path = join(projectDir, candidate)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+/** A module's default export, or the module itself for a CJS `module.exports`. */
+export function defaultExport(module: Record<string, unknown>): unknown {
+  return 'default' in module ? module.default : module
+}
+
+/** Narrow an unknown to a plain object, the shape every reader here digs into. */
+export function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+/** A non-empty string, or undefined — config values are not to be trusted. */
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/** An array of non-empty strings, or undefined. */
+export function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const strings = value.filter((v): v is string => typeof v === 'string' && v.length > 0)
+  return strings.length > 0 ? strings : undefined
+}

--- a/packages/cli/src/config/framework/next.ts
+++ b/packages/cli/src/config/framework/next.ts
@@ -6,7 +6,9 @@
  * that the default locale, so `{de,en,fr}.json` made German the source of
  * truth for an English project (#296).
  */
-import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting } from './execute.js'
+import { createRequire } from 'node:module'
+import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting, resolveStub } from './execute.js'
+import { toErrorMessage } from '../../utils/errors.js'
 import { log } from '../../utils/logger.js'
 
 /** next-intl: `defineRouting({ locales, defaultLocale })`, usually re-exported as `routing`. */
@@ -62,15 +64,15 @@ export async function readNextI18n(projectDir: string): Promise<NextI18n | null>
 
 /**
  * next-intl. `defineRouting` returns the object it was handed, so the exported
- * routing object carries `locales` and `defaultLocale` without the plugin
- * having to be stubbed — the package is installed in any project that has one
- * of these files.
+ * routing object carries `locales` and `defaultLocale` verbatim — which is why
+ * substituting it (only when it is missing; see `routingAlias`) cannot change
+ * the answer.
  */
 async function readRouting(projectDir: string): Promise<NextI18n | null> {
   const path = firstExisting(projectDir, ROUTING_FILES)
   if (!path) return null
 
-  const module = await executeConfig(path)
+  const module = await executeConfig(path, { alias: routingAlias(path) })
   if (!module) return null
 
   // `export const routing = defineRouting(...)` is what the docs show, but a
@@ -87,6 +89,59 @@ async function readRouting(projectDir: string): Promise<NextI18n | null> {
   }
 
   return null
+}
+
+/**
+ * Substitute `defineRouting` only when the real one cannot be found from the
+ * routing file's own location.
+ *
+ * The real package always wins where it is installed — it is the authority on
+ * its own API, and a substitution that silently shadowed it would be the kind
+ * of quiet divergence this whole line of work is about. The stub is purely a
+ * rescue for the case where the file exists and its dependencies do not, which
+ * is a fresh clone, a CI job that skipped install, or a fixture. Reading a
+ * declaration should not require a `node_modules` to be present.
+ */
+function routingAlias(routingPath: string): Record<string, string> | undefined {
+  if (resolvableFrom('next-intl/routing', routingPath)) return undefined
+
+  const path = resolveStub('next-intl-routing')
+  if (!path) return undefined
+
+  log.debug(`next-intl is not installed for ${routingPath} — reading it with a stubbed defineRouting`)
+  return { 'next-intl/routing': path }
+}
+
+/**
+ * `next.config.js` may export `(phase, { defaultConfig }) => config`, sync or
+ * async, which Next.js calls for you. An uncalled function is not a config, so
+ * without this the `i18n` block of every project using that form is invisible.
+ *
+ * A function that throws yields nothing, like any other unreadable config.
+ */
+async function resolveConfigExport(exported: unknown, path: string): Promise<unknown> {
+  if (typeof exported !== 'function') return exported
+
+  try {
+    return await (exported as (phase: string, context: unknown) => unknown)(
+      'phase-production-build',
+      { defaultConfig: {} },
+    )
+  }
+  catch (error) {
+    log.warn(`Could not evaluate the config function in ${path}: ${toErrorMessage(error)}`)
+    return undefined
+  }
+}
+
+function resolvableFrom(specifier: string, fromFile: string): boolean {
+  try {
+    createRequire(fromFile).resolve(specifier)
+    return true
+  }
+  catch {
+    return false
+  }
 }
 
 /** next-translate's `i18n.js`, a plain object of `{ locales, defaultLocale, pages }`. */
@@ -119,7 +174,7 @@ async function readNextConfig(projectDir: string): Promise<NextI18n | null> {
   const module = await executeConfig(path)
   if (!module) return null
 
-  const config = asObject(defaultExport(module))
+  const config = asObject(await resolveConfigExport(defaultExport(module), path))
   const i18n = config && asObject(config.i18n)
   if (!i18n) return null
 

--- a/packages/cli/src/config/framework/next.ts
+++ b/packages/cli/src/config/framework/next.ts
@@ -1,0 +1,131 @@
+/**
+ * Reading what a Next.js project already says about its locales.
+ *
+ * Three setups declare it authoritatively, and the adapter used to read none
+ * of them — it took the alphabetically first file in `messages/` and called
+ * that the default locale, so `{de,en,fr}.json` made German the source of
+ * truth for an English project (#296).
+ */
+import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting } from './execute.js'
+import { log } from '../../utils/logger.js'
+
+/** next-intl: `defineRouting({ locales, defaultLocale })`, usually re-exported as `routing`. */
+const ROUTING_FILES = [
+  'src/i18n/routing.ts',
+  'src/i18n/routing.js',
+  'i18n/routing.ts',
+  'i18n/routing.js',
+]
+
+/** next-translate: a top-level `i18n.js` consumed by `nextTranslate(...)`. */
+const NEXT_TRANSLATE_FILES = [
+  'i18n.js',
+  'i18n.ts',
+  'i18n.mjs',
+]
+
+/** Pages Router: `i18n: { locales, defaultLocale }` in the Next config itself. */
+const NEXT_CONFIG_FILES = [
+  'next.config.ts',
+  'next.config.js',
+  'next.config.mjs',
+]
+
+export interface NextI18n {
+  defaultLocale?: string
+  locales?: string[]
+  /** Which file this came from, for the message that explains the choice. */
+  source: string
+}
+
+/**
+ * The first source that yields something, in order of how specifically it is
+ * about i18n: a routing file exists only to declare locales, whereas
+ * `next.config` is mostly about everything else and the likeliest to throw.
+ *
+ * Returns null when no source could be read — every failure is a warning and a
+ * fallback to directory detection, never an error.
+ */
+export async function readNextI18n(projectDir: string): Promise<NextI18n | null> {
+  const readers = [readRouting, readNextTranslate, readNextConfig]
+
+  for (const reader of readers) {
+    const found = await reader(projectDir)
+    if (found?.defaultLocale || found?.locales) {
+      log.info(`Read i18n from ${found.source}: defaultLocale=${found.defaultLocale ?? '(none)'}`)
+      return found
+    }
+  }
+
+  return null
+}
+
+/**
+ * next-intl. `defineRouting` returns the object it was handed, so the exported
+ * routing object carries `locales` and `defaultLocale` without the plugin
+ * having to be stubbed — the package is installed in any project that has one
+ * of these files.
+ */
+async function readRouting(projectDir: string): Promise<NextI18n | null> {
+  const path = firstExisting(projectDir, ROUTING_FILES)
+  if (!path) return null
+
+  const module = await executeConfig(path)
+  if (!module) return null
+
+  // `export const routing = defineRouting(...)` is what the docs show, but a
+  // default export is just as valid, and both may be present.
+  for (const candidate of [module.routing, defaultExport(module)]) {
+    const routing = asObject(candidate)
+    if (!routing) continue
+
+    const defaultLocale = asString(routing.defaultLocale)
+    const locales = asStringArray(routing.locales)
+    if (defaultLocale || locales) {
+      return { ...(defaultLocale ? { defaultLocale } : {}), ...(locales ? { locales } : {}), source: path }
+    }
+  }
+
+  return null
+}
+
+/** next-translate's `i18n.js`, a plain object of `{ locales, defaultLocale, pages }`. */
+async function readNextTranslate(projectDir: string): Promise<NextI18n | null> {
+  const path = firstExisting(projectDir, NEXT_TRANSLATE_FILES)
+  if (!path) return null
+
+  const module = await executeConfig(path)
+  if (!module) return null
+
+  const config = asObject(defaultExport(module))
+  if (!config) return null
+
+  const defaultLocale = asString(config.defaultLocale)
+  const locales = asStringArray(config.locales)
+  if (!defaultLocale && !locales) return null
+
+  return { ...(defaultLocale ? { defaultLocale } : {}), ...(locales ? { locales } : {}), source: path }
+}
+
+/**
+ * The Pages Router's `i18n` block. Read last because this is the file most
+ * likely to throw: in a real project it is wrapped in `withNextIntl(...)`,
+ * `withSentryConfig(...)` and whatever else, and needs their env to run.
+ */
+async function readNextConfig(projectDir: string): Promise<NextI18n | null> {
+  const path = firstExisting(projectDir, NEXT_CONFIG_FILES)
+  if (!path) return null
+
+  const module = await executeConfig(path)
+  if (!module) return null
+
+  const config = asObject(defaultExport(module))
+  const i18n = config && asObject(config.i18n)
+  if (!i18n) return null
+
+  const defaultLocale = asString(i18n.defaultLocale)
+  const locales = asStringArray(i18n.locales)
+  if (!defaultLocale && !locales) return null
+
+  return { ...(defaultLocale ? { defaultLocale } : {}), ...(locales ? { locales } : {}), source: path }
+}

--- a/packages/cli/src/config/framework/stubs/next-intl-routing.ts
+++ b/packages/cli/src/config/framework/stubs/next-intl-routing.ts
@@ -1,0 +1,19 @@
+/**
+ * A stand-in for `next-intl/routing`, used only when the real package cannot
+ * be resolved from the config file being read.
+ *
+ * `defineRouting` returns the object it is given, so a routing file's
+ * `locales` and `defaultLocale` survive this substitution untouched — which is
+ * the only reason it is safe. It exists so that reading a routing file does
+ * not require the project's dependencies to be installed: a fresh clone, a CI
+ * lint job, or a playground fixture has a `routing.ts` long before it has a
+ * `node_modules`.
+ *
+ * The real package is preferred whenever it resolves. See `resolvableFrom` in
+ * ../next.ts.
+ */
+export function defineRouting<T>(config: T): T {
+  return config
+}
+
+export default defineRouting

--- a/packages/cli/src/config/framework/stubs/unplugin-vue-i18n.ts
+++ b/packages/cli/src/config/framework/stubs/unplugin-vue-i18n.ts
@@ -1,0 +1,24 @@
+/**
+ * A stand-in for `@intlify/unplugin-vue-i18n` used only while reading a
+ * project's `vite.config`.
+ *
+ * The real plugin keeps its `include` option in a closure — the object it
+ * returns is all Vite hooks, no options — so executing the config teaches us
+ * nothing unless the call itself is observed. This records the options and
+ * hands back an inert plugin; the resolved Vite config is thrown away either
+ * way, we are only here for that one value.
+ *
+ * Recorded on `globalThis` because jiti compiles this file into its own module
+ * registry: a module-level variable here is not the same variable the CLI
+ * would read. A registered symbol crosses that boundary.
+ */
+export const RECORDED = Symbol.for('the-i18n-kit:unplugin-vue-i18n-options')
+
+function record(options?: unknown) {
+  ;(globalThis as Record<symbol, unknown>)[RECORDED] = options
+  return { name: 'the-i18n-kit:unplugin-vue-i18n-stub' }
+}
+
+export default record
+export const vueI18n = record
+export const unpluginVueI18n = record

--- a/packages/cli/src/config/framework/vue.ts
+++ b/packages/cli/src/config/framework/vue.ts
@@ -8,8 +8,7 @@
  */
 import { existsSync, statSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { asObject, executeConfig, firstExisting } from './execute.js'
+import { asObject, executeConfig, firstExisting, resolveStub } from './execute.js'
 import { log } from '../../utils/logger.js'
 
 /**
@@ -47,6 +46,22 @@ export async function readVueI18nLocaleDirs(projectDir: string): Promise<string[
   const path = firstExisting(projectDir, VITE_CONFIG_FILES)
   if (!path) return null
 
+  // Answers are remembered per config file because the file itself can only be
+  // executed once: Node caches an ES module by URL for the life of the
+  // process, so a second read would import the cache, call no plugin, record
+  // nothing, and quietly report that this project declares no locale
+  // directories. Resolving the same project twice has to give the same answer.
+  const remembered = answers.get(path)
+  if (remembered !== undefined) return remembered
+
+  const dirs = await readInclude(path)
+  answers.set(path, dirs)
+  return dirs
+}
+
+const answers = new Map<string, string[] | null>()
+
+async function readInclude(path: string): Promise<string[] | null> {
   const globalScope = globalThis as Record<symbol, unknown>
   delete globalScope[RECORDED]
 
@@ -101,7 +116,10 @@ function includeToDirs(include: unknown, configDir: string): string[] {
 
 /** Everything before the first glob segment: `src/locales/**\/*.json` → `src/locales`. */
 function globRoot(pattern: string): string | undefined {
-  const segments = pattern.split('/')
+  // `resolve()` in a vite.config produces backslashes on Windows, and a
+  // backslash path split on '/' is one segment containing the wildcard —
+  // which would discard the directory entirely.
+  const segments = pattern.replace(/\\/g, '/').split('/')
   const wildcard = segments.findIndex(s => s.includes('*') || s.includes('?') || s.includes('['))
   const kept = wildcard === -1 ? segments.slice(0, -1) : segments.slice(0, wildcard)
   return kept.length > 0 ? kept.join('/') : undefined
@@ -123,16 +141,7 @@ function isDirectory(path: string): boolean {
  * gives up rather than executing a config for no reason.
  */
 function stubAlias(): Record<string, string> | null {
-  // Running from source this file sits next to `stubs/`; in the bundle it is
-  // a chunk at the root of `dist/`, and the stub is emitted as its own entry
-  // under the path it has in `src/`.
-  for (const candidate of [
-    './stubs/unplugin-vue-i18n.ts',
-    './config/framework/stubs/unplugin-vue-i18n.js',
-  ]) {
-    const path = fileURLToPath(new URL(candidate, import.meta.url))
-    if (!existsSync(path)) continue
-    return Object.fromEntries(PLUGIN_SPECIFIERS.map(specifier => [specifier, path]))
-  }
-  return null
+  const path = resolveStub('unplugin-vue-i18n')
+  if (!path) return null
+  return Object.fromEntries(PLUGIN_SPECIFIERS.map(specifier => [specifier, path]))
 }

--- a/packages/cli/src/config/framework/vue.ts
+++ b/packages/cli/src/config/framework/vue.ts
@@ -1,0 +1,138 @@
+/**
+ * Reading where a Vue project keeps its locale files, from the place it
+ * already says so: `@intlify/unplugin-vue-i18n`'s `include`.
+ *
+ * The adapter's alternative is six candidate directories and a regex over
+ * `src/i18n/index.ts` looking for `messages:` — which finds nothing at all if
+ * the project keeps its locales anywhere else.
+ */
+import { existsSync, statSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { asObject, executeConfig, firstExisting } from './execute.js'
+import { log } from '../../utils/logger.js'
+
+/**
+ * Where the stub leaves what it recorded. Spelled out rather than imported
+ * from the stub: importing it would fold the stub into this bundle chunk, and
+ * it has to survive the build as a standalone file to be aliased to by path.
+ * A registered symbol is the same symbol in both, which is the point.
+ */
+const RECORDED = Symbol.for('the-i18n-kit:unplugin-vue-i18n-options')
+
+const VITE_CONFIG_FILES = [
+  'vite.config.ts',
+  'vite.config.js',
+  'vite.config.mts',
+  'vite.config.mjs',
+]
+
+/** Every specifier the plugin is imported under, all pointing at the stub. */
+const PLUGIN_SPECIFIERS = [
+  '@intlify/unplugin-vue-i18n/vite',
+  '@intlify/unplugin-vue-i18n',
+  '@intlify/unplugin-vue-i18n/rollup',
+  '@intlify/unplugin-vue-i18n/webpack',
+]
+
+/**
+ * The directories `include` points at, or null when the config declares none,
+ * cannot be read, or names paths that do not exist.
+ *
+ * Never throws: a `vite.config.ts` needs Vite and every plugin it imports to
+ * be installed, and a project where that fails must keep working exactly as it
+ * did before this could be read at all.
+ */
+export async function readVueI18nLocaleDirs(projectDir: string): Promise<string[] | null> {
+  const path = firstExisting(projectDir, VITE_CONFIG_FILES)
+  if (!path) return null
+
+  const globalScope = globalThis as Record<symbol, unknown>
+  delete globalScope[RECORDED]
+
+  const alias = stubAlias()
+  if (!alias) return null
+
+  const module = await executeConfig(path, { alias })
+  if (!module) return null
+
+  // `defineConfig(({ mode }) => ({ ... }))` is as common as the object form,
+  // and the plugin is only constructed once the function runs.
+  const exported = 'default' in module ? module.default : module
+  if (typeof exported === 'function') {
+    try {
+      await (exported as (env: unknown) => unknown)({ command: 'build', mode: 'production', isSsrBuild: false })
+    }
+    catch (error) {
+      log.warn(`Could not evaluate the config function in ${path}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  const options = asObject(globalScope[RECORDED])
+  delete globalScope[RECORDED]
+  if (!options) return null
+
+  const dirs = includeToDirs(options.include, dirname(path))
+  if (dirs.length === 0) return null
+
+  log.info(`Read locale directories from ${path}: ${dirs.join(', ')}`)
+  return dirs
+}
+
+/**
+ * Turn `include` — one path or many, each usually a glob — into the existing
+ * directories they live in. `resolve(__dirname, './src/locales/**')` is the
+ * shape the plugin's own docs use.
+ */
+function includeToDirs(include: unknown, configDir: string): string[] {
+  const patterns = (Array.isArray(include) ? include : [include])
+    .filter((v): v is string => typeof v === 'string' && v.length > 0)
+
+  const dirs: string[] = []
+  for (const pattern of patterns) {
+    const dir = globRoot(pattern)
+    if (!dir) continue
+
+    const full = isAbsolute(dir) ? dir : resolve(configDir, dir)
+    if (!dirs.includes(full) && isDirectory(full)) dirs.push(full)
+  }
+  return dirs
+}
+
+/** Everything before the first glob segment: `src/locales/**\/*.json` → `src/locales`. */
+function globRoot(pattern: string): string | undefined {
+  const segments = pattern.split('/')
+  const wildcard = segments.findIndex(s => s.includes('*') || s.includes('?') || s.includes('['))
+  const kept = wildcard === -1 ? segments.slice(0, -1) : segments.slice(0, wildcard)
+  return kept.length > 0 ? kept.join('/') : undefined
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return existsSync(path) && statSync(path).isDirectory()
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Map every specifier the plugin is imported under onto the stub that records
+ * its options. Returns null if the stub cannot be located, which leaves the
+ * real plugin in place — and the real plugin tells us nothing, so the caller
+ * gives up rather than executing a config for no reason.
+ */
+function stubAlias(): Record<string, string> | null {
+  // Running from source this file sits next to `stubs/`; in the bundle it is
+  // a chunk at the root of `dist/`, and the stub is emitted as its own entry
+  // under the path it has in `src/`.
+  for (const candidate of [
+    './stubs/unplugin-vue-i18n.ts',
+    './config/framework/stubs/unplugin-vue-i18n.js',
+  ]) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url))
+    if (!existsSync(path)) continue
+    return Object.fromEntries(PLUGIN_SPECIFIERS.map(specifier => [specifier, path]))
+  }
+  return null
+}

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import type { ProjectConfig } from './types.js'
-import { validateProjectConfig } from './schema.js'
+import { dropDeprecatedKeys, validateProjectConfig } from './schema.js'
 import { loadTypedConfig } from './typed-config.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
@@ -123,14 +123,5 @@ async function loadJsonConfig(
 
   log.debug(`Project config loaded successfully from ${configPath}`)
 
-  const data = result.data as ProjectConfig & { samplingPreferences?: unknown }
-  if ('samplingPreferences' in data) {
-    log.warn(
-      `${CONFIG_FILENAME}: "samplingPreferences" is deprecated and ignored — `
-      + 'MCP sampling was removed. Configure a provider (e.g. I18N_PROVIDER/I18N_MODEL) instead.',
-    )
-    delete data.samplingPreferences
-  }
-
-  return { path: configPath, config: data }
+  return { path: configPath, config: dropDeprecatedKeys(result.data, CONFIG_FILENAME) }
 }

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -1,75 +1,18 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
-import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
+import { validateProjectConfig } from './schema.js'
+import { loadTypedConfig } from './typed-config.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
 export const CONFIG_FILENAME = '.i18n-mcp.json'
 
-// ─── Zod schema ─────────────────────────────────────────────────
-
-const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
-
-const layerRuleSchema = z.object({
-  layer: z.string(),
-  description: z.string(),
-  when: z.string(),
-})
-
-const localeDirEntrySchema = z.union([
-  nonEmptyString,
-  z.object({
-    path: nonEmptyString,
-    layer: nonEmptyString,
-  }),
-])
-
-const projectConfigSchema = z.object({
-  $schema: z.string().optional(),
-  framework: z.string().optional(),
-  context: z.string().optional(),
-  layerRules: z.array(layerRuleSchema).optional(),
-  glossary: z.record(z.string(), z.string()).optional(),
-  translationPrompt: z.string().optional(),
-  localeNotes: z.record(z.string(), z.string()).optional(),
-  examples: z.array(z.record(z.string(), z.string())).optional(),
-  orphanScan: z.record(z.string(), z.object({
-    ignorePatterns: z.array(z.string()).optional(),
-  }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
-  localeDirs: z.array(localeDirEntrySchema).optional(),
-  defaultLocale: z.string().optional(),
-  locales: z.array(z.string()).optional(),
-  protectedLocales: z.array(nonEmptyString).optional(),
-  reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
-  localeFileFormat: z.enum(['json', 'php-array']).optional(),
-  providerBaseUrl: nonEmptyString.optional(),
-  // Deprecated with the removal of MCP sampling: accepted so existing config
-  // files keep validating (the schema is strict), warned about, and ignored.
-  samplingPreferences: z.unknown().optional(),
-}).strict()
-
-/**
- * Validate a candidate project config against the published schema, returning
- * the formatted issue list rather than throwing. `init` uses this to refuse to
- * emit a config the tool would then reject; loadProjectConfig turns the same
- * failure into a ConfigError.
- */
-export function validateProjectConfig(
-  value: unknown,
-): { ok: true; data: ProjectConfig } | { ok: false; error: string } {
-  const result = projectConfigSchema.safeParse(value)
-  if (result.success) return { ok: true, data: result.data as ProjectConfig }
-
-  const error = result.error.issues
-    .map((issue) => {
-      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
-      return `  ${path}: ${issue.message}`
-    })
-    .join('\n')
-  return { ok: false, error }
-}
+// The schema itself lives in ./schema.ts, shared with the typed-config loader.
+// Re-exported here because this has been its import path since before there
+// was a second config format.
+export { validateProjectConfig } from './schema.js'
 
 // ─── Config file discovery ──────────────────────────────────────
 
@@ -92,13 +35,57 @@ export function findConfigFile(startDir: string): string | null {
 }
 
 /**
- * Load the optional project config file (.i18n-mcp.json).
- * Walks up from projectDir to find the nearest config file,
- * similar to how ESLint, Prettier, and tsconfig resolve configs.
+ * Load the project's declared configuration, from either place it can be
+ * declared: `i18n-kit.config.ts` and `.i18n-mcp.json`. Both are searched from
+ * projectDir upwards, the way ESLint, Prettier and tsconfig resolve configs.
+ *
+ * Returns null when neither exists — the case that must keep behaving exactly
+ * as it did before there were two. Throws ConfigError when either file is
+ * present but unusable, or when the two disagree.
+ *
+ * Every adapter funnels through here, which is what makes the typed config
+ * work for all of them rather than for whichever one was taught about it.
+ */
+export async function loadProjectConfig(projectDir: string): Promise<ProjectConfig | null> {
+  const [json, typed] = await Promise.all([
+    loadJsonConfig(projectDir),
+    loadTypedConfig(projectDir),
+  ])
+
+  if (!typed) return json?.config ?? null
+  if (!json) return typed.config
+
+  const conflicts = conflictingKeys(typed.config, json.config)
+  if (conflicts.length > 0) {
+    throw new ConfigError(
+      `${conflicts.join(', ')} ${conflicts.length === 1 ? 'is' : 'are'} declared in both\n`
+      + `  ${typed.path}\n`
+      + `  ${json.path}\n`
+      + 'Neither wins — a reader cannot tell which one took effect. '
+      + 'Delete the duplicate from one of them.',
+    )
+  }
+
+  // Disjoint by the check above, so the spread order only decides where
+  // untouched keys come from, not who wins.
+  return { ...json.config, ...typed.config }
+}
+
+/** Keys present in both files, ignoring the JSON-only `$schema`. */
+function conflictingKeys(typed: ProjectConfig, json: ProjectConfig): string[] {
+  const a = typed as Record<string, unknown>
+  const b = json as Record<string, unknown>
+  return Object.keys(a).filter(key => key !== '$schema' && a[key] !== undefined && b[key] !== undefined)
+}
+
+/**
+ * Load the optional `.i18n-mcp.json`, with the path it was found at.
  * Returns null if no config file is found in any ancestor.
  * Throws ConfigError if a file is found but is invalid.
  */
-export async function loadProjectConfig(projectDir: string): Promise<ProjectConfig | null> {
+async function loadJsonConfig(
+  projectDir: string,
+): Promise<{ path: string, config: ProjectConfig } | null> {
   log.debug(`Searching for ${CONFIG_FILENAME} starting from: ${projectDir}`)
 
   const configPath = findConfigFile(projectDir)
@@ -145,5 +132,5 @@ export async function loadProjectConfig(projectDir: string): Promise<ProjectConf
     delete data.samplingPreferences
   }
 
-  return data
+  return { path: configPath, config: data }
 }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -9,6 +9,7 @@
  */
 import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
+import { log } from '../utils/logger.js'
 
 const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
 
@@ -39,8 +40,8 @@ const projectConfigSchema = z.object({
     ignorePatterns: z.array(z.string()).optional(),
   }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
   localeDirs: z.array(localeDirEntrySchema).optional(),
-  defaultLocale: z.string().optional(),
-  locales: z.array(z.string()).optional(),
+  defaultLocale: nonEmptyString.optional(),
+  locales: z.array(nonEmptyString).optional(),
   protectedLocales: z.array(nonEmptyString).optional(),
   reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
   localeFileFormat: z.enum(['json', 'php-array']).optional(),
@@ -69,6 +70,25 @@ export function validateProjectConfig(
     })
     .join('\n')
   return { ok: false, error }
+}
+
+/**
+ * Strip the deprecated keys the schema still accepts, warning once, so that a
+ * config keeps validating without the value going on to mean anything. Applied
+ * by every loader — a key ignored in `.i18n-mcp.json` but silently honoured in
+ * `i18n-kit.config.ts` would be exactly the divergence this file exists to
+ * prevent.
+ */
+export function dropDeprecatedKeys(config: ProjectConfig, source: string): ProjectConfig {
+  const data = config as ProjectConfig & { samplingPreferences?: unknown }
+  if ('samplingPreferences' in data) {
+    log.warn(
+      `${source}: "samplingPreferences" is deprecated and ignored — `
+      + 'MCP sampling was removed. Configure a provider (e.g. I18N_PROVIDER/I18N_MODEL) instead.',
+    )
+    delete data.samplingPreferences
+  }
+  return data
 }
 
 // ─── Drift guard ────────────────────────────────────────────────

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,0 +1,91 @@
+/**
+ * The one definition of the declared half of the kit's configuration —
+ * everything a human tells the tool, as opposed to what it can see for itself.
+ *
+ * `.i18n-mcp.json`, `i18n-kit.config.ts` and the `i18nKit` block in
+ * `nuxt.config.ts` all accept this same shape, and all validate against this
+ * same schema. The `ProjectConfig` interface in `./types.ts` documents it;
+ * the guard at the bottom of this file fails the build if the two drift.
+ */
+import { z } from 'zod'
+import type { ProjectConfig } from './types.js'
+
+const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
+
+const layerRuleSchema = z.object({
+  layer: z.string(),
+  description: z.string(),
+  when: z.string(),
+})
+
+const localeDirEntrySchema = z.union([
+  nonEmptyString,
+  z.object({
+    path: nonEmptyString,
+    layer: nonEmptyString,
+  }),
+])
+
+const projectConfigSchema = z.object({
+  $schema: z.string().optional(),
+  framework: z.string().optional(),
+  context: z.string().optional(),
+  layerRules: z.array(layerRuleSchema).optional(),
+  glossary: z.record(z.string(), z.string()).optional(),
+  translationPrompt: z.string().optional(),
+  localeNotes: z.record(z.string(), z.string()).optional(),
+  examples: z.array(z.record(z.string(), z.string())).optional(),
+  orphanScan: z.record(z.string(), z.object({
+    ignorePatterns: z.array(z.string()).optional(),
+  }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
+  localeDirs: z.array(localeDirEntrySchema).optional(),
+  defaultLocale: z.string().optional(),
+  locales: z.array(z.string()).optional(),
+  protectedLocales: z.array(nonEmptyString).optional(),
+  reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
+  localeFileFormat: z.enum(['json', 'php-array']).optional(),
+  providerBaseUrl: nonEmptyString.optional(),
+  // Deprecated with the removal of MCP sampling: accepted so existing config
+  // files keep validating (the schema is strict), warned about, and ignored.
+  samplingPreferences: z.unknown().optional(),
+}).strict()
+
+/**
+ * Validate a candidate project config against the published schema, returning
+ * the formatted issue list rather than throwing. `init` uses this to refuse to
+ * emit a config the tool would then reject; the loaders turn the same failure
+ * into a ConfigError naming the file it came from.
+ */
+export function validateProjectConfig(
+  value: unknown,
+): { ok: true, data: ProjectConfig } | { ok: false, error: string } {
+  const result = projectConfigSchema.safeParse(value)
+  if (result.success) return { ok: true, data: result.data as ProjectConfig }
+
+  const error = result.error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+      return `  ${path}: ${issue.message}`
+    })
+    .join('\n')
+  return { ok: false, error }
+}
+
+// ─── Drift guard ────────────────────────────────────────────────
+//
+// A key added to the interface but not the schema is rejected at runtime as an
+// unknown key (the schema is strict) — a typed config that the editor accepts
+// and the CLI refuses. A key added to the schema but not the interface is
+// accepted at runtime and invisible in an editor. Both are the drift this
+// module exists to prevent, so both are a type error here.
+//
+// `$schema` is JSON-only, and `samplingPreferences` is accepted purely so old
+// files keep validating; neither belongs in the documented type.
+
+type SchemaKey = Exclude<keyof z.infer<typeof projectConfigSchema>, '$schema' | 'samplingPreferences'>
+
+/** Fails to compile unless `T` is `never`, naming the offending key when not. */
+type NoDrift<T extends never> = T
+
+type _SchemaCoversType = NoDrift<Exclude<keyof ProjectConfig, SchemaKey>>
+type _TypeCoversSchema = NoDrift<Exclude<SchemaKey, keyof ProjectConfig>>

--- a/packages/cli/src/config/typed-config.ts
+++ b/packages/cli/src/config/typed-config.ts
@@ -1,0 +1,152 @@
+/**
+ * Loading `i18n-kit.config.ts` — the same configuration `.i18n-mcp.json`
+ * carries, written in TypeScript so the editor checks it.
+ *
+ * Read with no build step, which is the whole point: a `protectedLocales` entry
+ * that only takes effect once something has been built is a locale that quietly
+ * goes unprotected in a fresh checkout. Everything here runs off the source
+ * file as it sits on disk.
+ */
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { ProjectConfig } from './types.js'
+import { validateProjectConfig } from './schema.js'
+import { ConfigError, toErrorMessage } from '../utils/errors.js'
+import { log } from '../utils/logger.js'
+
+/**
+ * Candidate names, in the order a directory is searched. `.ts` first because
+ * it is the one worth having; the rest exist so a JavaScript project is not
+ * told to adopt TypeScript to get a typed config.
+ */
+const TYPED_CONFIG_FILENAMES = [
+  'i18n-kit.config.ts',
+  'i18n-kit.config.mts',
+  'i18n-kit.config.js',
+  'i18n-kit.config.mjs',
+  'i18n-kit.config.cjs',
+] as const
+
+/**
+ * Walk up from `startDir` for the nearest `i18n-kit.config.*`, the same way
+ * `findConfigFile` looks for `.i18n-mcp.json`. Both stop at the first
+ * directory that has one, so a config in an app directory shadows one in the
+ * repository root rather than merging with it.
+ */
+export function findTypedConfigFile(startDir: string): string | null {
+  let dir = startDir
+  while (true) {
+    const found = TYPED_CONFIG_FILENAMES
+      .map(name => join(dir, name))
+      .filter(path => existsSync(path))
+
+    if (found[0]) {
+      if (found.length > 1) {
+        log.warn(
+          `Several i18n-kit configs in ${dir} (${found.map(p => p.slice(dir.length + 1)).join(', ')}). `
+          + `Using ${found[0].slice(dir.length + 1)} — delete the others, they are being ignored.`,
+        )
+      }
+      return found[0]
+    }
+
+    const parent = dirname(dir)
+    if (parent === dir) break // filesystem root
+    dir = parent
+  }
+  return null
+}
+
+/**
+ * Load and validate the nearest typed config, or null when there isn't one.
+ *
+ * Throws, unlike the framework-config readers this issue also adds. Those read
+ * a file someone wrote for another tool, so failing to read it means falling
+ * back to a guess. This file exists only for the kit: if it throws, or declares
+ * a key that does not exist, carrying on without it is precisely the silent
+ * non-application the typed config was added to prevent.
+ */
+export async function loadTypedConfig(
+  projectDir: string,
+): Promise<{ path: string, config: ProjectConfig } | null> {
+  const path = findTypedConfigFile(projectDir)
+  if (!path) {
+    log.debug(`No i18n-kit.config.* found in ${projectDir} or any parent directory — skipping`)
+    return null
+  }
+
+  log.info(`Found typed project config: ${path}`)
+
+  let module: unknown
+  try {
+    const { createJiti } = await import('jiti')
+    // interopDefault stays off so that a file with only named exports is
+    // distinguishable from one with a default: with the interop on, the whole
+    // namespace comes back and the schema rejects it as a config full of
+    // unknown keys, which explains nothing.
+    const jiti = createJiti(import.meta.url, {
+      interopDefault: false,
+      alias: selfAlias(),
+    })
+    module = await jiti.import(path)
+  }
+  catch (error) {
+    throw new ConfigError(
+      `Failed to load ${path}: ${toErrorMessage(error)}`,
+    )
+  }
+
+  if (module === null || typeof module !== 'object' || !('default' in module)) {
+    throw new ConfigError(
+      `${path} must export its config as the default export — `
+      + 'write `export default defineI18nKitConfig({ ... })`.',
+    )
+  }
+
+  const exported = (module as { default: unknown }).default
+
+  if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
+    throw new ConfigError(
+      `${path} must export a config object as its default export — got ${describe(exported)}. `
+      + 'Wrap it in defineI18nKitConfig() from "the-i18n-cli/config".',
+    )
+  }
+
+  const result = validateProjectConfig(exported)
+  if (!result.ok) {
+    throw new ConfigError(`Invalid ${path}:\n${result.error}`)
+  }
+
+  return { path, config: result.data }
+}
+
+/**
+ * Point `the-i18n-cli/config` at the copy of `defineI18nKitConfig` that is
+ * already running.
+ *
+ * A config file imports it for the types, and types only need the package
+ * installed at author time — but the CLI is often run through `npx` in a
+ * project that never added it as a dependency, where a bare import would be
+ * unresolvable and take the whole config down with it. Resolving it to
+ * ourselves costs nothing and is the same function either way: identity.
+ *
+ * Returns no alias when the entry cannot be located, which leaves normal
+ * resolution to find the installed package.
+ */
+function selfAlias(): Record<string, string> {
+  // `./` when running from the bundle, where define-config.js sits beside the
+  // chunk this code ends up in; `../` when running from source, as tests do.
+  for (const candidate of ['./define-config.js', '../define-config.js', '../define-config.ts']) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url))
+    if (existsSync(path)) return { 'the-i18n-cli/config': path }
+  }
+  return {}
+}
+
+function describe(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'an array'
+  if (typeof value === 'function') return 'a function (call defineI18nKitConfig, do not pass it)'
+  return typeof value
+}

--- a/packages/cli/src/config/typed-config.ts
+++ b/packages/cli/src/config/typed-config.ts
@@ -11,7 +11,7 @@ import { existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ProjectConfig } from './types.js'
-import { validateProjectConfig } from './schema.js'
+import { dropDeprecatedKeys, validateProjectConfig } from './schema.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
@@ -26,6 +26,7 @@ const TYPED_CONFIG_FILENAMES = [
   'i18n-kit.config.js',
   'i18n-kit.config.mjs',
   'i18n-kit.config.cjs',
+  'i18n-kit.config.cts',
 ] as const
 
 /**
@@ -100,14 +101,26 @@ export async function loadTypedConfig(
     )
   }
 
-  if (module === null || typeof module !== 'object' || !('default' in module)) {
+  if (module === null || typeof module !== 'object') {
     throw new ConfigError(
       `${path} must export its config as the default export — `
       + 'write `export default defineI18nKitConfig({ ... })`.',
     )
   }
 
-  const exported = (module as { default: unknown }).default
+  // In a `.cts` file `module.exports` comes back as the module itself, with no
+  // `default` to unwrap — so for the CommonJS spellings, that object *is* the
+  // config. Everywhere else a missing `default` means a file of named exports,
+  // and saying so beats letting the schema report a config full of unknown keys.
+  const commonJs = path.endsWith('.cts') || path.endsWith('.cjs')
+  if (!('default' in module) && !commonJs) {
+    throw new ConfigError(
+      `${path} must export its config as the default export — `
+      + 'write `export default defineI18nKitConfig({ ... })`.',
+    )
+  }
+
+  const exported = 'default' in module ? (module as { default: unknown }).default : module
 
   if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
     throw new ConfigError(
@@ -121,7 +134,7 @@ export async function loadTypedConfig(
     throw new ConfigError(`Invalid ${path}:\n${result.error}`)
   }
 
-  return { path, config: result.data }
+  return { path, config: dropDeprecatedKeys(result.data, path) }
 }
 
 /**

--- a/packages/cli/src/config/typed-config.ts
+++ b/packages/cli/src/config/typed-config.ts
@@ -8,7 +8,7 @@
  * file as it sits on disk.
  */
 import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ProjectConfig } from './types.js'
 import { validateProjectConfig } from './schema.js'
@@ -35,7 +35,10 @@ const TYPED_CONFIG_FILENAMES = [
  * repository root rather than merging with it.
  */
 export function findTypedConfigFile(startDir: string): string | null {
-  let dir = startDir
+  // Absolute from the outset: a relative `--projectDir` would otherwise yield
+  // a relative config path, and jiti reads a relative path as a bare module
+  // specifier — resolved against node_modules, where it is never found.
+  let dir = resolve(startDir)
   while (true) {
     const found = TYPED_CONFIG_FILENAMES
       .map(name => join(dir, name))

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -65,8 +65,12 @@ export interface ProjectConfig {
     /** Glob patterns for translation keys to exclude from orphan detection (e.g., "common.datetime.months.*"). */
     ignorePatterns?: string[]
   }>
-  /** Default output directory for diagnostic tool reports. Set to true for '.i18n-reports/', or a string for a custom relative path. */
-  reportOutput?: string | boolean
+  /**
+   * Where diagnostic reports are written: `true` for '.i18n-reports/', or a
+   * relative path. There is no `false` — omitting the key is how you say no,
+   * and accepting both spellings of "off" would be two ways to mean one thing.
+   */
+  reportOutput?: string | true
   /** Locale directories for the generic adapter. Each entry is a path string (layer="default") or { path, layer } object. */
   localeDirs?: Array<string | { path: string; layer: string }>
   /** Default locale code (required for generic adapter activation). */

--- a/packages/cli/src/define-config.ts
+++ b/packages/cli/src/define-config.ts
@@ -1,0 +1,33 @@
+/**
+ * The entry point a project's own `i18n-kit.config.ts` imports:
+ *
+ * ```ts
+ * import { defineI18nKitConfig } from 'the-i18n-cli/config'
+ *
+ * export default defineI18nKitConfig({ defaultLocale: 'en' })
+ * ```
+ *
+ * Deliberately its own entry rather than part of the package's main export.
+ * This module is loaded *by the config file the CLI is about to read*, so it
+ * has to stay free of anything that touches the filesystem, the logger, or a
+ * provider — importing it must not be able to do anything.
+ */
+import type { ProjectConfig } from './config/types.js'
+
+/**
+ * Everything `.i18n-mcp.json` accepts, minus the JSON-only `$schema` key —
+ * a TypeScript config is checked by the editor rather than by a schema URL.
+ */
+export type I18nKitConfig = ProjectConfig
+
+/**
+ * Identity at runtime; the point is the type. Returning the argument unchanged
+ * keeps the config file's inferred type exact, so `defaultLocale` autocompletes
+ * and a misspelled `protectedLocals` is a red squiggle rather than a key that
+ * silently protects nothing.
+ */
+export function defineI18nKitConfig(config: I18nKitConfig): I18nKitConfig {
+  return config
+}
+
+export type { ProjectConfig, LocaleDefinition, LocaleDir, I18nConfig } from './config/types.js'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,4 +55,6 @@ export { ToolError, toErrorMessage } from './utils/errors.js'
 // LLM providers
 export { createTranslateFn, TranslateProviderError, classifyProviderError, resolveProviderBaseUrl, BASE_URL_ENV } from './llm/providers.js'
 export { loadProjectConfig } from './config/project-config.js'
+export { defineI18nKitConfig } from './define-config.js'
+export type { I18nKitConfig } from './define-config.js'
 export type { LlmProvider, LlmProviderConfig, TranslateProviderErrorKind } from './llm/providers.js'

--- a/packages/cli/tests/adapters/vue-adapter.test.ts
+++ b/packages/cli/tests/adapters/vue-adapter.test.ts
@@ -306,3 +306,48 @@ describe('Adapter registry: Vue vs Nuxt', () => {
     }
   })
 })
+
+describe('VueAdapter with several unplugin-vue-i18n include roots', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `vue-multi-include-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(join(tempDir, 'src/messages'), { recursive: true })
+    mkdirSync(join(tempDir, 'src/admin/messages'), { recursive: true })
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      name: 'vue-multi', dependencies: { vue: '^3.5.0', 'vue-i18n': '^11.0.0' },
+    }))
+    writeFileSync(join(tempDir, 'src/messages/en.json'), JSON.stringify({ shared: 'Shared' }))
+    writeFileSync(join(tempDir, 'src/messages/de.json'), JSON.stringify({ shared: 'Geteilt' }))
+    writeFileSync(join(tempDir, 'src/admin/messages/en.json'), JSON.stringify({ admin: 'Admin' }))
+    writeFileSync(join(tempDir, 'vite.config.ts'), `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default {
+        plugins: [VueI18nPlugin({
+          include: ['./src/messages/**', './src/admin/messages/**'],
+        })],
+      }
+    `)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('keeps every include root, each as its own layer', async () => {
+    const config = await new VueAdapter().resolve(tempDir)
+
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      join(tempDir, 'src/messages'),
+      join(tempDir, 'src/admin/messages'),
+    ])
+    // Both directories are called "messages", so the names have to say more.
+    expect(config.localeDirs.map(d => d.layer)).toEqual(['src/messages', 'admin/messages'])
+    expect(config.apps[0]!.layers).toEqual(['src/messages', 'admin/messages'])
+  })
+
+  it('unions the locales across the roots', async () => {
+    const config = await new VueAdapter().resolve(tempDir)
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de', 'en'])
+  })
+})

--- a/packages/cli/tests/config/framework-config.test.ts
+++ b/packages/cli/tests/config/framework-config.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { resolve } from 'node:path'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { readNextI18n } from '../../src/config/framework/next.js'
+import { readVueI18nLocaleDirs } from '../../src/config/framework/vue.js'
+
+const root = resolve(import.meta.dirname, '../../.tmp-framework-config')
+
+// One directory per test: Node's ESM loader caches a module by URL for the
+// life of the process, so reusing a path would serve the first test's file.
+let tmpDir: string
+let n = 0
+beforeEach(() => {
+  tmpDir = resolve(root, `case-${n++}`)
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function write(name: string, contents: string) {
+  const path = resolve(tmpDir, name)
+  await mkdir(resolve(path, '..'), { recursive: true })
+  await writeFile(path, contents, 'utf-8')
+  return path
+}
+
+describe('readNextI18n', () => {
+  it('returns null when the project declares nothing', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    expect(await readNextI18n(tmpDir)).toBeNull()
+  })
+
+  it('reads next-intl routing, defineRouting being identity over its argument', async () => {
+    await write('src/i18n/routing.ts', `
+      const defineRouting = (c: unknown) => c
+      export const routing = defineRouting({ locales: ['en', 'de'], defaultLocale: 'en' })
+    `)
+
+    const found = await readNextI18n(tmpDir)
+    expect(found?.defaultLocale).toBe('en')
+    expect(found?.locales).toEqual(['en', 'de'])
+  })
+
+  it('reads a routing file that uses a default export', async () => {
+    await write('src/i18n/routing.ts', `export default { locales: ['fr'], defaultLocale: 'fr' }`)
+    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('fr')
+  })
+
+  it("reads next-translate's i18n.js", async () => {
+    await write('i18n.js', `
+      module.exports = { locales: ['en', 'pl'], defaultLocale: 'pl', pages: { '*': ['common'] } }
+    `)
+
+    const found = await readNextI18n(tmpDir)
+    expect(found?.defaultLocale).toBe('pl')
+    expect(found?.locales).toEqual(['en', 'pl'])
+  })
+
+  it("reads the Pages Router's i18n block from next.config", async () => {
+    await write('next.config.js', `
+      export default { reactStrictMode: true, i18n: { locales: ['en', 'nl'], defaultLocale: 'nl' } }
+    `)
+
+    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('nl')
+  })
+
+  it('prefers the routing file over next.config, being the more specific statement', async () => {
+    await write('src/i18n/routing.ts', `export default { locales: ['en'], defaultLocale: 'en' }`)
+    await write('next.config.js', `export default { i18n: { locales: ['de'], defaultLocale: 'de' } }`)
+
+    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('en')
+  })
+
+  it('warns and yields nothing when a config throws — never a failure', async () => {
+    // The shape of the real problem: a next.config wrapped in a plugin that
+    // is not installed, or that needs env the CLI does not have.
+    await write('next.config.js', `
+      import withSomething from 'a-plugin-that-is-not-installed'
+      export default withSomething({ i18n: { locales: ['de'], defaultLocale: 'de' } })
+    `)
+
+    await expect(readNextI18n(tmpDir)).resolves.toBeNull()
+  })
+
+  it('ignores a config that declares no locales at all', async () => {
+    await write('next.config.js', `export default { reactStrictMode: true }`)
+    expect(await readNextI18n(tmpDir)).toBeNull()
+  })
+
+  it('ignores locale values of the wrong type rather than trusting them', async () => {
+    await write('next.config.js', `export default { i18n: { locales: [1, 2], defaultLocale: 42 } }`)
+    expect(await readNextI18n(tmpDir)).toBeNull()
+  })
+})
+
+describe('readVueI18nLocaleDirs', () => {
+  it('returns null without a vite config', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+  })
+
+  it("reads the plugin's include, which the plugin object itself never exposes", async () => {
+    await mkdir(resolve(tmpDir, 'src/translations'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default {
+        plugins: [VueI18nPlugin({ include: ['./src/translations/**'] })],
+      }
+    `)
+
+    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/translations')])
+  })
+
+  it('evaluates the function form of defineConfig', async () => {
+    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default ({ mode }: { mode: string }) => ({
+        plugins: [VueI18nPlugin({ include: ['./locales/**/*.json'] })],
+        mode,
+      })
+    `)
+
+    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'locales')])
+  })
+
+  it('resolves an absolute include, as the plugin docs write it', async () => {
+    await mkdir(resolve(tmpDir, 'src/i18n/messages'), { recursive: true })
+    await write('vite.config.ts', `
+      import { resolve, dirname } from 'node:path'
+      import { fileURLToPath } from 'node:url'
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      const here = dirname(fileURLToPath(import.meta.url))
+      export default {
+        plugins: [VueI18nPlugin({ include: [resolve(here, './src/i18n/messages/**')] })],
+      }
+    `)
+
+    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/i18n/messages')])
+  })
+
+  it('ignores an include naming a directory that does not exist', async () => {
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['./nowhere/**'] })] }
+    `)
+
+    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+  })
+
+  it('returns null when the config never uses the plugin', async () => {
+    await write('vite.config.ts', `export default { plugins: [] }`)
+    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+  })
+
+  it('warns and yields nothing when the vite config throws', async () => {
+    await write('vite.config.ts', `
+      import somethingMissing from 'a-vite-plugin-that-is-not-installed'
+      export default { plugins: [somethingMissing()] }
+    `)
+
+    await expect(readVueI18nLocaleDirs(tmpDir)).resolves.toBeNull()
+  })
+
+  it('does not leak a recorded include into the next project read', async () => {
+    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['./locales/**'] })] }
+    `)
+    expect(await readVueI18nLocaleDirs(tmpDir)).not.toBeNull()
+
+    // A second project with a config that never calls the plugin must not
+    // inherit the first one's answer through the recording symbol.
+    const other = resolve(root, 'other-project')
+    await mkdir(other, { recursive: true })
+    await writeFile(resolve(other, 'vite.config.ts'), `export default { plugins: [] }`, 'utf-8')
+
+    expect(await readVueI18nLocaleDirs(other)).toBeNull()
+  })
+})

--- a/packages/cli/tests/config/framework-config.test.ts
+++ b/packages/cli/tests/config/framework-config.test.ts
@@ -1,34 +1,17 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { relative as relativePath, resolve } from 'node:path'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { readNextI18n } from '../../src/config/framework/next.js'
 import { readVueI18nLocaleDirs } from '../../src/config/framework/vue.js'
+import { tmpProject } from './tmp-project.js'
 
-const root = resolve(import.meta.dirname, '../../.tmp-framework-config')
-
-// One directory per test: Node's ESM loader caches a module by URL for the
-// life of the process, so reusing a path would serve the first test's file.
-let tmpDir: string
-let n = 0
-beforeEach(() => {
-  tmpDir = resolve(root, `case-${n++}`)
-})
-
-afterAll(async () => {
-  await rm(root, { recursive: true, force: true })
-})
-
-async function write(name: string, contents: string) {
-  const path = resolve(tmpDir, name)
-  await mkdir(resolve(path, '..'), { recursive: true })
-  await writeFile(path, contents, 'utf-8')
-  return path
-}
+const project = tmpProject('framework-config')
+const write = (name: string, contents: string) => project.write(name, contents)
 
 describe('readNextI18n', () => {
   it('returns null when the project declares nothing', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 
   it('reads next-intl routing, defineRouting being identity over its argument', async () => {
@@ -37,14 +20,14 @@ describe('readNextI18n', () => {
       export const routing = defineRouting({ locales: ['en', 'de'], defaultLocale: 'en' })
     `)
 
-    const found = await readNextI18n(tmpDir)
+    const found = await readNextI18n(project.dir)
     expect(found?.defaultLocale).toBe('en')
     expect(found?.locales).toEqual(['en', 'de'])
   })
 
   it('reads a routing file that uses a default export', async () => {
     await write('src/i18n/routing.ts', `export default { locales: ['fr'], defaultLocale: 'fr' }`)
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('fr')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('fr')
   })
 
   it("reads next-translate's i18n.js", async () => {
@@ -52,7 +35,7 @@ describe('readNextI18n', () => {
       module.exports = { locales: ['en', 'pl'], defaultLocale: 'pl', pages: { '*': ['common'] } }
     `)
 
-    const found = await readNextI18n(tmpDir)
+    const found = await readNextI18n(project.dir)
     expect(found?.defaultLocale).toBe('pl')
     expect(found?.locales).toEqual(['en', 'pl'])
   })
@@ -62,14 +45,14 @@ describe('readNextI18n', () => {
       export default { reactStrictMode: true, i18n: { locales: ['en', 'nl'], defaultLocale: 'nl' } }
     `)
 
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('nl')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('nl')
   })
 
   it('prefers the routing file over next.config, being the more specific statement', async () => {
     await write('src/i18n/routing.ts', `export default { locales: ['en'], defaultLocale: 'en' }`)
     await write('next.config.js', `export default { i18n: { locales: ['de'], defaultLocale: 'de' } }`)
 
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('en')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('en')
   })
 
   it('warns and yields nothing when a config throws — never a failure', async () => {
@@ -80,35 +63,59 @@ describe('readNextI18n', () => {
       export default withSomething({ i18n: { locales: ['de'], defaultLocale: 'de' } })
     `)
 
-    await expect(readNextI18n(tmpDir)).resolves.toBeNull()
+    await expect(readNextI18n(project.dir)).resolves.toBeNull()
   })
 
   it('reads through a relative project directory', async () => {
     await write('next.config.js', `export default { i18n: { locales: ['en', 'sv'], defaultLocale: 'sv' } }`)
-    const relative = relativePath(process.cwd(), tmpDir)
+    const relative = relativePath(process.cwd(), project.dir)
 
     expect((await readNextI18n(relative))?.defaultLocale).toBe('sv')
   })
 
+  it('calls a config exported as a function, as Next.js does', async () => {
+    await write('next.config.js', `
+      export default (phase, { defaultConfig }) => ({
+        ...defaultConfig,
+        i18n: { locales: ['en', 'da'], defaultLocale: 'da' },
+      })
+    `)
+
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('da')
+  })
+
+  it('awaits an async config function', async () => {
+    await write('next.config.js', `
+      export default async () => ({ i18n: { locales: ['en', 'fi'], defaultLocale: 'fi' } })
+    `)
+
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('fi')
+  })
+
+  it('warns and yields nothing when the config function throws', async () => {
+    await write('next.config.js', `export default () => { throw new Error('needs env') }`)
+    await expect(readNextI18n(project.dir)).resolves.toBeNull()
+  })
+
   it('ignores a config that declares no locales at all', async () => {
     await write('next.config.js', `export default { reactStrictMode: true }`)
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 
   it('ignores locale values of the wrong type rather than trusting them', async () => {
     await write('next.config.js', `export default { i18n: { locales: [1, 2], defaultLocale: 42 } }`)
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 })
 
 describe('readVueI18nLocaleDirs', () => {
   it('returns null without a vite config', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
   })
 
   it("reads the plugin's include, which the plugin object itself never exposes", async () => {
-    await mkdir(resolve(tmpDir, 'src/translations'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default {
@@ -116,11 +123,11 @@ describe('readVueI18nLocaleDirs', () => {
       }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/translations')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'src/translations')])
   })
 
   it('evaluates the function form of defineConfig', async () => {
-    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await mkdir(resolve(project.dir, 'locales'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default ({ mode }: { mode: string }) => ({
@@ -129,11 +136,11 @@ describe('readVueI18nLocaleDirs', () => {
       })
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'locales')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'locales')])
   })
 
   it('resolves an absolute include, as the plugin docs write it', async () => {
-    await mkdir(resolve(tmpDir, 'src/i18n/messages'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/i18n/messages'), { recursive: true })
     await write('vite.config.ts', `
       import { resolve, dirname } from 'node:path'
       import { fileURLToPath } from 'node:url'
@@ -144,7 +151,7 @@ describe('readVueI18nLocaleDirs', () => {
       }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/i18n/messages')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'src/i18n/messages')])
   })
 
   it('ignores an include naming a directory that does not exist', async () => {
@@ -153,12 +160,46 @@ describe('readVueI18nLocaleDirs', () => {
       export default { plugins: [VueI18nPlugin({ include: ['./nowhere/**'] })] }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
+  })
+
+  it('keeps every directory in include, not just the first', async () => {
+    await mkdir(resolve(project.dir, 'src/messages'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/admin-messages'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default {
+        plugins: [VueI18nPlugin({
+          include: ['./src/messages/**', './src/admin-messages/**'],
+        })],
+      }
+    `)
+
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([
+      resolve(project.dir, 'src/messages'),
+      resolve(project.dir, 'src/admin-messages'),
+    ])
+  })
+
+  it('reads a Windows-style include, where resolve() yields backslashes', async () => {
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
+    // What `resolve(__dirname, './src/translations/**')` produces on Windows.
+    const windowsStyle = `C:\\project\\src\\translations\\**`
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['${windowsStyle}', './src/translations/**'] })] }
+    `)
+
+    // The absolute C:\ path does not exist here, so it drops out; the point is
+    // that splitting it no longer swallows the entry beside it.
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([
+      resolve(project.dir, 'src/translations'),
+    ])
   })
 
   it('returns null when the config never uses the plugin', async () => {
     await write('vite.config.ts', `export default { plugins: [] }`)
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
   })
 
   it('warns and yields nothing when the vite config throws', async () => {
@@ -167,20 +208,37 @@ describe('readVueI18nLocaleDirs', () => {
       export default { plugins: [somethingMissing()] }
     `)
 
-    await expect(readVueI18nLocaleDirs(tmpDir)).resolves.toBeNull()
+    await expect(readVueI18nLocaleDirs(project.dir)).resolves.toBeNull()
+  })
+
+  it('gives the same answer when the same project is read twice', async () => {
+    // Node executes an ES module once per process, so the second read imports
+    // the cache, calls no plugin and records nothing. Without remembering the
+    // answer that silently became "this project declares no locale dirs".
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['./src/translations/**'] })] }
+    `)
+
+    const first = await readVueI18nLocaleDirs(project.dir)
+    const second = await readVueI18nLocaleDirs(project.dir)
+
+    expect(first).toEqual([resolve(project.dir, 'src/translations')])
+    expect(second).toEqual(first)
   })
 
   it('does not leak a recorded include into the next project read', async () => {
-    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await mkdir(resolve(project.dir, 'locales'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default { plugins: [VueI18nPlugin({ include: ['./locales/**'] })] }
     `)
-    expect(await readVueI18nLocaleDirs(tmpDir)).not.toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).not.toBeNull()
 
     // A second project with a config that never calls the plugin must not
     // inherit the first one's answer through the recording symbol.
-    const other = resolve(root, 'other-project')
+    const other = resolve(project.root, 'other-project')
     await mkdir(other, { recursive: true })
     await writeFile(resolve(other, 'vite.config.ts'), `export default { plugins: [] }`, 'utf-8')
 

--- a/packages/cli/tests/config/framework-config.test.ts
+++ b/packages/cli/tests/config/framework-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { resolve } from 'node:path'
+import { relative as relativePath, resolve } from 'node:path'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { readNextI18n } from '../../src/config/framework/next.js'
 import { readVueI18nLocaleDirs } from '../../src/config/framework/vue.js'
@@ -81,6 +81,13 @@ describe('readNextI18n', () => {
     `)
 
     await expect(readNextI18n(tmpDir)).resolves.toBeNull()
+  })
+
+  it('reads through a relative project directory', async () => {
+    await write('next.config.js', `export default { i18n: { locales: ['en', 'sv'], defaultLocale: 'sv' } }`)
+    const relative = relativePath(process.cwd(), tmpDir)
+
+    expect((await readNextI18n(relative))?.defaultLocale).toBe('sv')
   })
 
   it('ignores a config that declares no locales at all', async () => {

--- a/packages/cli/tests/config/playgrounds.test.ts
+++ b/packages/cli/tests/config/playgrounds.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
+import { detectI18nConfig, clearConfigCache } from '../../src/config/detector.js'
+
+/**
+ * The playgrounds are the only place every adapter is exercised end to end
+ * against a project rather than a fixture assembled inside a test. Asserting
+ * the resolution each one is there to demonstrate keeps them from rotting into
+ * directories nobody runs — a playground that silently stopped proving its
+ * point would be worse than not having it.
+ */
+const playgroundsDir = resolve(import.meta.dirname, '../../../../playground')
+
+beforeEach(() => {
+  clearConfigCache()
+})
+
+describe('playground/react', () => {
+  it('takes its default locale from next-intl, not from directory order', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'react'))
+
+    // messages/ sorts de-DE first; routing.ts says otherwise and wins (#296).
+    expect(config.framework).toBe('react')
+    expect(config.defaultLocale).toBe('en-US')
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de-DE', 'en-US', 'es-ES', 'fr-FR'])
+  })
+})
+
+describe('playground/vue', () => {
+  it('finds locale files in a directory no candidate list contains', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'vue'))
+
+    expect(config.framework).toBe('vue')
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      resolve(playgroundsDir, 'vue/src/translations'),
+    ])
+  })
+
+  it('reads defaultLocale and protectedLocales from the typed config', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'vue'))
+
+    expect(config.defaultLocale).toBe('en-US')
+    expect(config.projectConfig?.protectedLocales).toEqual(['de-DE'])
+  })
+})
+
+describe('playground/generic', () => {
+  it('activates on localeDirs + defaultLocale alone, with nothing to detect', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'generic'))
+
+    expect(config.framework).toBe('generic')
+    expect(config.defaultLocale).toBe('en')
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      resolve(playgroundsDir, 'generic/translations'),
+    ])
+  })
+})
+
+describe('playground/laravel', () => {
+  it('resolves PHP locale directories', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'laravel'))
+
+    expect(config.framework).toBe('laravel')
+    expect(config.localeFileFormat).toBe('php-array')
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de', 'en', 'es', 'fr'])
+  })
+})

--- a/packages/cli/tests/config/tmp-project.ts
+++ b/packages/cli/tests/config/tmp-project.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+
+/**
+ * A throwaway project directory per test, plus a `write` for putting config
+ * files in it.
+ *
+ * One directory *per test*, not per file: Node caches an ES module by URL for
+ * the life of the process, so two tests writing different configs to the same
+ * path would both see whichever ran first. Which is also the reason the
+ * production code remembers what it read — see `readVueI18nLocaleDirs`.
+ */
+export function tmpProject(name: string) {
+  const root = resolve(import.meta.dirname, `../../.tmp-${name}`)
+  let dir = root
+  let n = 0
+
+  beforeEach(() => {
+    dir = resolve(root, `case-${n++}`)
+  })
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  return {
+    /** The current test's directory. */
+    get dir() {
+      return dir
+    },
+    /** The shared root, for tests that need a second project of their own. */
+    root,
+    /** Write a file, creating any directories along the way. */
+    async write(relativePath: string, contents: string, into = dir) {
+      const path = resolve(into, relativePath)
+      await mkdir(resolve(path, '..'), { recursive: true })
+      await writeFile(path, contents, 'utf-8')
+      return path
+    },
+    /** Create the directory without putting anything in it. */
+    async empty() {
+      await mkdir(dir, { recursive: true })
+      return dir
+    },
+  }
+}

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -1,34 +1,17 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { relative as relativePath, resolve } from 'node:path'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import { loadTypedConfig, findTypedConfigFile } from '../../src/config/typed-config.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
+import { tmpProject } from './tmp-project.js'
 
-const root = resolve(import.meta.dirname, '../../.tmp-typed-config')
-
-// A directory per test. Node's ESM loader caches a module by URL for the life
-// of the process, so two tests writing different configs to the same path
-// would see whichever ran first — which is also why the CLI, a one-shot
-// process, gets a fresh read every invocation.
-let tmpDir: string
-let n = 0
-beforeEach(() => {
-  tmpDir = resolve(root, `case-${n++}`)
-})
-
-afterAll(async () => {
-  await rm(root, { recursive: true, force: true })
-})
-
-async function write(name: string, contents: string, dir = tmpDir) {
-  await mkdir(dir, { recursive: true })
-  await writeFile(resolve(dir, name), contents, 'utf-8')
-}
+const project = tmpProject('typed-config')
+const write = (name: string, contents: string, into?: string) => project.write(name, contents, into)
 
 describe('loadTypedConfig', () => {
   it('returns null when there is no config file — the case that must keep behaving as before', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await loadTypedConfig(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await loadTypedConfig(project.dir)).toBeNull()
   })
 
   it('loads a TypeScript config, types and all', async () => {
@@ -42,11 +25,11 @@ describe('loadTypedConfig', () => {
       }
     `)
 
-    const loaded = await loadTypedConfig(tmpDir)
+    const loaded = await loadTypedConfig(project.dir)
     expect(loaded?.config.defaultLocale).toBe('en')
     expect(loaded?.config.protectedLocales).toEqual(['de-formal'])
     expect(loaded?.config.glossary).toEqual({ anny: 'type annotations must survive' })
-    expect(loaded?.path).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(loaded?.path).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 
   it('resolves defineI18nKitConfig without the package being installed', async () => {
@@ -57,23 +40,23 @@ describe('loadTypedConfig', () => {
       export default defineI18nKitConfig({ defaultLocale: 'fr' })
     `)
 
-    const loaded = await loadTypedConfig(tmpDir)
+    const loaded = await loadTypedConfig(project.dir)
     expect(loaded?.config.defaultLocale).toBe('fr')
   })
 
   it('accepts a plain .js config', async () => {
     await write('i18n-kit.config.js', `export default { defaultLocale: 'it' }`)
-    expect((await loadTypedConfig(tmpDir))?.config.defaultLocale).toBe('it')
+    expect((await loadTypedConfig(project.dir))?.config.defaultLocale).toBe('it')
   })
 
   it('rejects an unknown key rather than ignoring it', async () => {
     await write('i18n-kit.config.ts', `export default { protectedLocals: ['de'] }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocals/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/protectedLocals/)
   })
 
   it('rejects a value the schema disallows', async () => {
     await write('i18n-kit.config.ts', `export default { protectedLocales: [''] }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocales/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/protectedLocales/)
   })
 
   it('fails loudly when the config throws, naming the file', async () => {
@@ -81,31 +64,31 @@ describe('loadTypedConfig', () => {
     // file exists only for the kit, so ignoring it means silently applying
     // none of the policy someone can see in their repository.
     await write('i18n-kit.config.ts', `throw new Error('boom')`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts.*boom/s)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/i18n-kit\.config\.ts.*boom/s)
   })
 
   it('explains a config with no default export', async () => {
     await write('i18n-kit.config.ts', `export const config = { defaultLocale: 'en' }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/default export/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/default export/)
   })
 
   it('explains a config that exports the function instead of calling it', async () => {
     await write('i18n-kit.config.ts', `export default function config() { return {} }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/do not pass it/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/do not pass it/)
   })
 })
 
 describe('findTypedConfigFile', () => {
   it('walks up to a parent directory, as .i18n-mcp.json does', async () => {
-    const child = resolve(tmpDir, 'apps/admin')
+    const child = resolve(project.dir, 'apps/admin')
     await mkdir(child, { recursive: true })
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
 
-    expect(findTypedConfigFile(child)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(child)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 
   it('stops at the nearest one, so an app config shadows the root', async () => {
-    const child = resolve(tmpDir, 'apps/admin')
+    const child = resolve(project.dir, 'apps/admin')
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'de' }`, child)
 
@@ -116,17 +99,31 @@ describe('findTypedConfigFile', () => {
     // jiti reads a relative path as a bare module specifier, so a relative
     // --projectDir used to make loading a typed config fail outright.
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
-    const relative = relativePath(process.cwd(), tmpDir)
+    const relative = relativePath(process.cwd(), project.dir)
 
-    expect(findTypedConfigFile(relative)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(relative)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
     expect((await loadTypedConfig(relative))?.config.defaultLocale).toBe('en')
+  })
+
+  it('finds a .cts config, the CommonJS TypeScript spelling', async () => {
+    await write('i18n-kit.config.cts', `module.exports = { defaultLocale: 'pt' }`)
+
+    expect(findTypedConfigFile(project.dir)).toBe(resolve(project.dir, 'i18n-kit.config.cts'))
+    expect((await loadTypedConfig(project.dir))?.config.defaultLocale).toBe('pt')
+  })
+
+  it('warns about a deprecated key rather than passing it through', async () => {
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en', samplingPreferences: { model: 'x' } }`)
+
+    const loaded = await loadTypedConfig(project.dir)
+    expect(loaded?.config).toEqual({ defaultLocale: 'en' })
   })
 
   it('prefers .ts when a directory has several', async () => {
     await write('i18n-kit.config.js', `export default { defaultLocale: 'js' }`)
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'ts' }`)
 
-    expect(findTypedConfigFile(tmpDir)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(project.dir)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 })
 
@@ -135,7 +132,7 @@ describe('loadProjectConfig with both config formats', () => {
     await write('i18n-kit.config.ts', `export default { protectedLocales: ['de-formal'] }`)
     await write('.i18n-mcp.json', JSON.stringify({ context: 'a booking product' }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config).toEqual({ context: 'a booking product', protectedLocales: ['de-formal'] })
   })
 
@@ -143,28 +140,28 @@ describe('loadProjectConfig with both config formats', () => {
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de' }))
 
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/defaultLocale/)
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts/)
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/\.i18n-mcp\.json/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/defaultLocale/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/i18n-kit\.config\.ts/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/\.i18n-mcp\.json/)
   })
 
   it('does not count the JSON-only $schema as a conflict', async () => {
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('.i18n-mcp.json', JSON.stringify({ $schema: './schema.json', context: 'x' }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config?.defaultLocale).toBe('en')
   })
 
   it('returns the JSON config unchanged when there is no typed config', async () => {
     await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de', protectedLocales: ['en'] }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config).toEqual({ defaultLocale: 'de', protectedLocales: ['en'] })
   })
 
   it('returns null when neither file exists', async () => {
-    await mkdir(resolve(tmpDir, 'nested'), { recursive: true })
-    expect(await loadProjectConfig(resolve(tmpDir, 'nested'))).toBeNull()
+    await mkdir(resolve(project.dir, 'nested'), { recursive: true })
+    expect(await loadProjectConfig(resolve(project.dir, 'nested'))).toBeNull()
   })
 })

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { resolve } from 'node:path'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { loadTypedConfig, findTypedConfigFile } from '../../src/config/typed-config.js'
+import { loadProjectConfig } from '../../src/config/project-config.js'
+
+const root = resolve(import.meta.dirname, '../../.tmp-typed-config')
+
+// A directory per test. Node's ESM loader caches a module by URL for the life
+// of the process, so two tests writing different configs to the same path
+// would see whichever ran first — which is also why the CLI, a one-shot
+// process, gets a fresh read every invocation.
+let tmpDir: string
+let n = 0
+beforeEach(() => {
+  tmpDir = resolve(root, `case-${n++}`)
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function write(name: string, contents: string, dir = tmpDir) {
+  await mkdir(dir, { recursive: true })
+  await writeFile(resolve(dir, name), contents, 'utf-8')
+}
+
+describe('loadTypedConfig', () => {
+  it('returns null when there is no config file — the case that must keep behaving as before', async () => {
+    await mkdir(tmpDir, { recursive: true })
+    expect(await loadTypedConfig(tmpDir)).toBeNull()
+  })
+
+  it('loads a TypeScript config, types and all', async () => {
+    await write('i18n-kit.config.ts', `
+      interface Extra { note: string }
+      const extra: Extra = { note: 'type annotations must survive' }
+      export default {
+        defaultLocale: 'en',
+        protectedLocales: ['de-formal'],
+        glossary: { anny: extra.note },
+      }
+    `)
+
+    const loaded = await loadTypedConfig(tmpDir)
+    expect(loaded?.config.defaultLocale).toBe('en')
+    expect(loaded?.config.protectedLocales).toEqual(['de-formal'])
+    expect(loaded?.config.glossary).toEqual({ anny: 'type annotations must survive' })
+    expect(loaded?.path).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+  })
+
+  it('resolves defineI18nKitConfig without the package being installed', async () => {
+    // What a project written against the docs actually contains. jiti resolves
+    // the import to the running CLI, so an npx invocation works too.
+    await write('i18n-kit.config.ts', `
+      import { defineI18nKitConfig } from 'the-i18n-cli/config'
+      export default defineI18nKitConfig({ defaultLocale: 'fr' })
+    `)
+
+    const loaded = await loadTypedConfig(tmpDir)
+    expect(loaded?.config.defaultLocale).toBe('fr')
+  })
+
+  it('accepts a plain .js config', async () => {
+    await write('i18n-kit.config.js', `export default { defaultLocale: 'it' }`)
+    expect((await loadTypedConfig(tmpDir))?.config.defaultLocale).toBe('it')
+  })
+
+  it('rejects an unknown key rather than ignoring it', async () => {
+    await write('i18n-kit.config.ts', `export default { protectedLocals: ['de'] }`)
+    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocals/)
+  })
+
+  it('rejects a value the schema disallows', async () => {
+    await write('i18n-kit.config.ts', `export default { protectedLocales: [''] }`)
+    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocales/)
+  })
+
+  it('fails loudly when the config throws, naming the file', async () => {
+    // Deliberately not the framework-config rule of warn-and-fall-back: this
+    // file exists only for the kit, so ignoring it means silently applying
+    // none of the policy someone can see in their repository.
+    await write('i18n-kit.config.ts', `throw new Error('boom')`)
+    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts.*boom/s)
+  })
+
+  it('explains a config with no default export', async () => {
+    await write('i18n-kit.config.ts', `export const config = { defaultLocale: 'en' }`)
+    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/default export/)
+  })
+
+  it('explains a config that exports the function instead of calling it', async () => {
+    await write('i18n-kit.config.ts', `export default function config() { return {} }`)
+    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/do not pass it/)
+  })
+})
+
+describe('findTypedConfigFile', () => {
+  it('walks up to a parent directory, as .i18n-mcp.json does', async () => {
+    const child = resolve(tmpDir, 'apps/admin')
+    await mkdir(child, { recursive: true })
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
+
+    expect(findTypedConfigFile(child)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+  })
+
+  it('stops at the nearest one, so an app config shadows the root', async () => {
+    const child = resolve(tmpDir, 'apps/admin')
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'de' }`, child)
+
+    expect(findTypedConfigFile(child)).toBe(resolve(child, 'i18n-kit.config.ts'))
+  })
+
+  it('prefers .ts when a directory has several', async () => {
+    await write('i18n-kit.config.js', `export default { defaultLocale: 'js' }`)
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'ts' }`)
+
+    expect(findTypedConfigFile(tmpDir)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+  })
+})
+
+describe('loadProjectConfig with both config formats', () => {
+  it('merges disjoint keys from the two files', async () => {
+    await write('i18n-kit.config.ts', `export default { protectedLocales: ['de-formal'] }`)
+    await write('.i18n-mcp.json', JSON.stringify({ context: 'a booking product' }))
+
+    const config = await loadProjectConfig(tmpDir)
+    expect(config).toEqual({ context: 'a booking product', protectedLocales: ['de-formal'] })
+  })
+
+  it('refuses a key declared in both, naming the key and both files', async () => {
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
+    await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de' }))
+
+    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/defaultLocale/)
+    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts/)
+    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/\.i18n-mcp\.json/)
+  })
+
+  it('does not count the JSON-only $schema as a conflict', async () => {
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
+    await write('.i18n-mcp.json', JSON.stringify({ $schema: './schema.json', context: 'x' }))
+
+    const config = await loadProjectConfig(tmpDir)
+    expect(config?.defaultLocale).toBe('en')
+  })
+
+  it('returns the JSON config unchanged when there is no typed config', async () => {
+    await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de', protectedLocales: ['en'] }))
+
+    const config = await loadProjectConfig(tmpDir)
+    expect(config).toEqual({ defaultLocale: 'de', protectedLocales: ['en'] })
+  })
+
+  it('returns null when neither file exists', async () => {
+    await mkdir(resolve(tmpDir, 'nested'), { recursive: true })
+    expect(await loadProjectConfig(resolve(tmpDir, 'nested'))).toBeNull()
+  })
+})

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { resolve } from 'node:path'
+import { relative as relativePath, resolve } from 'node:path'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { loadTypedConfig, findTypedConfigFile } from '../../src/config/typed-config.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
@@ -110,6 +110,16 @@ describe('findTypedConfigFile', () => {
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'de' }`, child)
 
     expect(findTypedConfigFile(child)).toBe(resolve(child, 'i18n-kit.config.ts'))
+  })
+
+  it('resolves a relative start directory to an absolute config path', async () => {
+    // jiti reads a relative path as a bare module specifier, so a relative
+    // --projectDir used to make loading a typed config fail outright.
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
+    const relative = relativePath(process.cwd(), tmpDir)
+
+    expect(findTypedConfigFile(relative)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect((await loadTypedConfig(relative))?.config.defaultLocale).toBe('en')
   })
 
   it('prefers .ts when a directory has several', async () => {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     // while reading a project's vite.config, so it has to survive bundling as
     // a file. See config/framework/stubs/unplugin-vue-i18n.ts.
     'src/config/framework/stubs/unplugin-vue-i18n.ts',
+    'src/config/framework/stubs/next-intl-routing.ts',
   ],
   format: 'esm',
   target: 'node18',

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,19 +1,35 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/bin.ts'],
+  entry: [
+    'src/index.ts',
+    'src/bin.ts',
+    'src/define-config.ts',
+    // Its own entry because it is never imported — it is aliased to by path
+    // while reading a project's vite.config, so it has to survive bundling as
+    // a file. See config/framework/stubs/unplugin-vue-i18n.ts.
+    'src/config/framework/stubs/unplugin-vue-i18n.ts',
+  ],
   format: 'esm',
   target: 'node18',
   clean: true,
   dts: true,
   sourcemap: true,
   onSuccess: async () => {
-    // tsdown generates hashed .d.ts names — create a stable index.d.ts redirect
-    const { readdirSync, writeFileSync } = await import('node:fs')
+    // tsdown emits hashed .d.ts names; package.json points at stable ones, so
+    // write a redirect per entry. An entry can produce several hashed chunks —
+    // its own, plus shared ones it pulls in. The entry's own chunk is the one
+    // nothing else imports.
+    const { readdirSync, readFileSync, writeFileSync } = await import('node:fs')
     const files = readdirSync('dist')
-    const indexDts = files.find(f => f.startsWith('index-') && f.endsWith('.d.ts'))
-    if (indexDts) {
-      writeFileSync('dist/index.d.ts', `export * from './${indexDts}';\n`)
+    const dts = files.filter(f => f.endsWith('.d.ts'))
+    const contents = dts.map(f => readFileSync(`dist/${f}`, 'utf-8')).join('\n')
+
+    for (const entry of ['index', 'define-config']) {
+      const entryChunk = dts.find(f => f.startsWith(`${entry}-`) && !contents.includes(f.replace(/\.d\.ts$/, '.js')))
+      if (entryChunk) {
+        writeFileSync(`dist/${entry}.d.ts`, `export * from './${entryChunk}';\n`)
+      }
     }
   },
 })

--- a/packages/nuxt/src/policy.ts
+++ b/packages/nuxt/src/policy.ts
@@ -36,8 +36,8 @@ export interface I18nKitPolicy {
   /** Per-layer orphan-scan settings, keyed by layer name. */
   orphanScan?: Record<string, { ignorePatterns?: string[] }>
 
-  /** Where diagnostic reports are written: true for `.i18n-reports/`, or a path. */
-  reportOutput?: string | boolean
+  /** Where diagnostic reports are written: true for `.i18n-reports/`, or a path. Omit it for none. */
+  reportOutput?: string | true
 
   /** Override the detected locale file format. */
   localeFileFormat?: 'json' | 'php-array'

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,36 @@
+# Playgrounds
+
+One project per supported adapter, so that every detection and resolution path has somewhere real to be run against.
+
+| Directory | Adapter | Locale files | Reference locale comes from |
+|---|---|---|---|
+| [`nuxt`](./nuxt) | Nuxt | `i18n/locales/` per layer | `nuxt.config.ts`, via `@nuxtjs/i18n` |
+| [`react`](./react) | React / Next.js | `messages/` | `src/i18n/routing.ts` — next-intl |
+| [`vue`](./vue) | Vue | `src/translations/` | `i18n-kit.config.ts`; directories from `vite.config.ts` |
+| [`laravel`](./laravel) | Laravel | `lang/<locale>/*.php` | directory layout |
+| [`generic`](./generic) | Generic | `translations/` | `i18n-kit.config.ts` — the only source there is |
+
+```bash
+pnpm --filter the-i18n-cli build
+
+for p in nuxt react vue laravel generic; do
+  node packages/cli/dist/bin.js status --projectDir "playground/$p"
+done
+```
+
+Each one has a README explaining what it exists to prove.
+
+## Between them they cover every way the CLI can learn a project's locales
+
+1. **Declared by a person** — `i18n-kit.config.ts` (`vue`, `generic`) or `.i18n-mcp.json` (`nuxt`, `laravel`).
+2. **Published by a build** — `.nuxt/i18n-kit.json`, written by `@the-i18n-kit/nuxt` (`nuxt`).
+3. **Read from the framework's own config** — next-intl's routing file (`react`), the unplugin's `include` (`vue`).
+4. **Probed from directory layout** — the fallback, and all `laravel` needs.
+
+Each also has locales that are deliberately incomplete, so `missing`, `status` and `translate` have something to report rather than a uniform green.
+
+## Only `nuxt` is a workspace member
+
+It needs a real install: its config loads `@the-i18n-kit/nuxt`, and the E2E translate workflow builds and runs it.
+
+The rest are fixtures with no `node_modules`, which is why adding four of them costs CI nothing. They still contain the imports a real project would (`next-intl/routing`, `@intlify/unplugin-vue-i18n/vite`, `the-i18n-cli/config`), because the CLI substitutes what it cannot resolve — and prefers the real package wherever one is installed. Run `pnpm install` inside any of them and the output does not change.

--- a/playground/generic/README.md
+++ b/playground/generic/README.md
@@ -1,0 +1,26 @@
+# Generic playground
+
+A project with **no i18n framework at all** — plain JSON files loaded by hand — for exercising the generic adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/generic
+```
+
+## What it is here to prove
+
+There is nothing to detect and nothing to read: no `nuxt.config`, no `vite.config`, no `next.config`, not even a `package.json` dependency worth scoring. Everything the CLI knows comes from `i18n-kit.config.ts`:
+
+```ts
+export default defineI18nKitConfig({
+  localeDirs: ['translations'],
+  defaultLocale: 'en',
+})
+```
+
+`localeDirs` and `defaultLocale` together are what activate the generic adapter, and what let it outscore framework inference. Locale files live in `translations/`, which no adapter probes.
+
+This is the case the typed config matters most for, because it is the only source of truth there is. Previously it had to be untyped JSON — a misspelled `localeDirs` meant the adapter silently did not activate, and the CLI reported that it could not work out what kind of project this was.
+
+## Deliberately incomplete
+
+`booking` is absent from `nl` and partial in `fr`, and `app.tagline` is missing from `nl`, so `missing` and `status` have something to report.

--- a/playground/generic/i18n-kit.config.ts
+++ b/playground/generic/i18n-kit.config.ts
@@ -1,0 +1,22 @@
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
+/**
+ * There is no framework here to ask, so everything is declared. `localeDirs`
+ * plus `defaultLocale` is what activates the generic adapter — and what makes
+ * it win detection over any framework the dependencies might otherwise hint at.
+ */
+export default defineI18nKitConfig({
+  localeDirs: ['translations'],
+  defaultLocale: 'en',
+  context: 'A SaaS booking platform with no i18n framework — plain JSON files read at runtime.',
+  glossary: {
+    Booking: "Core concept. Never 'Reservation'.",
+    Resource: 'A bookable entity — a room, a desk, a person.',
+  },
+  translationPrompt: 'Professional but approachable. Preserve all {placeholders}. Keep translations concise.',
+  localeNotes: {
+    de: 'Informal German (du).',
+    fr: 'French.',
+    nl: 'Dutch.',
+  },
+})

--- a/playground/generic/src/app.js
+++ b/playground/generic/src/app.js
@@ -1,0 +1,13 @@
+import en from '../translations/en.json' with { type: 'json' }
+
+const messages = { en }
+const locale = 'en'
+
+/** Deliberately plain: no framework, no macro — just a lookup by dot path. */
+export function t(key) {
+  return key.split('.').reduce((node, part) => node?.[part], messages[locale]) ?? key
+}
+
+console.log(t('app.tagline'))
+console.log(t('common.actions.save'))
+console.log(t('booking.confirm'))

--- a/playground/generic/translations/de.json
+++ b/playground/generic/translations/de.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "tagline": "Buche alles, überall",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "success": "Erfolgreich gespeichert"
+    }
+  }
+}

--- a/playground/generic/translations/en.json
+++ b/playground/generic/translations/en.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "tagline": "Book anything, anywhere",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "success": "Successfully saved"
+    }
+  }
+}

--- a/playground/generic/translations/fr.json
+++ b/playground/generic/translations/fr.json
@@ -1,0 +1,19 @@
+{
+  "app": {
+    "tagline": "Réservez tout, partout",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Confirmer la réservation"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "success": "Enregistré avec succès"
+    }
+  }
+}

--- a/playground/generic/translations/nl.json
+++ b/playground/generic/translations/nl.json
@@ -1,0 +1,15 @@
+{
+  "app": {
+    "title": "Anny"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuleren",
+      "save": "Opslaan"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "success": "Succesvol opgeslagen"
+    }
+  }
+}

--- a/playground/laravel/lang/de/common.php
+++ b/playground/laravel/lang/de/common.php
@@ -8,6 +8,7 @@ return [
         'edit' => 'Bearbeiten',
         'create' => 'Erstellen',
         'back' => 'Zurück',
+        'duplicate' => 'Duplizieren',
     ],
     'messages' => [
         'success' => 'Vorgang erfolgreich abgeschlossen.',

--- a/playground/laravel/lang/en/common.php
+++ b/playground/laravel/lang/en/common.php
@@ -8,6 +8,7 @@ return [
         'edit' => 'Edit',
         'create' => 'Create',
         'back' => 'Back',
+        'duplicate' => 'Duplicate',
     ],
     'messages' => [
         'success' => 'Operation completed successfully.',

--- a/playground/react/README.md
+++ b/playground/react/README.md
@@ -1,0 +1,32 @@
+# React / Next.js playground
+
+A Next.js App Router project using **next-intl**, for exercising the React adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/react
+```
+
+## What it is here to prove
+
+`messages/` contains `de-DE`, `en-US`, `es-ES` and `fr-FR`. Alphabetically first is `de-DE` — and until the adapter could read a project's own config, that made German the reference locale of an English project purely by sorting order ([#296](https://github.com/fabkho/the-i18n-kit/issues/296)).
+
+`src/i18n/routing.ts` says otherwise, and is read:
+
+```ts
+export const routing = defineRouting({
+  locales: ['de-DE', 'en-US', 'es-ES', 'fr-FR'],
+  defaultLocale: 'en-US',
+})
+```
+
+So `status` reports `en-US` as the reference locale. Change `defaultLocale` there and the CLI follows it, with no `.i18n-mcp.json` involved.
+
+`next.config.mjs` is a realistic one — wrapped in `withNextIntl(...)`, so it cannot be executed without the dependencies installed. It is never reached: the routing file is more specifically about i18n and is read first. If you delete `src/i18n/routing.ts`, the CLI warns that it could not read `next.config.mjs` and falls back to directory order, which is the intended never-load-bearing behaviour rather than a failure.
+
+## No install required
+
+There is no `node_modules` here, deliberately — this is a fixture, not a workspace member, so it costs CI nothing. `defineRouting` returns its argument unchanged, so when next-intl cannot be resolved the CLI substitutes an identity stub and reads the file anyway. Run `pnpm add next-intl` inside this directory and the real package is preferred; the answer is identical either way.
+
+## Deliberately incomplete
+
+`booking.slotsLeft` exists only in `en-US` and `de-DE`, and the whole `booking` namespace is missing from `es-ES`, so `missing` and `status` have something to report.

--- a/playground/react/messages/de-DE.json
+++ b/playground/react/messages/de-DE.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "delete": "Löschen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "noData": "Keine Daten vorhanden",
+      "success": "Erfolgreich gespeichert"
+    },
+    "navigation": {
+      "back": "Zurück",
+      "home": "Startseite",
+      "settings": "Einstellungen"
+    }
+  },
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource",
+    "slotsLeft": "{count, plural, =0 {Keine Plätze frei} one {Ein Platz frei} other {# Plätze frei}}"
+  }
+}

--- a/playground/react/messages/en-US.json
+++ b/playground/react/messages/en-US.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "noData": "No data available",
+      "success": "Successfully saved"
+    },
+    "navigation": {
+      "back": "Back",
+      "home": "Home",
+      "settings": "Settings"
+    }
+  },
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource",
+    "slotsLeft": "{count, plural, =0 {No slots left} one {One slot left} other {# slots left}}"
+  }
+}

--- a/playground/react/messages/es-ES.json
+++ b/playground/react/messages/es-ES.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "save": "Guardar"
+    },
+    "messages": {
+      "loading": "Cargando...",
+      "noData": "No hay datos disponibles",
+      "success": "Guardado correctamente"
+    },
+    "navigation": {
+      "back": "Atrás",
+      "home": "Inicio",
+      "settings": "Ajustes"
+    }
+  }
+}

--- a/playground/react/messages/fr-FR.json
+++ b/playground/react/messages/fr-FR.json
@@ -1,0 +1,23 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "noData": "Aucune donnée disponible",
+      "success": "Enregistré avec succès"
+    },
+    "navigation": {
+      "back": "Retour",
+      "home": "Accueil",
+      "settings": "Paramètres"
+    }
+  },
+  "booking": {
+    "confirm": "Confirmer la réservation",
+    "resource": "Ressource"
+  }
+}

--- a/playground/react/next.config.mjs
+++ b/playground/react/next.config.mjs
@@ -1,0 +1,8 @@
+import createNextIntlPlugin from 'next-intl/plugin'
+
+const withNextIntl = createNextIntlPlugin()
+
+/** @type {import('next').NextConfig} */
+export default withNextIntl({
+  reactStrictMode: true,
+})

--- a/playground/react/package.json
+++ b/playground/react/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "the-i18n-kit/playground-react",
+  "private": true,
+  "type": "module",
+  "description": "Next.js App Router playground for the React adapter",
+  "dependencies": {
+    "next": "^15.0.0",
+    "next-intl": "^3.26.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/playground/react/src/app/page.tsx
+++ b/playground/react/src/app/page.tsx
@@ -1,0 +1,18 @@
+import { useTranslations } from 'next-intl'
+
+/**
+ * Here so the scanner has real call sites to find. `booking.slotsLeft` is used
+ * but only translated in two locales, which is what `missing` reports.
+ */
+export default function Home() {
+  const t = useTranslations()
+
+  return (
+    <main>
+      <h1>{t('common.navigation.home')}</h1>
+      <p>{t('booking.slotsLeft', { count: 3 })}</p>
+      <button type="button">{t('common.actions.save')}</button>
+      <button type="button">{t('booking.confirm')}</button>
+    </main>
+  )
+}

--- a/playground/react/src/i18n/routing.ts
+++ b/playground/react/src/i18n/routing.ts
@@ -1,0 +1,11 @@
+import { defineRouting } from 'next-intl/routing'
+
+/**
+ * The authoritative statement of this project's locales. The CLI reads this
+ * file rather than guessing from the contents of `messages/` — where the
+ * alphabetically first entry is `de-DE`, which is not the default locale.
+ */
+export const routing = defineRouting({
+  locales: ['de-DE', 'en-US', 'es-ES', 'fr-FR'],
+  defaultLocale: 'en-US',
+})

--- a/playground/vue/README.md
+++ b/playground/vue/README.md
@@ -1,0 +1,34 @@
+# Vue playground
+
+A Vue 3 SPA using **vue-i18n** and `@intlify/unplugin-vue-i18n`, for exercising the Vue adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/vue
+```
+
+## What it is here to prove
+
+**Locale files that probing would never find.** They live in `src/translations`, which is not one of the six directories the adapter guesses at (`src/locales`, `locales`, `src/i18n/locales`, `i18n/locales`, `src/plugins/i18n/locales`, `src/i18n`). Before the adapter could read a build config, this project simply failed with "no locale directory found".
+
+`vite.config.ts` says where they are, and that is read:
+
+```ts
+VueI18nPlugin({ include: [resolve(here, './src/translations/**')] })
+```
+
+The plugin keeps `include` in a closure — the object it returns is nothing but Vite hooks — so the CLI substitutes a stub that records the call. Nothing of the resolved Vite config is used beyond that one value.
+
+**Policy no Vue config can express.** `i18n-kit.config.ts` declares `defaultLocale: 'en-US'`, so the reference locale is English rather than `de-DE`, which is merely what the alphabet suggests. It marks `de-DE` as human-maintained so nothing machine-translates into it, and carries the glossary and tone notes. Being TypeScript, a misspelled key is an editor error rather than a line that quietly does nothing:
+
+```
+$ the-i18n-cli status --projectDir playground/vue --json | jq .summary.protectedLocales
+["de-DE"]
+```
+
+## No install required
+
+There is no `node_modules` here — this is a fixture, not a workspace member, so it costs CI nothing. The plugin is substituted rather than imported, and `the-i18n-cli/config` resolves to the running CLI, so both files are read as they are.
+
+## Deliberately incomplete
+
+The `booking` namespace is missing entirely from `es-ES` and partly from `fr-FR`, so `missing` and `status` have something to report.

--- a/playground/vue/i18n-kit.config.ts
+++ b/playground/vue/i18n-kit.config.ts
@@ -1,0 +1,28 @@
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
+/**
+ * The half no config file of Vue's can state: which locale is the source of
+ * truth, and how the product wants to be translated.
+ *
+ * `vite.config.ts` says where the files are; this says what to do with them.
+ * Typed, so a misspelled key is an editor error rather than a silently
+ * ignored one.
+ */
+export default defineI18nKitConfig({
+  defaultLocale: 'en-US',
+  context: 'A SaaS booking platform. Vue 3 SPA with vue-i18n.',
+  glossary: {
+    Booking: "Core concept. Never 'Reservation'.",
+    Resource: 'A bookable entity — a room, a desk, a person.',
+  },
+  translationPrompt: 'Professional but approachable. Preserve all {placeholders}. Keep translations concise.',
+  localeNotes: {
+    'de-DE': 'Informal German (du). Maintained by hand.',
+    'fr-FR': 'French.',
+    'es-ES': 'Spanish.',
+  },
+  // German is written by a person here, so nothing may machine-translate into
+  // it. Address a protected locale by its `code`: a ref matching nothing is
+  // the mistake this file being typed is meant to catch.
+  protectedLocales: ['de-DE'],
+})

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "the-i18n-kit/playground-vue",
+  "private": true,
+  "type": "module",
+  "description": "Vue 3 + vite playground for the Vue adapter",
+  "dependencies": {
+    "vue": "^3.5.30",
+    "vue-i18n": "^11.1.0"
+  },
+  "devDependencies": {
+    "@intlify/unplugin-vue-i18n": "^6.0.0",
+    "@vitejs/plugin-vue": "^5.2.0",
+    "vite": "^7.3.0"
+  }
+}

--- a/playground/vue/src/App.vue
+++ b/playground/vue/src/App.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <main>
+    <h1>{{ $t('common.navigation.home') }}</h1>
+    <p>{{ $t('booking.upcoming') }}</p>
+    <button type="button">
+      {{ t('common.actions.save') }}
+    </button>
+    <button type="button">
+      {{ t('booking.confirm') }}
+    </button>
+  </main>
+</template>

--- a/playground/vue/src/translations/de-DE.json
+++ b/playground/vue/src/translations/de-DE.json
@@ -1,0 +1,24 @@
+{
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource",
+    "upcoming": "Anstehende Buchungen"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "delete": "Löschen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "noData": "Keine Daten vorhanden",
+      "success": "Erfolgreich gespeichert"
+    },
+    "navigation": {
+      "back": "Zurück",
+      "home": "Startseite",
+      "settings": "Einstellungen"
+    }
+  }
+}

--- a/playground/vue/src/translations/en-US.json
+++ b/playground/vue/src/translations/en-US.json
@@ -1,0 +1,24 @@
+{
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource",
+    "upcoming": "Upcoming bookings"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "noData": "No data available",
+      "success": "Successfully saved"
+    },
+    "navigation": {
+      "back": "Back",
+      "home": "Home",
+      "settings": "Settings"
+    }
+  }
+}

--- a/playground/vue/src/translations/es-ES.json
+++ b/playground/vue/src/translations/es-ES.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "save": "Guardar"
+    },
+    "messages": {
+      "loading": "Cargando...",
+      "noData": "No hay datos disponibles",
+      "success": "Guardado correctamente"
+    },
+    "navigation": {
+      "back": "Atrás",
+      "home": "Inicio",
+      "settings": "Ajustes"
+    }
+  }
+}

--- a/playground/vue/src/translations/fr-FR.json
+++ b/playground/vue/src/translations/fr-FR.json
@@ -1,0 +1,23 @@
+{
+  "booking": {
+    "confirm": "Confirmer la réservation",
+    "resource": "Ressource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "noData": "Aucune donnée disponible",
+      "success": "Enregistré avec succès"
+    },
+    "navigation": {
+      "back": "Retour",
+      "home": "Accueil",
+      "settings": "Paramètres"
+    }
+  }
+}

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * `include` is the authoritative statement of where the locale files live —
+ * and `src/translations` is deliberately not one of the directories the
+ * adapter would otherwise probe.
+ */
+export default {
+  plugins: [
+    VueI18nPlugin({
+      include: [resolve(here, './src/translations/**')],
+    }),
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       openai:
         specifier: ^4.0.0 || ^5.0.0
         version: 5.23.2(ws@8.19.0)(zod@4.3.6)
@@ -118,13 +121,13 @@ importers:
         version: 22.19.15
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2)
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
 
   playground/nuxt:
     dependencies:
@@ -3537,10 +3540,6 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
-
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -5859,12 +5858,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 10.1.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-    optional: true
-
   '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.7.0))':
     dependencies:
       eslint: 10.1.0(jiti@2.7.0)
@@ -6166,7 +6159,7 @@ snapshots:
       fuse.js: 7.1.0
       fzf: 0.5.2
       giget: 3.1.2
-      jiti: 2.6.1
+      jiti: 2.7.0
       listhen: 1.9.0
       nypm: 0.6.5
       ofetch: 1.5.1
@@ -6192,14 +6185,6 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      execa: 8.0.1
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - magicast
-
   '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -6218,47 +6203,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       semver: 7.7.4
-
-  '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-      '@nuxt/devtools-wizard': 3.2.4
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vue/devtools-core': 8.1.0(vue@3.5.30(typescript@5.9.3))
-      '@vue/devtools-kit': 8.1.0
-      birpc: 4.0.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 1.0.5
-      execa: 8.0.1
-      fast-npm-meta: 1.4.2
-      get-port-please: 3.2.0
-      hookable: 6.1.0
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.13.1
-      local-pkg: 1.1.2
-      magicast: 0.5.2
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.0
-      semver: 7.7.4
-      simple-git: 3.33.0
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      which: 6.0.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - vue
 
   '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -6310,7 +6254,7 @@ snapshots:
       errx: 0.1.0
       exsolve: 1.0.8
       ignore: 7.0.5
-      jiti: 2.6.1
+      jiti: 2.7.0
       klona: 2.0.6
       mlly: 1.8.2
       ohash: 2.0.11
@@ -6352,75 +6296,6 @@ snapshots:
       - sass
       - vue
       - vue-tsc
-
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.0-rc.10)(typescript@5.9.3)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.9
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.2(rolldown@1.0.0-rc.10)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2)
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unstorage: 1.17.4(db0@0.3.4)(ioredis@5.10.1)
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
 
   '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.0-rc.10)(typescript@5.9.3)':
     dependencies:
@@ -6508,67 +6383,6 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.15)(eslint@10.1.0(jiti@2.6.1))(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      autoprefixer: 10.4.27(postcss@8.5.8)
-      consola: 3.4.2
-      cssnano: 7.1.3(postcss@8.5.8)
-      defu: 6.1.4
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.6.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2)
-      nypm: 0.6.5
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      postcss: 8.5.8
-      seroval: 1.5.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@10.1.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.0.0-rc.10
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
   '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.15)(eslint@10.1.0(jiti@2.7.0))(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -6582,7 +6396,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
       get-port-please: 3.2.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
@@ -6596,8 +6410,8 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
+      vite-node: 5.3.0(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
       vite-plugin-checker: 0.12.0(eslint@10.1.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))
       vue: 3.5.30(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
@@ -7456,18 +7270,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.10
-      '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vue: 3.5.30(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -7479,12 +7281,6 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vue: 3.5.30(typescript@5.9.3)
 
   '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -7499,14 +7295,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
@@ -7909,7 +7697,7 @@ snapshots:
       dotenv: 17.3.1
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -8070,7 +7858,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      jiti: 2.6.1
+      jiti: 2.7.0
       typescript: 5.9.3
 
   cosmiconfig@9.0.1(typescript@5.9.3):
@@ -8393,44 +8181,6 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@5.0.1: {}
-
-  eslint@10.1.0(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.3
-      '@eslint/config-helpers': 0.5.3
-      '@eslint/core': 1.1.1
-      '@eslint/plugin-kit': 0.6.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.4
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   eslint@10.1.0(jiti@2.7.0):
     dependencies:
@@ -9013,8 +8763,6 @@ snapshots:
 
   jiti@1.21.7: {}
 
-  jiti@2.6.1: {}
-
   jiti@2.7.0: {}
 
   jose@6.2.2: {}
@@ -9109,7 +8857,7 @@ snapshots:
       get-port-please: 3.2.0
       h3: 1.15.9
       http-shutdown: 1.2.2
-      jiti: 2.6.1
+      jiti: 2.7.0
       mlly: 1.8.2
       node-forge: 1.3.3
       pathe: 1.1.2
@@ -9331,7 +9079,7 @@ snapshots:
       hookable: 5.5.3
       httpxy: 0.3.1
       ioredis: 5.10.1
-      jiti: 2.6.1
+      jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
       listhen: 1.9.0
@@ -9444,136 +9192,6 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2):
-    dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.0-rc.10)(typescript@5.9.3)
-      '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.15)(eslint@10.1.0(jiti@2.6.1))(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.0
-      defu: 6.1.4
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.0
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.117.0
-      oxc-parser: 0.117.0
-      oxc-transform: 0.117.0
-      oxc-walker: 0.7.0(oxc-parser@0.117.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.0.0
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.0.2
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.30(typescript@5.9.3)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.9.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 22.19.15
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
   nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.1.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
@@ -9599,7 +9217,7 @@ snapshots:
       hookable: 6.1.0
       ignore: 7.0.5
       impound: 1.1.5
-      jiti: 2.6.1
+      jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
       magic-string: 0.30.21
@@ -10785,7 +10403,7 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       defu: 6.1.4
-      jiti: 2.6.1
+      jiti: 2.7.0
       quansync: 1.0.0
       unconfig-core: 7.5.0
 
@@ -10906,7 +10524,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       defu: 6.1.4
-      jiti: 2.6.1
+      jiti: 2.7.0
       knitwork: 1.3.0
       scule: 1.3.0
 
@@ -10936,46 +10554,15 @@ snapshots:
   vary@1.1.2:
     optional: true
 
-  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)):
-    dependencies:
-      birpc: 2.9.0
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-
   vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
       birpc: 2.9.0
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
       vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))
 
-  vite-hot-client@2.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)):
-    dependencies:
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-
   vite-hot-client@2.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
-
-  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vite-node@3.2.4(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
@@ -10998,13 +10585,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@5.3.0(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2):
+  vite-node@5.3.0(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -11017,23 +10604,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-plugin-checker@0.12.0(eslint@10.1.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      chokidar: 4.0.3
-      npm-run-path: 6.0.0
-      picocolors: 1.1.1
-      picomatch: 4.0.3
-      tiny-invariant: 1.3.3
-      tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      eslint: 10.1.0(jiti@2.6.1)
-      meow: 13.2.0
-      optionator: 0.9.4
-      typescript: 5.9.3
 
   vite-plugin-checker@0.12.0(eslint@10.1.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
@@ -11052,23 +10622,6 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)):
-    dependencies:
-      ansis: 4.2.0
-      debug: 4.4.3
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.1
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-    optionalDependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
@@ -11086,16 +10639,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
-    dependencies:
-      estree-walker: 3.0.3
-      exsolve: 1.0.8
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      source-map-js: 1.2.1
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vue: 3.5.30(typescript@5.9.3)
-
   vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
@@ -11105,21 +10648,6 @@ snapshots:
       source-map-js: 1.2.1
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2)
       vue: 3.5.30(typescript@5.9.3)
-
-  vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.15
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.1
-      yaml: 2.8.2
 
   vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
@@ -11135,47 +10663,6 @@ snapshots:
       jiti: 2.7.0
       terser: 5.46.1
       yaml: 2.8.2
-
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.15
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
Implements #324. Closes #296.

The kit had one place to declare configuration — `.i18n-mcp.json` — and it was untyped JSON, while everything it *could* have derived was guessed differently in every adapter. Both halves have the same cause: the CLI could not execute TypeScript, so config had to be JSON and framework config files could only be pattern-matched. jiti (2.7.0, zero dependencies) removes both limits.

## The declared half

`i18n-kit.config.ts` — also `.mts`, `.js`, `.mjs`, `.cjs` — loaded with **no build step**:

```ts
import { defineI18nKitConfig } from 'the-i18n-cli/config'

export default defineI18nKitConfig({
  defaultLocale: 'en',
  protectedLocales: ['de-formal'],
  glossary: { anny: 'Brand name. NEVER translate.' },
})
```

No build step is the point, not a detail. It is the difference between policy that always applies and policy that applies once something has been built — **the question #322 left open**: policy declared only in `nuxt.config.ts` reaches the CLI through the build artifact, so an unbuilt checkout does not apply it. Harmless for `glossary`; for `protectedLocales` it means translating a locale marked protected. This removes the need for the marker file that was the proposed mitigation.

And a misspelled `protectedLocals` is now a red squiggle rather than a key that silently protects nothing — which is how `de-DE-formal` sat in a config for months appearing to protect formal German while it was machine-translated.

Every adapter funnels through `loadProjectConfig`, so teaching that one function about the new file covers all of them rather than whichever one was remembered.

- **A key declared in both files is an error naming both**, not a merge. Silent precedence between two hand-written sources is what this ends.
- `defineI18nKitConfig` ships as `the-i18n-cli/config`, and jiti resolves that specifier to the running CLI — so a config file written against the docs works under `npx` in a project that never installed the package.

## The derived half

Where a project already declares its locales, read it instead of guessing:

| Setup | Read from | Gives |
|---|---|---|
| next-intl | `src/i18n/routing.ts` | `locales`, `defaultLocale` |
| next-translate | `i18n.js` | `locales`, `defaultLocale` |
| Pages Router | `next.config.{ts,js,mjs}` | `locales`, `defaultLocale` |
| Vue + `@intlify/unplugin-vue-i18n` | `vite.config.{ts,js}` `include` | locale directories |

Ordered most-specifically-about-i18n first, which also puts the file likeliest to throw last.

So React no longer takes the alphabetically first file in `messages/` as the default locale, and neither React nor Vue ignores a declared `defaultLocale` any more — **that was #296, from both directions**: the adapters were not ignoring a value, they had no way to read one, *and* they never consulted the one place it could already be written down.

## Two things worth reviewing

**A broken `i18n-kit.config.ts` throws; a broken framework config warns.** These look inconsistent and are deliberate. `next.config.js` belongs to another tool and is wrapped in `withNextIntl(...)` / `withSentryConfig(...)` — failing to read it means falling back to a guess, so it warns and falls back, the rule `config/artifact.ts` already follows. `i18n-kit.config.ts` exists only for the kit: carrying on without it means silently applying none of the policy someone can see in their repository, which is the exact failure this PR exists to end. Easy to flip if you disagree.

**Reading `include` needs a stub.** The plugin keeps `include` in a closure and the object it returns is all Vite hooks — verified against the installed package. So the plugin is aliased to a recorder that ships as its own build entry. `defineRouting` needed no such trick: it returns its argument.

Executing someone else's config happens in `resolve()` only, **never in `detect()`**, which runs against every project the CLI is pointed at.

## Also

The zod schema moves to `config/schema.ts`, shared by both loaders, with a type-level guard that fails the build if it and `ProjectConfig` drift. Verified by deliberately drifting it — the error names the offending key. That is two of the three definitions unified; `I18nKitPolicy` in `packages/nuxt` stays separate, since sharing it would mean a Nuxt module depending on the CLI.

## Verification

- All seven acceptance criteria in #324 met.
- **Byte-identical output** (`status --json`, `missing --json`) against a 30-locale, 7-app project with neither config file present.
- That diff caught a real bug mid-PR: `loadProjectConfig` returning a wrapper object, silently disabling all `.i18n-mcp.json` policy. A full typecheck and 937 passing tests missed it.
- 38 new tests; 1043 pass. `fallow audit` exits 0.

`scan --json` could not be used for the no-op diff because its output order is nondeterministic — filed separately as #327, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for typed project configuration through `i18n-kit.config.ts`, with JavaScript and TypeScript variants.
  - Added a configuration helper and public package export for typed configuration.
  - Added automatic locale discovery from Next.js and Vue i18n framework configuration.
  - Added support for merging JSON and typed configuration, with clear errors for conflicting settings.

- **Documentation**
  - Expanded CLI documentation covering configuration discovery, supported file formats, fallback behavior, and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->