### PR TITLE
test(playground): a project per adapter

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -293,6 +293,8 @@ These files are executed, so a `next.config.js` wrapped in `withNextIntl(...)` o
 A value you declare yourself always wins over both. To pin the reference locale regardless of what any framework config says:
 
 ```ts
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
 export default defineI18nKitConfig({
   defaultLocale: 'en',
   localeDirs: ['src/locales'],

--- a/packages/cli/src/adapters/vue/index.ts
+++ b/packages/cli/src/adapters/vue/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import type { FrameworkAdapter, LocaleFileFormat } from '../types'
 import type { I18nConfig, LocaleDefinition } from '../../config/types'
 import { loadProjectConfig } from '../../config/project-config'
@@ -53,21 +53,31 @@ export class VueAdapter implements FrameworkAdapter {
   async resolve(projectDir: string): Promise<I18nConfig> {
     const projectConfig = await loadProjectConfig(projectDir)
 
-    const localeDir = await resolveLocaleDir(projectDir)
-    const discovered = await requireLocales(localeDir)
+    const dirs = await resolveLocaleDirs(projectDir)
+    const discovered = await requireLocales(dirs)
     const locales = applyLocaleOverride(discovered, projectConfig?.locales)
 
     // Declared beats discovered. Falling through to the first locale is
     // alphabetical order dressed up as a decision (#296).
     const defaultLocale = projectConfig?.defaultLocale ?? locales[0]?.code ?? discovered[0].code
 
-    return buildSingleDirConfig({
-      projectDir,
-      localeDir,
+    // One directory keeps the shape it has always had, layer name and all.
+    if (dirs.length === 1) {
+      return buildSingleDirConfig({ projectDir, localeDir: dirs[0]!, defaultLocale, locales, projectConfig })
+    }
+
+    const localeDirs = dirs.map(path => ({ path, layer: layerNameFor(path, dirs), layerRootDir: projectDir }))
+
+    return {
+      rootDir: projectDir,
       defaultLocale,
+      fallbackLocale: { default: [defaultLocale] },
       locales,
-      projectConfig,
-    })
+      localeDirs,
+      layerRootDirs: [projectDir],
+      ...(projectConfig ? { projectConfig } : {}),
+      apps: [{ name: 'default', rootDir: projectDir, layers: localeDirs.map(d => d.layer) }],
+    }
   }
 }
 
@@ -105,21 +115,46 @@ async function computeScore(projectDir: string, deps: Record<string, unknown>): 
  * ahead of what the source looks like it means. `include` *is* where the
  * locale files are, by definition; the candidate list is a guess about where
  * people tend to put them.
+ *
+ * All of `include` is kept, not just the first entry — it is an array because
+ * projects do split their messages across directories, and dropping the rest
+ * would silently hide every key in them.
  */
-async function resolveLocaleDir(projectDir: string): Promise<string> {
+async function resolveLocaleDirs(projectDir: string): Promise<string[]> {
   const fromPlugin = await readVueI18nLocaleDirs(projectDir)
-  const localeDir = fromPlugin?.[0] ?? await findLocaleDir(projectDir)
+  if (fromPlugin?.length) return fromPlugin
+
+  const localeDir = await findLocaleDir(projectDir)
   if (!localeDir) throw noLocaleDirError(projectDir, COMMON_LOCALE_DIRS)
-  return localeDir
+  return [localeDir]
 }
 
-/** The locales in a directory, or an explanation of why there are none. */
-async function requireLocales(localeDir: string): Promise<[LocaleDefinition, ...LocaleDefinition[]]> {
-  const locales = await discoverLocales(localeDir)
+/**
+ * A layer name per directory: its own name, or enough of its path to tell it
+ * apart from a sibling of the same name (`messages` and `admin/messages`).
+ */
+function layerNameFor(path: string, all: string[]): string {
+  const name = basename(path)
+  const ambiguous = all.filter(other => basename(other) === name).length > 1
+  return ambiguous ? `${basename(dirname(path))}/${name}` : name
+}
+
+/** The locales across every directory, or an explanation of why there are none. */
+async function requireLocales(localeDirs: string[]): Promise<[LocaleDefinition, ...LocaleDefinition[]]> {
+  const byCode = new Map<string, LocaleDefinition>()
+  for (const dir of localeDirs) {
+    for (const locale of await discoverLocales(dir)) {
+      // First directory to define a locale owns its file name; the rest add
+      // their keys to it, the way a layer does.
+      if (!byCode.has(locale.code)) byCode.set(locale.code, locale)
+    }
+  }
+
+  const locales = [...byCode.values()]
   const [first] = locales
   if (first === undefined) {
     throw new ConfigError(
-      `No JSON locale files found in ${localeDir}. `
+      `No JSON locale files found in ${localeDirs.join(', ')}. `
       + 'Make sure your Vue i18n project has locale files like en.json, de.json etc.',
     )
   }

--- a/packages/cli/src/config/framework/execute.ts
+++ b/packages/cli/src/config/framework/execute.ts
@@ -15,6 +15,7 @@
  */
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { toErrorMessage } from '../../utils/errors.js'
 import { log } from '../../utils/logger.js'
 
@@ -55,6 +56,27 @@ export async function executeConfig(
 export function firstExisting(projectDir: string, candidates: readonly string[]): string | null {
   for (const candidate of candidates) {
     const path = resolve(projectDir, candidate)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+/**
+ * Locate one of the stub modules in `./stubs/`, as a path jiti can be aliased
+ * to. Returns null when it cannot be found, which leaves normal resolution in
+ * place.
+ *
+ * A stub has to survive the build as a *file* — it is referred to by path and
+ * never imported, so it is declared as its own tsdown entry rather than
+ * bundled. That gives it two possible homes, and this resolves against the
+ * location of this module, which sits beside `stubs/` in the source tree and
+ * at the root of `dist/` in the bundle.
+ */
+export function resolveStub(name: string): string | null {
+  const candidates = [`./stubs/${name}.ts`, `./config/framework/stubs/${name}.js`]
+
+  for (const candidate of candidates) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url))
     if (existsSync(path)) return path
   }
   return null

--- a/packages/cli/src/config/framework/next.ts
+++ b/packages/cli/src/config/framework/next.ts
@@ -6,7 +6,8 @@
  * that the default locale, so `{de,en,fr}.json` made German the source of
  * truth for an English project (#296).
  */
-import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting } from './execute.js'
+import { createRequire } from 'node:module'
+import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting, resolveStub } from './execute.js'
 import { log } from '../../utils/logger.js'
 
 /** next-intl: `defineRouting({ locales, defaultLocale })`, usually re-exported as `routing`. */
@@ -62,15 +63,15 @@ export async function readNextI18n(projectDir: string): Promise<NextI18n | null>
 
 /**
  * next-intl. `defineRouting` returns the object it was handed, so the exported
- * routing object carries `locales` and `defaultLocale` without the plugin
- * having to be stubbed — the package is installed in any project that has one
- * of these files.
+ * routing object carries `locales` and `defaultLocale` verbatim — which is why
+ * substituting it (only when it is missing; see `routingAlias`) cannot change
+ * the answer.
  */
 async function readRouting(projectDir: string): Promise<NextI18n | null> {
   const path = firstExisting(projectDir, ROUTING_FILES)
   if (!path) return null
 
-  const module = await executeConfig(path)
+  const module = await executeConfig(path, { alias: routingAlias(path) })
   if (!module) return null
 
   // `export const routing = defineRouting(...)` is what the docs show, but a
@@ -87,6 +88,37 @@ async function readRouting(projectDir: string): Promise<NextI18n | null> {
   }
 
   return null
+}
+
+/**
+ * Substitute `defineRouting` only when the real one cannot be found from the
+ * routing file's own location.
+ *
+ * The real package always wins where it is installed — it is the authority on
+ * its own API, and a substitution that silently shadowed it would be the kind
+ * of quiet divergence this whole line of work is about. The stub is purely a
+ * rescue for the case where the file exists and its dependencies do not, which
+ * is a fresh clone, a CI job that skipped install, or a fixture. Reading a
+ * declaration should not require a `node_modules` to be present.
+ */
+function routingAlias(routingPath: string): Record<string, string> | undefined {
+  if (resolvableFrom('next-intl/routing', routingPath)) return undefined
+
+  const path = resolveStub('next-intl-routing')
+  if (!path) return undefined
+
+  log.debug(`next-intl is not installed for ${routingPath} — reading it with a stubbed defineRouting`)
+  return { 'next-intl/routing': path }
+}
+
+function resolvableFrom(specifier: string, fromFile: string): boolean {
+  try {
+    createRequire(fromFile).resolve(specifier)
+    return true
+  }
+  catch {
+    return false
+  }
 }
 
 /** next-translate's `i18n.js`, a plain object of `{ locales, defaultLocale, pages }`. */

--- a/packages/cli/src/config/framework/next.ts
+++ b/packages/cli/src/config/framework/next.ts
@@ -8,6 +8,7 @@
  */
 import { createRequire } from 'node:module'
 import { asObject, asString, asStringArray, defaultExport, executeConfig, firstExisting, resolveStub } from './execute.js'
+import { toErrorMessage } from '../../utils/errors.js'
 import { log } from '../../utils/logger.js'
 
 /** next-intl: `defineRouting({ locales, defaultLocale })`, usually re-exported as `routing`. */
@@ -111,6 +112,28 @@ function routingAlias(routingPath: string): Record<string, string> | undefined {
   return { 'next-intl/routing': path }
 }
 
+/**
+ * `next.config.js` may export `(phase, { defaultConfig }) => config`, sync or
+ * async, which Next.js calls for you. An uncalled function is not a config, so
+ * without this the `i18n` block of every project using that form is invisible.
+ *
+ * A function that throws yields nothing, like any other unreadable config.
+ */
+async function resolveConfigExport(exported: unknown, path: string): Promise<unknown> {
+  if (typeof exported !== 'function') return exported
+
+  try {
+    return await (exported as (phase: string, context: unknown) => unknown)(
+      'phase-production-build',
+      { defaultConfig: {} },
+    )
+  }
+  catch (error) {
+    log.warn(`Could not evaluate the config function in ${path}: ${toErrorMessage(error)}`)
+    return undefined
+  }
+}
+
 function resolvableFrom(specifier: string, fromFile: string): boolean {
   try {
     createRequire(fromFile).resolve(specifier)
@@ -151,7 +174,7 @@ async function readNextConfig(projectDir: string): Promise<NextI18n | null> {
   const module = await executeConfig(path)
   if (!module) return null
 
-  const config = asObject(defaultExport(module))
+  const config = asObject(await resolveConfigExport(defaultExport(module), path))
   const i18n = config && asObject(config.i18n)
   if (!i18n) return null
 

--- a/packages/cli/src/config/framework/stubs/next-intl-routing.ts
+++ b/packages/cli/src/config/framework/stubs/next-intl-routing.ts
@@ -1,0 +1,19 @@
+/**
+ * A stand-in for `next-intl/routing`, used only when the real package cannot
+ * be resolved from the config file being read.
+ *
+ * `defineRouting` returns the object it is given, so a routing file's
+ * `locales` and `defaultLocale` survive this substitution untouched — which is
+ * the only reason it is safe. It exists so that reading a routing file does
+ * not require the project's dependencies to be installed: a fresh clone, a CI
+ * lint job, or a playground fixture has a `routing.ts` long before it has a
+ * `node_modules`.
+ *
+ * The real package is preferred whenever it resolves. See `resolvableFrom` in
+ * ../next.ts.
+ */
+export function defineRouting<T>(config: T): T {
+  return config
+}
+
+export default defineRouting

--- a/packages/cli/src/config/framework/vue.ts
+++ b/packages/cli/src/config/framework/vue.ts
@@ -8,8 +8,7 @@
  */
 import { existsSync, statSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { asObject, executeConfig, firstExisting } from './execute.js'
+import { asObject, executeConfig, firstExisting, resolveStub } from './execute.js'
 import { log } from '../../utils/logger.js'
 
 /**
@@ -47,6 +46,22 @@ export async function readVueI18nLocaleDirs(projectDir: string): Promise<string[
   const path = firstExisting(projectDir, VITE_CONFIG_FILES)
   if (!path) return null
 
+  // Answers are remembered per config file because the file itself can only be
+  // executed once: Node caches an ES module by URL for the life of the
+  // process, so a second read would import the cache, call no plugin, record
+  // nothing, and quietly report that this project declares no locale
+  // directories. Resolving the same project twice has to give the same answer.
+  const remembered = answers.get(path)
+  if (remembered !== undefined) return remembered
+
+  const dirs = await readInclude(path)
+  answers.set(path, dirs)
+  return dirs
+}
+
+const answers = new Map<string, string[] | null>()
+
+async function readInclude(path: string): Promise<string[] | null> {
   const globalScope = globalThis as Record<symbol, unknown>
   delete globalScope[RECORDED]
 
@@ -123,16 +138,7 @@ function isDirectory(path: string): boolean {
  * gives up rather than executing a config for no reason.
  */
 function stubAlias(): Record<string, string> | null {
-  // Running from source this file sits next to `stubs/`; in the bundle it is
-  // a chunk at the root of `dist/`, and the stub is emitted as its own entry
-  // under the path it has in `src/`.
-  for (const candidate of [
-    './stubs/unplugin-vue-i18n.ts',
-    './config/framework/stubs/unplugin-vue-i18n.js',
-  ]) {
-    const path = fileURLToPath(new URL(candidate, import.meta.url))
-    if (!existsSync(path)) continue
-    return Object.fromEntries(PLUGIN_SPECIFIERS.map(specifier => [specifier, path]))
-  }
-  return null
+  const path = resolveStub('unplugin-vue-i18n')
+  if (!path) return null
+  return Object.fromEntries(PLUGIN_SPECIFIERS.map(specifier => [specifier, path]))
 }

--- a/packages/cli/src/config/framework/vue.ts
+++ b/packages/cli/src/config/framework/vue.ts
@@ -116,7 +116,10 @@ function includeToDirs(include: unknown, configDir: string): string[] {
 
 /** Everything before the first glob segment: `src/locales/**\/*.json` → `src/locales`. */
 function globRoot(pattern: string): string | undefined {
-  const segments = pattern.split('/')
+  // `resolve()` in a vite.config produces backslashes on Windows, and a
+  // backslash path split on '/' is one segment containing the wildcard —
+  // which would discard the directory entirely.
+  const segments = pattern.replace(/\\/g, '/').split('/')
   const wildcard = segments.findIndex(s => s.includes('*') || s.includes('?') || s.includes('['))
   const kept = wildcard === -1 ? segments.slice(0, -1) : segments.slice(0, wildcard)
   return kept.length > 0 ? kept.join('/') : undefined

--- a/packages/cli/src/config/project-config.ts
+++ b/packages/cli/src/config/project-config.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import type { ProjectConfig } from './types.js'
-import { validateProjectConfig } from './schema.js'
+import { dropDeprecatedKeys, validateProjectConfig } from './schema.js'
 import { loadTypedConfig } from './typed-config.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
@@ -123,14 +123,5 @@ async function loadJsonConfig(
 
   log.debug(`Project config loaded successfully from ${configPath}`)
 
-  const data = result.data as ProjectConfig & { samplingPreferences?: unknown }
-  if ('samplingPreferences' in data) {
-    log.warn(
-      `${CONFIG_FILENAME}: "samplingPreferences" is deprecated and ignored — `
-      + 'MCP sampling was removed. Configure a provider (e.g. I18N_PROVIDER/I18N_MODEL) instead.',
-    )
-    delete data.samplingPreferences
-  }
-
-  return { path: configPath, config: data }
+  return { path: configPath, config: dropDeprecatedKeys(result.data, CONFIG_FILENAME) }
 }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -9,6 +9,7 @@
  */
 import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
+import { log } from '../utils/logger.js'
 
 const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
 
@@ -39,8 +40,8 @@ const projectConfigSchema = z.object({
     ignorePatterns: z.array(z.string()).optional(),
   }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
   localeDirs: z.array(localeDirEntrySchema).optional(),
-  defaultLocale: z.string().optional(),
-  locales: z.array(z.string()).optional(),
+  defaultLocale: nonEmptyString.optional(),
+  locales: z.array(nonEmptyString).optional(),
   protectedLocales: z.array(nonEmptyString).optional(),
   reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
   localeFileFormat: z.enum(['json', 'php-array']).optional(),
@@ -69,6 +70,25 @@ export function validateProjectConfig(
     })
     .join('\n')
   return { ok: false, error }
+}
+
+/**
+ * Strip the deprecated keys the schema still accepts, warning once, so that a
+ * config keeps validating without the value going on to mean anything. Applied
+ * by every loader — a key ignored in `.i18n-mcp.json` but silently honoured in
+ * `i18n-kit.config.ts` would be exactly the divergence this file exists to
+ * prevent.
+ */
+export function dropDeprecatedKeys(config: ProjectConfig, source: string): ProjectConfig {
+  const data = config as ProjectConfig & { samplingPreferences?: unknown }
+  if ('samplingPreferences' in data) {
+    log.warn(
+      `${source}: "samplingPreferences" is deprecated and ignored — `
+      + 'MCP sampling was removed. Configure a provider (e.g. I18N_PROVIDER/I18N_MODEL) instead.',
+    )
+    delete data.samplingPreferences
+  }
+  return data
 }
 
 // ─── Drift guard ────────────────────────────────────────────────

--- a/packages/cli/src/config/typed-config.ts
+++ b/packages/cli/src/config/typed-config.ts
@@ -11,7 +11,7 @@ import { existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ProjectConfig } from './types.js'
-import { validateProjectConfig } from './schema.js'
+import { dropDeprecatedKeys, validateProjectConfig } from './schema.js'
 import { ConfigError, toErrorMessage } from '../utils/errors.js'
 import { log } from '../utils/logger.js'
 
@@ -26,6 +26,7 @@ const TYPED_CONFIG_FILENAMES = [
   'i18n-kit.config.js',
   'i18n-kit.config.mjs',
   'i18n-kit.config.cjs',
+  'i18n-kit.config.cts',
 ] as const
 
 /**
@@ -100,14 +101,26 @@ export async function loadTypedConfig(
     )
   }
 
-  if (module === null || typeof module !== 'object' || !('default' in module)) {
+  if (module === null || typeof module !== 'object') {
     throw new ConfigError(
       `${path} must export its config as the default export — `
       + 'write `export default defineI18nKitConfig({ ... })`.',
     )
   }
 
-  const exported = (module as { default: unknown }).default
+  // In a `.cts` file `module.exports` comes back as the module itself, with no
+  // `default` to unwrap — so for the CommonJS spellings, that object *is* the
+  // config. Everywhere else a missing `default` means a file of named exports,
+  // and saying so beats letting the schema report a config full of unknown keys.
+  const commonJs = path.endsWith('.cts') || path.endsWith('.cjs')
+  if (!('default' in module) && !commonJs) {
+    throw new ConfigError(
+      `${path} must export its config as the default export — `
+      + 'write `export default defineI18nKitConfig({ ... })`.',
+    )
+  }
+
+  const exported = 'default' in module ? (module as { default: unknown }).default : module
 
   if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
     throw new ConfigError(
@@ -121,7 +134,7 @@ export async function loadTypedConfig(
     throw new ConfigError(`Invalid ${path}:\n${result.error}`)
   }
 
-  return { path, config: result.data }
+  return { path, config: dropDeprecatedKeys(result.data, path) }
 }
 
 /**

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -65,8 +65,12 @@ export interface ProjectConfig {
     /** Glob patterns for translation keys to exclude from orphan detection (e.g., "common.datetime.months.*"). */
     ignorePatterns?: string[]
   }>
-  /** Default output directory for diagnostic tool reports. Set to true for '.i18n-reports/', or a string for a custom relative path. */
-  reportOutput?: string | boolean
+  /**
+   * Where diagnostic reports are written: `true` for '.i18n-reports/', or a
+   * relative path. There is no `false` — omitting the key is how you say no,
+   * and accepting both spellings of "off" would be two ways to mean one thing.
+   */
+  reportOutput?: string | true
   /** Locale directories for the generic adapter. Each entry is a path string (layer="default") or { path, layer } object. */
   localeDirs?: Array<string | { path: string; layer: string }>
   /** Default locale code (required for generic adapter activation). */

--- a/packages/cli/tests/adapters/vue-adapter.test.ts
+++ b/packages/cli/tests/adapters/vue-adapter.test.ts
@@ -306,3 +306,48 @@ describe('Adapter registry: Vue vs Nuxt', () => {
     }
   })
 })
+
+describe('VueAdapter with several unplugin-vue-i18n include roots', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `vue-multi-include-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(join(tempDir, 'src/messages'), { recursive: true })
+    mkdirSync(join(tempDir, 'src/admin/messages'), { recursive: true })
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      name: 'vue-multi', dependencies: { vue: '^3.5.0', 'vue-i18n': '^11.0.0' },
+    }))
+    writeFileSync(join(tempDir, 'src/messages/en.json'), JSON.stringify({ shared: 'Shared' }))
+    writeFileSync(join(tempDir, 'src/messages/de.json'), JSON.stringify({ shared: 'Geteilt' }))
+    writeFileSync(join(tempDir, 'src/admin/messages/en.json'), JSON.stringify({ admin: 'Admin' }))
+    writeFileSync(join(tempDir, 'vite.config.ts'), `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default {
+        plugins: [VueI18nPlugin({
+          include: ['./src/messages/**', './src/admin/messages/**'],
+        })],
+      }
+    `)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('keeps every include root, each as its own layer', async () => {
+    const config = await new VueAdapter().resolve(tempDir)
+
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      join(tempDir, 'src/messages'),
+      join(tempDir, 'src/admin/messages'),
+    ])
+    // Both directories are called "messages", so the names have to say more.
+    expect(config.localeDirs.map(d => d.layer)).toEqual(['src/messages', 'admin/messages'])
+    expect(config.apps[0]!.layers).toEqual(['src/messages', 'admin/messages'])
+  })
+
+  it('unions the locales across the roots', async () => {
+    const config = await new VueAdapter().resolve(tempDir)
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de', 'en'])
+  })
+})

--- a/packages/cli/tests/config/framework-config.test.ts
+++ b/packages/cli/tests/config/framework-config.test.ts
@@ -1,34 +1,17 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { relative as relativePath, resolve } from 'node:path'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { readNextI18n } from '../../src/config/framework/next.js'
 import { readVueI18nLocaleDirs } from '../../src/config/framework/vue.js'
+import { tmpProject } from './tmp-project.js'
 
-const root = resolve(import.meta.dirname, '../../.tmp-framework-config')
-
-// One directory per test: Node's ESM loader caches a module by URL for the
-// life of the process, so reusing a path would serve the first test's file.
-let tmpDir: string
-let n = 0
-beforeEach(() => {
-  tmpDir = resolve(root, `case-${n++}`)
-})
-
-afterAll(async () => {
-  await rm(root, { recursive: true, force: true })
-})
-
-async function write(name: string, contents: string) {
-  const path = resolve(tmpDir, name)
-  await mkdir(resolve(path, '..'), { recursive: true })
-  await writeFile(path, contents, 'utf-8')
-  return path
-}
+const project = tmpProject('framework-config')
+const write = (name: string, contents: string) => project.write(name, contents)
 
 describe('readNextI18n', () => {
   it('returns null when the project declares nothing', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 
   it('reads next-intl routing, defineRouting being identity over its argument', async () => {
@@ -37,14 +20,14 @@ describe('readNextI18n', () => {
       export const routing = defineRouting({ locales: ['en', 'de'], defaultLocale: 'en' })
     `)
 
-    const found = await readNextI18n(tmpDir)
+    const found = await readNextI18n(project.dir)
     expect(found?.defaultLocale).toBe('en')
     expect(found?.locales).toEqual(['en', 'de'])
   })
 
   it('reads a routing file that uses a default export', async () => {
     await write('src/i18n/routing.ts', `export default { locales: ['fr'], defaultLocale: 'fr' }`)
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('fr')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('fr')
   })
 
   it("reads next-translate's i18n.js", async () => {
@@ -52,7 +35,7 @@ describe('readNextI18n', () => {
       module.exports = { locales: ['en', 'pl'], defaultLocale: 'pl', pages: { '*': ['common'] } }
     `)
 
-    const found = await readNextI18n(tmpDir)
+    const found = await readNextI18n(project.dir)
     expect(found?.defaultLocale).toBe('pl')
     expect(found?.locales).toEqual(['en', 'pl'])
   })
@@ -62,14 +45,14 @@ describe('readNextI18n', () => {
       export default { reactStrictMode: true, i18n: { locales: ['en', 'nl'], defaultLocale: 'nl' } }
     `)
 
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('nl')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('nl')
   })
 
   it('prefers the routing file over next.config, being the more specific statement', async () => {
     await write('src/i18n/routing.ts', `export default { locales: ['en'], defaultLocale: 'en' }`)
     await write('next.config.js', `export default { i18n: { locales: ['de'], defaultLocale: 'de' } }`)
 
-    expect((await readNextI18n(tmpDir))?.defaultLocale).toBe('en')
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('en')
   })
 
   it('warns and yields nothing when a config throws — never a failure', async () => {
@@ -80,35 +63,35 @@ describe('readNextI18n', () => {
       export default withSomething({ i18n: { locales: ['de'], defaultLocale: 'de' } })
     `)
 
-    await expect(readNextI18n(tmpDir)).resolves.toBeNull()
+    await expect(readNextI18n(project.dir)).resolves.toBeNull()
   })
 
   it('reads through a relative project directory', async () => {
     await write('next.config.js', `export default { i18n: { locales: ['en', 'sv'], defaultLocale: 'sv' } }`)
-    const relative = relativePath(process.cwd(), tmpDir)
+    const relative = relativePath(process.cwd(), project.dir)
 
     expect((await readNextI18n(relative))?.defaultLocale).toBe('sv')
   })
 
   it('ignores a config that declares no locales at all', async () => {
     await write('next.config.js', `export default { reactStrictMode: true }`)
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 
   it('ignores locale values of the wrong type rather than trusting them', async () => {
     await write('next.config.js', `export default { i18n: { locales: [1, 2], defaultLocale: 42 } }`)
-    expect(await readNextI18n(tmpDir)).toBeNull()
+    expect(await readNextI18n(project.dir)).toBeNull()
   })
 })
 
 describe('readVueI18nLocaleDirs', () => {
   it('returns null without a vite config', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
   })
 
   it("reads the plugin's include, which the plugin object itself never exposes", async () => {
-    await mkdir(resolve(tmpDir, 'src/translations'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default {
@@ -116,11 +99,11 @@ describe('readVueI18nLocaleDirs', () => {
       }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/translations')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'src/translations')])
   })
 
   it('evaluates the function form of defineConfig', async () => {
-    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await mkdir(resolve(project.dir, 'locales'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default ({ mode }: { mode: string }) => ({
@@ -129,11 +112,11 @@ describe('readVueI18nLocaleDirs', () => {
       })
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'locales')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'locales')])
   })
 
   it('resolves an absolute include, as the plugin docs write it', async () => {
-    await mkdir(resolve(tmpDir, 'src/i18n/messages'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/i18n/messages'), { recursive: true })
     await write('vite.config.ts', `
       import { resolve, dirname } from 'node:path'
       import { fileURLToPath } from 'node:url'
@@ -144,7 +127,7 @@ describe('readVueI18nLocaleDirs', () => {
       }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toEqual([resolve(tmpDir, 'src/i18n/messages')])
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([resolve(project.dir, 'src/i18n/messages')])
   })
 
   it('ignores an include naming a directory that does not exist', async () => {
@@ -153,12 +136,12 @@ describe('readVueI18nLocaleDirs', () => {
       export default { plugins: [VueI18nPlugin({ include: ['./nowhere/**'] })] }
     `)
 
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
   })
 
   it('returns null when the config never uses the plugin', async () => {
     await write('vite.config.ts', `export default { plugins: [] }`)
-    expect(await readVueI18nLocaleDirs(tmpDir)).toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
   })
 
   it('warns and yields nothing when the vite config throws', async () => {
@@ -167,20 +150,37 @@ describe('readVueI18nLocaleDirs', () => {
       export default { plugins: [somethingMissing()] }
     `)
 
-    await expect(readVueI18nLocaleDirs(tmpDir)).resolves.toBeNull()
+    await expect(readVueI18nLocaleDirs(project.dir)).resolves.toBeNull()
+  })
+
+  it('gives the same answer when the same project is read twice', async () => {
+    // Node executes an ES module once per process, so the second read imports
+    // the cache, calls no plugin and records nothing. Without remembering the
+    // answer that silently became "this project declares no locale dirs".
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['./src/translations/**'] })] }
+    `)
+
+    const first = await readVueI18nLocaleDirs(project.dir)
+    const second = await readVueI18nLocaleDirs(project.dir)
+
+    expect(first).toEqual([resolve(project.dir, 'src/translations')])
+    expect(second).toEqual(first)
   })
 
   it('does not leak a recorded include into the next project read', async () => {
-    await mkdir(resolve(tmpDir, 'locales'), { recursive: true })
+    await mkdir(resolve(project.dir, 'locales'), { recursive: true })
     await write('vite.config.ts', `
       import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
       export default { plugins: [VueI18nPlugin({ include: ['./locales/**'] })] }
     `)
-    expect(await readVueI18nLocaleDirs(tmpDir)).not.toBeNull()
+    expect(await readVueI18nLocaleDirs(project.dir)).not.toBeNull()
 
     // A second project with a config that never calls the plugin must not
     // inherit the first one's answer through the recording symbol.
-    const other = resolve(root, 'other-project')
+    const other = resolve(project.root, 'other-project')
     await mkdir(other, { recursive: true })
     await writeFile(resolve(other, 'vite.config.ts'), `export default { plugins: [] }`, 'utf-8')
 

--- a/packages/cli/tests/config/framework-config.test.ts
+++ b/packages/cli/tests/config/framework-config.test.ts
@@ -73,6 +73,30 @@ describe('readNextI18n', () => {
     expect((await readNextI18n(relative))?.defaultLocale).toBe('sv')
   })
 
+  it('calls a config exported as a function, as Next.js does', async () => {
+    await write('next.config.js', `
+      export default (phase, { defaultConfig }) => ({
+        ...defaultConfig,
+        i18n: { locales: ['en', 'da'], defaultLocale: 'da' },
+      })
+    `)
+
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('da')
+  })
+
+  it('awaits an async config function', async () => {
+    await write('next.config.js', `
+      export default async () => ({ i18n: { locales: ['en', 'fi'], defaultLocale: 'fi' } })
+    `)
+
+    expect((await readNextI18n(project.dir))?.defaultLocale).toBe('fi')
+  })
+
+  it('warns and yields nothing when the config function throws', async () => {
+    await write('next.config.js', `export default () => { throw new Error('needs env') }`)
+    await expect(readNextI18n(project.dir)).resolves.toBeNull()
+  })
+
   it('ignores a config that declares no locales at all', async () => {
     await write('next.config.js', `export default { reactStrictMode: true }`)
     expect(await readNextI18n(project.dir)).toBeNull()
@@ -137,6 +161,40 @@ describe('readVueI18nLocaleDirs', () => {
     `)
 
     expect(await readVueI18nLocaleDirs(project.dir)).toBeNull()
+  })
+
+  it('keeps every directory in include, not just the first', async () => {
+    await mkdir(resolve(project.dir, 'src/messages'), { recursive: true })
+    await mkdir(resolve(project.dir, 'src/admin-messages'), { recursive: true })
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default {
+        plugins: [VueI18nPlugin({
+          include: ['./src/messages/**', './src/admin-messages/**'],
+        })],
+      }
+    `)
+
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([
+      resolve(project.dir, 'src/messages'),
+      resolve(project.dir, 'src/admin-messages'),
+    ])
+  })
+
+  it('reads a Windows-style include, where resolve() yields backslashes', async () => {
+    await mkdir(resolve(project.dir, 'src/translations'), { recursive: true })
+    // What `resolve(__dirname, './src/translations/**')` produces on Windows.
+    const windowsStyle = `C:\\project\\src\\translations\\**`
+    await write('vite.config.ts', `
+      import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+      export default { plugins: [VueI18nPlugin({ include: ['${windowsStyle}', './src/translations/**'] })] }
+    `)
+
+    // The absolute C:\ path does not exist here, so it drops out; the point is
+    // that splitting it no longer swallows the entry beside it.
+    expect(await readVueI18nLocaleDirs(project.dir)).toEqual([
+      resolve(project.dir, 'src/translations'),
+    ])
   })
 
   it('returns null when the config never uses the plugin', async () => {

--- a/packages/cli/tests/config/playgrounds.test.ts
+++ b/packages/cli/tests/config/playgrounds.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
+import { detectI18nConfig, clearConfigCache } from '../../src/config/detector.js'
+
+/**
+ * The playgrounds are the only place every adapter is exercised end to end
+ * against a project rather than a fixture assembled inside a test. Asserting
+ * the resolution each one is there to demonstrate keeps them from rotting into
+ * directories nobody runs — a playground that silently stopped proving its
+ * point would be worse than not having it.
+ */
+const playgroundsDir = resolve(import.meta.dirname, '../../../../playground')
+
+beforeEach(() => {
+  clearConfigCache()
+})
+
+describe('playground/react', () => {
+  it('takes its default locale from next-intl, not from directory order', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'react'))
+
+    // messages/ sorts de-DE first; routing.ts says otherwise and wins (#296).
+    expect(config.framework).toBe('react')
+    expect(config.defaultLocale).toBe('en-US')
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de-DE', 'en-US', 'es-ES', 'fr-FR'])
+  })
+})
+
+describe('playground/vue', () => {
+  it('finds locale files in a directory no candidate list contains', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'vue'))
+
+    expect(config.framework).toBe('vue')
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      resolve(playgroundsDir, 'vue/src/translations'),
+    ])
+  })
+
+  it('reads defaultLocale and protectedLocales from the typed config', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'vue'))
+
+    expect(config.defaultLocale).toBe('en-US')
+    expect(config.projectConfig?.protectedLocales).toEqual(['de-DE'])
+  })
+})
+
+describe('playground/generic', () => {
+  it('activates on localeDirs + defaultLocale alone, with nothing to detect', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'generic'))
+
+    expect(config.framework).toBe('generic')
+    expect(config.defaultLocale).toBe('en')
+    expect(config.localeDirs.map(d => d.path)).toEqual([
+      resolve(playgroundsDir, 'generic/translations'),
+    ])
+  })
+})
+
+describe('playground/laravel', () => {
+  it('resolves PHP locale directories', async () => {
+    const config = await detectI18nConfig(resolve(playgroundsDir, 'laravel'))
+
+    expect(config.framework).toBe('laravel')
+    expect(config.localeFileFormat).toBe('php-array')
+    expect(config.locales.map(l => l.code).sort()).toEqual(['de', 'en', 'es', 'fr'])
+  })
+})

--- a/packages/cli/tests/config/tmp-project.ts
+++ b/packages/cli/tests/config/tmp-project.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+
+/**
+ * A throwaway project directory per test, plus a `write` for putting config
+ * files in it.
+ *
+ * One directory *per test*, not per file: Node caches an ES module by URL for
+ * the life of the process, so two tests writing different configs to the same
+ * path would both see whichever ran first. Which is also the reason the
+ * production code remembers what it read — see `readVueI18nLocaleDirs`.
+ */
+export function tmpProject(name: string) {
+  const root = resolve(import.meta.dirname, `../../.tmp-${name}`)
+  let dir = root
+  let n = 0
+
+  beforeEach(() => {
+    dir = resolve(root, `case-${n++}`)
+  })
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  return {
+    /** The current test's directory. */
+    get dir() {
+      return dir
+    },
+    /** The shared root, for tests that need a second project of their own. */
+    root,
+    /** Write a file, creating any directories along the way. */
+    async write(relativePath: string, contents: string, into = dir) {
+      const path = resolve(into, relativePath)
+      await mkdir(resolve(path, '..'), { recursive: true })
+      await writeFile(path, contents, 'utf-8')
+      return path
+    },
+    /** Create the directory without putting anything in it. */
+    async empty() {
+      await mkdir(dir, { recursive: true })
+      return dir
+    },
+  }
+}

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -1,34 +1,17 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { relative as relativePath, resolve } from 'node:path'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import { loadTypedConfig, findTypedConfigFile } from '../../src/config/typed-config.js'
 import { loadProjectConfig } from '../../src/config/project-config.js'
+import { tmpProject } from './tmp-project.js'
 
-const root = resolve(import.meta.dirname, '../../.tmp-typed-config')
-
-// A directory per test. Node's ESM loader caches a module by URL for the life
-// of the process, so two tests writing different configs to the same path
-// would see whichever ran first — which is also why the CLI, a one-shot
-// process, gets a fresh read every invocation.
-let tmpDir: string
-let n = 0
-beforeEach(() => {
-  tmpDir = resolve(root, `case-${n++}`)
-})
-
-afterAll(async () => {
-  await rm(root, { recursive: true, force: true })
-})
-
-async function write(name: string, contents: string, dir = tmpDir) {
-  await mkdir(dir, { recursive: true })
-  await writeFile(resolve(dir, name), contents, 'utf-8')
-}
+const project = tmpProject('typed-config')
+const write = (name: string, contents: string, into?: string) => project.write(name, contents, into)
 
 describe('loadTypedConfig', () => {
   it('returns null when there is no config file — the case that must keep behaving as before', async () => {
-    await mkdir(tmpDir, { recursive: true })
-    expect(await loadTypedConfig(tmpDir)).toBeNull()
+    await project.empty()
+    expect(await loadTypedConfig(project.dir)).toBeNull()
   })
 
   it('loads a TypeScript config, types and all', async () => {
@@ -42,11 +25,11 @@ describe('loadTypedConfig', () => {
       }
     `)
 
-    const loaded = await loadTypedConfig(tmpDir)
+    const loaded = await loadTypedConfig(project.dir)
     expect(loaded?.config.defaultLocale).toBe('en')
     expect(loaded?.config.protectedLocales).toEqual(['de-formal'])
     expect(loaded?.config.glossary).toEqual({ anny: 'type annotations must survive' })
-    expect(loaded?.path).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(loaded?.path).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 
   it('resolves defineI18nKitConfig without the package being installed', async () => {
@@ -57,23 +40,23 @@ describe('loadTypedConfig', () => {
       export default defineI18nKitConfig({ defaultLocale: 'fr' })
     `)
 
-    const loaded = await loadTypedConfig(tmpDir)
+    const loaded = await loadTypedConfig(project.dir)
     expect(loaded?.config.defaultLocale).toBe('fr')
   })
 
   it('accepts a plain .js config', async () => {
     await write('i18n-kit.config.js', `export default { defaultLocale: 'it' }`)
-    expect((await loadTypedConfig(tmpDir))?.config.defaultLocale).toBe('it')
+    expect((await loadTypedConfig(project.dir))?.config.defaultLocale).toBe('it')
   })
 
   it('rejects an unknown key rather than ignoring it', async () => {
     await write('i18n-kit.config.ts', `export default { protectedLocals: ['de'] }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocals/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/protectedLocals/)
   })
 
   it('rejects a value the schema disallows', async () => {
     await write('i18n-kit.config.ts', `export default { protectedLocales: [''] }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/protectedLocales/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/protectedLocales/)
   })
 
   it('fails loudly when the config throws, naming the file', async () => {
@@ -81,31 +64,31 @@ describe('loadTypedConfig', () => {
     // file exists only for the kit, so ignoring it means silently applying
     // none of the policy someone can see in their repository.
     await write('i18n-kit.config.ts', `throw new Error('boom')`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts.*boom/s)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/i18n-kit\.config\.ts.*boom/s)
   })
 
   it('explains a config with no default export', async () => {
     await write('i18n-kit.config.ts', `export const config = { defaultLocale: 'en' }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/default export/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/default export/)
   })
 
   it('explains a config that exports the function instead of calling it', async () => {
     await write('i18n-kit.config.ts', `export default function config() { return {} }`)
-    await expect(loadTypedConfig(tmpDir)).rejects.toThrow(/do not pass it/)
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/do not pass it/)
   })
 })
 
 describe('findTypedConfigFile', () => {
   it('walks up to a parent directory, as .i18n-mcp.json does', async () => {
-    const child = resolve(tmpDir, 'apps/admin')
+    const child = resolve(project.dir, 'apps/admin')
     await mkdir(child, { recursive: true })
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
 
-    expect(findTypedConfigFile(child)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(child)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 
   it('stops at the nearest one, so an app config shadows the root', async () => {
-    const child = resolve(tmpDir, 'apps/admin')
+    const child = resolve(project.dir, 'apps/admin')
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'de' }`, child)
 
@@ -116,9 +99,9 @@ describe('findTypedConfigFile', () => {
     // jiti reads a relative path as a bare module specifier, so a relative
     // --projectDir used to make loading a typed config fail outright.
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
-    const relative = relativePath(process.cwd(), tmpDir)
+    const relative = relativePath(process.cwd(), project.dir)
 
-    expect(findTypedConfigFile(relative)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(relative)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
     expect((await loadTypedConfig(relative))?.config.defaultLocale).toBe('en')
   })
 
@@ -126,7 +109,7 @@ describe('findTypedConfigFile', () => {
     await write('i18n-kit.config.js', `export default { defaultLocale: 'js' }`)
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'ts' }`)
 
-    expect(findTypedConfigFile(tmpDir)).toBe(resolve(tmpDir, 'i18n-kit.config.ts'))
+    expect(findTypedConfigFile(project.dir)).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 })
 
@@ -135,7 +118,7 @@ describe('loadProjectConfig with both config formats', () => {
     await write('i18n-kit.config.ts', `export default { protectedLocales: ['de-formal'] }`)
     await write('.i18n-mcp.json', JSON.stringify({ context: 'a booking product' }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config).toEqual({ context: 'a booking product', protectedLocales: ['de-formal'] })
   })
 
@@ -143,28 +126,28 @@ describe('loadProjectConfig with both config formats', () => {
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de' }))
 
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/defaultLocale/)
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/i18n-kit\.config\.ts/)
-    await expect(loadProjectConfig(tmpDir)).rejects.toThrow(/\.i18n-mcp\.json/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/defaultLocale/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/i18n-kit\.config\.ts/)
+    await expect(loadProjectConfig(project.dir)).rejects.toThrow(/\.i18n-mcp\.json/)
   })
 
   it('does not count the JSON-only $schema as a conflict', async () => {
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'en' }`)
     await write('.i18n-mcp.json', JSON.stringify({ $schema: './schema.json', context: 'x' }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config?.defaultLocale).toBe('en')
   })
 
   it('returns the JSON config unchanged when there is no typed config', async () => {
     await write('.i18n-mcp.json', JSON.stringify({ defaultLocale: 'de', protectedLocales: ['en'] }))
 
-    const config = await loadProjectConfig(tmpDir)
+    const config = await loadProjectConfig(project.dir)
     expect(config).toEqual({ defaultLocale: 'de', protectedLocales: ['en'] })
   })
 
   it('returns null when neither file exists', async () => {
-    await mkdir(resolve(tmpDir, 'nested'), { recursive: true })
-    expect(await loadProjectConfig(resolve(tmpDir, 'nested'))).toBeNull()
+    await mkdir(resolve(project.dir, 'nested'), { recursive: true })
+    expect(await loadProjectConfig(resolve(project.dir, 'nested'))).toBeNull()
   })
 })

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -105,6 +105,20 @@ describe('findTypedConfigFile', () => {
     expect((await loadTypedConfig(relative))?.config.defaultLocale).toBe('en')
   })
 
+  it('finds a .cts config, the CommonJS TypeScript spelling', async () => {
+    await write('i18n-kit.config.cts', `module.exports = { defaultLocale: 'pt' }`)
+
+    expect(findTypedConfigFile(project.dir)).toBe(resolve(project.dir, 'i18n-kit.config.cts'))
+    expect((await loadTypedConfig(project.dir))?.config.defaultLocale).toBe('pt')
+  })
+
+  it('warns about a deprecated key rather than passing it through', async () => {
+    await write('i18n-kit.config.ts', `export default { defaultLocale: 'en', samplingPreferences: { model: 'x' } }`)
+
+    const loaded = await loadTypedConfig(project.dir)
+    expect(loaded?.config).toEqual({ defaultLocale: 'en' })
+  })
+
   it('prefers .ts when a directory has several', async () => {
     await write('i18n-kit.config.js', `export default { defaultLocale: 'js' }`)
     await write('i18n-kit.config.ts', `export default { defaultLocale: 'ts' }`)

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     // while reading a project's vite.config, so it has to survive bundling as
     // a file. See config/framework/stubs/unplugin-vue-i18n.ts.
     'src/config/framework/stubs/unplugin-vue-i18n.ts',
+    'src/config/framework/stubs/next-intl-routing.ts',
   ],
   format: 'esm',
   target: 'node18',

--- a/packages/nuxt/src/policy.ts
+++ b/packages/nuxt/src/policy.ts
@@ -36,8 +36,8 @@ export interface I18nKitPolicy {
   /** Per-layer orphan-scan settings, keyed by layer name. */
   orphanScan?: Record<string, { ignorePatterns?: string[] }>
 
-  /** Where diagnostic reports are written: true for `.i18n-reports/`, or a path. */
-  reportOutput?: string | boolean
+  /** Where diagnostic reports are written: true for `.i18n-reports/`, or a path. Omit it for none. */
+  reportOutput?: string | true
 
   /** Override the detected locale file format. */
   localeFileFormat?: 'json' | 'php-array'

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,36 @@
+# Playgrounds
+
+One project per supported adapter, so that every detection and resolution path has somewhere real to be run against.
+
+| Directory | Adapter | Locale files | Reference locale comes from |
+|---|---|---|---|
+| [`nuxt`](./nuxt) | Nuxt | `i18n/locales/` per layer | `nuxt.config.ts`, via `@nuxtjs/i18n` |
+| [`react`](./react) | React / Next.js | `messages/` | `src/i18n/routing.ts` — next-intl |
+| [`vue`](./vue) | Vue | `src/translations/` | `i18n-kit.config.ts`; directories from `vite.config.ts` |
+| [`laravel`](./laravel) | Laravel | `lang/<locale>/*.php` | directory layout |
+| [`generic`](./generic) | Generic | `translations/` | `i18n-kit.config.ts` — the only source there is |
+
+```bash
+pnpm --filter the-i18n-cli build
+
+for p in nuxt react vue laravel generic; do
+  node packages/cli/dist/bin.js status --projectDir "playground/$p"
+done
+```
+
+Each one has a README explaining what it exists to prove.
+
+## Between them they cover every way the CLI can learn a project's locales
+
+1. **Declared by a person** — `i18n-kit.config.ts` (`vue`, `generic`) or `.i18n-mcp.json` (`nuxt`, `laravel`).
+2. **Published by a build** — `.nuxt/i18n-kit.json`, written by `@the-i18n-kit/nuxt` (`nuxt`).
+3. **Read from the framework's own config** — next-intl's routing file (`react`), the unplugin's `include` (`vue`).
+4. **Probed from directory layout** — the fallback, and all `laravel` needs.
+
+Each also has locales that are deliberately incomplete, so `missing`, `status` and `translate` have something to report rather than a uniform green.
+
+## Only `nuxt` is a workspace member
+
+It needs a real install: its config loads `@the-i18n-kit/nuxt`, and the E2E translate workflow builds and runs it.
+
+The rest are fixtures with no `node_modules`, which is why adding four of them costs CI nothing. They still contain the imports a real project would (`next-intl/routing`, `@intlify/unplugin-vue-i18n/vite`, `the-i18n-cli/config`), because the CLI substitutes what it cannot resolve — and prefers the real package wherever one is installed. Run `pnpm install` inside any of them and the output does not change.

--- a/playground/generic/README.md
+++ b/playground/generic/README.md
@@ -1,0 +1,26 @@
+# Generic playground
+
+A project with **no i18n framework at all** — plain JSON files loaded by hand — for exercising the generic adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/generic
+```
+
+## What it is here to prove
+
+There is nothing to detect and nothing to read: no `nuxt.config`, no `vite.config`, no `next.config`, not even a `package.json` dependency worth scoring. Everything the CLI knows comes from `i18n-kit.config.ts`:
+
+```ts
+export default defineI18nKitConfig({
+  localeDirs: ['translations'],
+  defaultLocale: 'en',
+})
+```
+
+`localeDirs` and `defaultLocale` together are what activate the generic adapter, and what let it outscore framework inference. Locale files live in `translations/`, which no adapter probes.
+
+This is the case the typed config matters most for, because it is the only source of truth there is. Previously it had to be untyped JSON — a misspelled `localeDirs` meant the adapter silently did not activate, and the CLI reported that it could not work out what kind of project this was.
+
+## Deliberately incomplete
+
+`booking` is absent from `nl` and partial in `fr`, and `app.tagline` is missing from `nl`, so `missing` and `status` have something to report.

--- a/playground/generic/i18n-kit.config.ts
+++ b/playground/generic/i18n-kit.config.ts
@@ -1,0 +1,22 @@
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
+/**
+ * There is no framework here to ask, so everything is declared. `localeDirs`
+ * plus `defaultLocale` is what activates the generic adapter — and what makes
+ * it win detection over any framework the dependencies might otherwise hint at.
+ */
+export default defineI18nKitConfig({
+  localeDirs: ['translations'],
+  defaultLocale: 'en',
+  context: 'A SaaS booking platform with no i18n framework — plain JSON files read at runtime.',
+  glossary: {
+    Booking: "Core concept. Never 'Reservation'.",
+    Resource: 'A bookable entity — a room, a desk, a person.',
+  },
+  translationPrompt: 'Professional but approachable. Preserve all {placeholders}. Keep translations concise.',
+  localeNotes: {
+    de: 'Informal German (du).',
+    fr: 'French.',
+    nl: 'Dutch.',
+  },
+})

--- a/playground/generic/src/app.js
+++ b/playground/generic/src/app.js
@@ -1,0 +1,13 @@
+import en from '../translations/en.json' with { type: 'json' }
+
+const messages = { en }
+const locale = 'en'
+
+/** Deliberately plain: no framework, no macro — just a lookup by dot path. */
+export function t(key) {
+  return key.split('.').reduce((node, part) => node?.[part], messages[locale]) ?? key
+}
+
+console.log(t('app.tagline'))
+console.log(t('common.actions.save'))
+console.log(t('booking.confirm'))

--- a/playground/generic/translations/de.json
+++ b/playground/generic/translations/de.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "tagline": "Buche alles, überall",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "success": "Erfolgreich gespeichert"
+    }
+  }
+}

--- a/playground/generic/translations/en.json
+++ b/playground/generic/translations/en.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "tagline": "Book anything, anywhere",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "success": "Successfully saved"
+    }
+  }
+}

--- a/playground/generic/translations/fr.json
+++ b/playground/generic/translations/fr.json
@@ -1,0 +1,19 @@
+{
+  "app": {
+    "tagline": "Réservez tout, partout",
+    "title": "Anny"
+  },
+  "booking": {
+    "confirm": "Confirmer la réservation"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "success": "Enregistré avec succès"
+    }
+  }
+}

--- a/playground/generic/translations/nl.json
+++ b/playground/generic/translations/nl.json
@@ -1,0 +1,15 @@
+{
+  "app": {
+    "title": "Anny"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuleren",
+      "save": "Opslaan"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "success": "Succesvol opgeslagen"
+    }
+  }
+}

--- a/playground/laravel/lang/de/common.php
+++ b/playground/laravel/lang/de/common.php
@@ -8,6 +8,7 @@ return [
         'edit' => 'Bearbeiten',
         'create' => 'Erstellen',
         'back' => 'Zurück',
+        'duplicate' => 'Duplizieren',
     ],
     'messages' => [
         'success' => 'Vorgang erfolgreich abgeschlossen.',

--- a/playground/laravel/lang/en/common.php
+++ b/playground/laravel/lang/en/common.php
@@ -8,6 +8,7 @@ return [
         'edit' => 'Edit',
         'create' => 'Create',
         'back' => 'Back',
+        'duplicate' => 'Duplicate',
     ],
     'messages' => [
         'success' => 'Operation completed successfully.',

--- a/playground/react/README.md
+++ b/playground/react/README.md
@@ -1,0 +1,32 @@
+# React / Next.js playground
+
+A Next.js App Router project using **next-intl**, for exercising the React adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/react
+```
+
+## What it is here to prove
+
+`messages/` contains `de-DE`, `en-US`, `es-ES` and `fr-FR`. Alphabetically first is `de-DE` — and until the adapter could read a project's own config, that made German the reference locale of an English project purely by sorting order ([#296](https://github.com/fabkho/the-i18n-kit/issues/296)).
+
+`src/i18n/routing.ts` says otherwise, and is read:
+
+```ts
+export const routing = defineRouting({
+  locales: ['de-DE', 'en-US', 'es-ES', 'fr-FR'],
+  defaultLocale: 'en-US',
+})
+```
+
+So `status` reports `en-US` as the reference locale. Change `defaultLocale` there and the CLI follows it, with no `.i18n-mcp.json` involved.
+
+`next.config.mjs` is a realistic one — wrapped in `withNextIntl(...)`, so it cannot be executed without the dependencies installed. It is never reached: the routing file is more specifically about i18n and is read first. If you delete `src/i18n/routing.ts`, the CLI warns that it could not read `next.config.mjs` and falls back to directory order, which is the intended never-load-bearing behaviour rather than a failure.
+
+## No install required
+
+There is no `node_modules` here, deliberately — this is a fixture, not a workspace member, so it costs CI nothing. `defineRouting` returns its argument unchanged, so when next-intl cannot be resolved the CLI substitutes an identity stub and reads the file anyway. Run `pnpm add next-intl` inside this directory and the real package is preferred; the answer is identical either way.
+
+## Deliberately incomplete
+
+`booking.slotsLeft` exists only in `en-US` and `de-DE`, and the whole `booking` namespace is missing from `es-ES`, so `missing` and `status` have something to report.

--- a/playground/react/messages/de-DE.json
+++ b/playground/react/messages/de-DE.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "delete": "Löschen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "noData": "Keine Daten vorhanden",
+      "success": "Erfolgreich gespeichert"
+    },
+    "navigation": {
+      "back": "Zurück",
+      "home": "Startseite",
+      "settings": "Einstellungen"
+    }
+  },
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource",
+    "slotsLeft": "{count, plural, =0 {Keine Plätze frei} one {Ein Platz frei} other {# Plätze frei}}"
+  }
+}

--- a/playground/react/messages/en-US.json
+++ b/playground/react/messages/en-US.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "noData": "No data available",
+      "success": "Successfully saved"
+    },
+    "navigation": {
+      "back": "Back",
+      "home": "Home",
+      "settings": "Settings"
+    }
+  },
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource",
+    "slotsLeft": "{count, plural, =0 {No slots left} one {One slot left} other {# slots left}}"
+  }
+}

--- a/playground/react/messages/es-ES.json
+++ b/playground/react/messages/es-ES.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "save": "Guardar"
+    },
+    "messages": {
+      "loading": "Cargando...",
+      "noData": "No hay datos disponibles",
+      "success": "Guardado correctamente"
+    },
+    "navigation": {
+      "back": "Atrás",
+      "home": "Inicio",
+      "settings": "Ajustes"
+    }
+  }
+}

--- a/playground/react/messages/fr-FR.json
+++ b/playground/react/messages/fr-FR.json
@@ -1,0 +1,23 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "noData": "Aucune donnée disponible",
+      "success": "Enregistré avec succès"
+    },
+    "navigation": {
+      "back": "Retour",
+      "home": "Accueil",
+      "settings": "Paramètres"
+    }
+  },
+  "booking": {
+    "confirm": "Confirmer la réservation",
+    "resource": "Ressource"
+  }
+}

--- a/playground/react/next.config.mjs
+++ b/playground/react/next.config.mjs
@@ -1,0 +1,8 @@
+import createNextIntlPlugin from 'next-intl/plugin'
+
+const withNextIntl = createNextIntlPlugin()
+
+/** @type {import('next').NextConfig} */
+export default withNextIntl({
+  reactStrictMode: true,
+})

--- a/playground/react/package.json
+++ b/playground/react/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "the-i18n-kit/playground-react",
+  "private": true,
+  "type": "module",
+  "description": "Next.js App Router playground for the React adapter",
+  "dependencies": {
+    "next": "^15.0.0",
+    "next-intl": "^3.26.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/playground/react/src/app/page.tsx
+++ b/playground/react/src/app/page.tsx
@@ -1,0 +1,18 @@
+import { useTranslations } from 'next-intl'
+
+/**
+ * Here so the scanner has real call sites to find. `booking.slotsLeft` is used
+ * but only translated in two locales, which is what `missing` reports.
+ */
+export default function Home() {
+  const t = useTranslations()
+
+  return (
+    <main>
+      <h1>{t('common.navigation.home')}</h1>
+      <p>{t('booking.slotsLeft', { count: 3 })}</p>
+      <button type="button">{t('common.actions.save')}</button>
+      <button type="button">{t('booking.confirm')}</button>
+    </main>
+  )
+}

--- a/playground/react/src/i18n/routing.ts
+++ b/playground/react/src/i18n/routing.ts
@@ -1,0 +1,11 @@
+import { defineRouting } from 'next-intl/routing'
+
+/**
+ * The authoritative statement of this project's locales. The CLI reads this
+ * file rather than guessing from the contents of `messages/` — where the
+ * alphabetically first entry is `de-DE`, which is not the default locale.
+ */
+export const routing = defineRouting({
+  locales: ['de-DE', 'en-US', 'es-ES', 'fr-FR'],
+  defaultLocale: 'en-US',
+})

--- a/playground/vue/README.md
+++ b/playground/vue/README.md
@@ -1,0 +1,34 @@
+# Vue playground
+
+A Vue 3 SPA using **vue-i18n** and `@intlify/unplugin-vue-i18n`, for exercising the Vue adapter.
+
+```bash
+the-i18n-cli status --projectDir playground/vue
+```
+
+## What it is here to prove
+
+**Locale files that probing would never find.** They live in `src/translations`, which is not one of the six directories the adapter guesses at (`src/locales`, `locales`, `src/i18n/locales`, `i18n/locales`, `src/plugins/i18n/locales`, `src/i18n`). Before the adapter could read a build config, this project simply failed with "no locale directory found".
+
+`vite.config.ts` says where they are, and that is read:
+
+```ts
+VueI18nPlugin({ include: [resolve(here, './src/translations/**')] })
+```
+
+The plugin keeps `include` in a closure — the object it returns is nothing but Vite hooks — so the CLI substitutes a stub that records the call. Nothing of the resolved Vite config is used beyond that one value.
+
+**Policy no Vue config can express.** `i18n-kit.config.ts` declares `defaultLocale: 'en-US'`, so the reference locale is English rather than `de-DE`, which is merely what the alphabet suggests. It marks `de-DE` as human-maintained so nothing machine-translates into it, and carries the glossary and tone notes. Being TypeScript, a misspelled key is an editor error rather than a line that quietly does nothing:
+
+```
+$ the-i18n-cli status --projectDir playground/vue --json | jq .summary.protectedLocales
+["de-DE"]
+```
+
+## No install required
+
+There is no `node_modules` here — this is a fixture, not a workspace member, so it costs CI nothing. The plugin is substituted rather than imported, and `the-i18n-cli/config` resolves to the running CLI, so both files are read as they are.
+
+## Deliberately incomplete
+
+The `booking` namespace is missing entirely from `es-ES` and partly from `fr-FR`, so `missing` and `status` have something to report.

--- a/playground/vue/i18n-kit.config.ts
+++ b/playground/vue/i18n-kit.config.ts
@@ -1,0 +1,28 @@
+import { defineI18nKitConfig } from 'the-i18n-cli/config'
+
+/**
+ * The half no config file of Vue's can state: which locale is the source of
+ * truth, and how the product wants to be translated.
+ *
+ * `vite.config.ts` says where the files are; this says what to do with them.
+ * Typed, so a misspelled key is an editor error rather than a silently
+ * ignored one.
+ */
+export default defineI18nKitConfig({
+  defaultLocale: 'en-US',
+  context: 'A SaaS booking platform. Vue 3 SPA with vue-i18n.',
+  glossary: {
+    Booking: "Core concept. Never 'Reservation'.",
+    Resource: 'A bookable entity — a room, a desk, a person.',
+  },
+  translationPrompt: 'Professional but approachable. Preserve all {placeholders}. Keep translations concise.',
+  localeNotes: {
+    'de-DE': 'Informal German (du). Maintained by hand.',
+    'fr-FR': 'French.',
+    'es-ES': 'Spanish.',
+  },
+  // German is written by a person here, so nothing may machine-translate into
+  // it. Address a protected locale by its `code`: a ref matching nothing is
+  // the mistake this file being typed is meant to catch.
+  protectedLocales: ['de-DE'],
+})

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "the-i18n-kit/playground-vue",
+  "private": true,
+  "type": "module",
+  "description": "Vue 3 + vite playground for the Vue adapter",
+  "dependencies": {
+    "vue": "^3.5.30",
+    "vue-i18n": "^11.1.0"
+  },
+  "devDependencies": {
+    "@intlify/unplugin-vue-i18n": "^6.0.0",
+    "@vitejs/plugin-vue": "^5.2.0",
+    "vite": "^7.3.0"
+  }
+}

--- a/playground/vue/src/App.vue
+++ b/playground/vue/src/App.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <main>
+    <h1>{{ $t('common.navigation.home') }}</h1>
+    <p>{{ $t('booking.upcoming') }}</p>
+    <button type="button">
+      {{ t('common.actions.save') }}
+    </button>
+    <button type="button">
+      {{ t('booking.confirm') }}
+    </button>
+  </main>
+</template>

--- a/playground/vue/src/translations/de-DE.json
+++ b/playground/vue/src/translations/de-DE.json
@@ -1,0 +1,24 @@
+{
+  "booking": {
+    "confirm": "Buchung bestätigen",
+    "resource": "Ressource",
+    "upcoming": "Anstehende Buchungen"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "delete": "Löschen",
+      "save": "Speichern"
+    },
+    "messages": {
+      "loading": "Laden...",
+      "noData": "Keine Daten vorhanden",
+      "success": "Erfolgreich gespeichert"
+    },
+    "navigation": {
+      "back": "Zurück",
+      "home": "Startseite",
+      "settings": "Einstellungen"
+    }
+  }
+}

--- a/playground/vue/src/translations/en-US.json
+++ b/playground/vue/src/translations/en-US.json
@@ -1,0 +1,24 @@
+{
+  "booking": {
+    "confirm": "Confirm booking",
+    "resource": "Resource",
+    "upcoming": "Upcoming bookings"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "save": "Save"
+    },
+    "messages": {
+      "loading": "Loading...",
+      "noData": "No data available",
+      "success": "Successfully saved"
+    },
+    "navigation": {
+      "back": "Back",
+      "home": "Home",
+      "settings": "Settings"
+    }
+  }
+}

--- a/playground/vue/src/translations/es-ES.json
+++ b/playground/vue/src/translations/es-ES.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "actions": {
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "save": "Guardar"
+    },
+    "messages": {
+      "loading": "Cargando...",
+      "noData": "No hay datos disponibles",
+      "success": "Guardado correctamente"
+    },
+    "navigation": {
+      "back": "Atrás",
+      "home": "Inicio",
+      "settings": "Ajustes"
+    }
+  }
+}

--- a/playground/vue/src/translations/fr-FR.json
+++ b/playground/vue/src/translations/fr-FR.json
@@ -1,0 +1,23 @@
+{
+  "booking": {
+    "confirm": "Confirmer la réservation",
+    "resource": "Ressource"
+  },
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "save": "Enregistrer"
+    },
+    "messages": {
+      "loading": "Chargement...",
+      "noData": "Aucune donnée disponible",
+      "success": "Enregistré avec succès"
+    },
+    "navigation": {
+      "back": "Retour",
+      "home": "Accueil",
+      "settings": "Paramètres"
+    }
+  }
+}

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * `include` is the authoritative statement of where the locale files live —
+ * and `src/translations` is deliberately not one of the directories the
+ * adapter would otherwise probe.
+ */
+export default {
+  plugins: [
+    VueI18nPlugin({
+      include: [resolve(here, './src/translations/**')],
+    }),
+  ],
+}


### PR DESCRIPTION
**Stacked on #328** — review that first; the base of this PR is `feat/typed-config`, so the diff here is only the playgrounds and what they turned up.

There was a playground for Nuxt and one for Laravel. Vue, React/Next and the generic adapter had only fixtures assembled inside tests — which is why the two bugs below survived a green suite: a test constructs the project it is about to read, so it never asks the questions a real directory does.

## What is added

| Directory | Adapter | Proves |
|---|---|---|
| `playground/react` | React / Next.js | `messages/` sorts `de-DE` first; `src/i18n/routing.ts` says `en-US` and wins |
| `playground/vue` | Vue | locales live in `src/translations`, which no candidate list contains; `vite.config.ts` says so |
| `playground/generic` | Generic | no framework at all — `i18n-kit.config.ts` is the only source of truth there is |

Each has a README saying what it exists to prove, locales that are deliberately incomplete so `missing` and `status` report something rather than a uniform green, and a test asserting the resolution it demonstrates. A playground that quietly stopped proving its point would be worse than not having one.

Between them the five now cover every route the CLI has to a project's locales: **declared by a person**, **published by a build**, **read from the framework's own config**, **probed from the directory layout**.

## Cost

Only `nuxt` stays a workspace member — it needs a real install for `@the-i18n-kit/nuxt` and the E2E translate workflow. The other four are fixtures with no `node_modules`, so they add nothing to CI install time. I measured the alternative: `next-intl` alone pulls 347 MB through pnpm, which is not worth it for a fixture.

They still contain the imports a real project would (`next-intl/routing`, `@intlify/unplugin-vue-i18n/vite`, `the-i18n-cli/config`), because the CLI substitutes what it cannot resolve — and prefers the real package wherever one is installed. Run `pnpm install` in any of them and the output is unchanged.

## Three bugs found by pointing the CLI at them

**1. A relative `--projectDir` broke the typed config outright.** jiti reads a relative path as a bare module specifier and resolves it against `node_modules`. For a framework config that meant a warning and a fallback; for `i18n-kit.config.ts` it meant `Failed to load: Cannot find module` and no output at all. Fixed on #328 (`bf58f04`), since that is where the code lives — anyone running `the-i18n-cli status --projectDir some/path` would have hit it.

**2. Reading the same Vue project twice gave a different answer the second time.** Node executes an ES module once per process, so the second read imported the cache, called no plugin, recorded no `include`, and reported that the project declares no locale directories. Exactly the class of silent inconsistency this line of work is about, and it would have hit the long-lived MCP server rather than the one-shot CLI. Answers are now remembered per config file, which is consistent with the module cache that causes it.

**3. next-intl's routing file could only be read where next-intl was installed.** `defineRouting` returns its argument, so it is now substituted when — and only when — the real one cannot be resolved from the routing file's own location. The real package always wins where it is present; the stub is a rescue for a fresh clone, a CI job that skipped install, or a fixture. Reading a declaration should not require a `node_modules`.

## Also

Locating the stub modules, and the per-test temporary project, each existed twice and now exist once — `fallow audit` flagged both, fairly.

## Verification

- All five playgrounds detect the intended adapter and resolve the intended reference locale.
- 979 CLI tests pass (up 36), plus nuxt and mcp suites. `fallow audit` exits 0.