### PR TITLE
fix(scanner): stop offering a used single-segment key for deletion

### DIFF
--- a/packages/cli/src/scanner/code-scanner.ts
+++ b/packages/cli/src/scanner/code-scanner.ts
@@ -103,6 +103,8 @@ interface LineExtraction {
   filePath: string
   usages: KeyUsage[]
   dynamicKeys: DynamicKeyUsage[]
+  /** Arguments to an ambiguous callee — see extractStaticMatches. */
+  bareCandidates: Set<string>
 }
 
 function extractStaticMatches(line: string, lineNumber: number, ctx: LineExtraction): void {
@@ -113,7 +115,15 @@ function extractStaticMatches(line: string, lineNumber: number, ctx: LineExtract
       const key = match[3]
       if (!key) continue
       if (key.includes('{$')) continue
-      if (ctx.pat.requiresDotForCallee?.(callee) && !key.includes('.')) continue
+      // A bare `t('word')` is ambiguous — `emit('save')` is not a translation —
+      // so it is not evidence of usage. Dropping it entirely was worse: a flat
+      // catalogue's keys then look unreferenced and remove-orphans offers a live
+      // key for deletion (#298). Kept as a candidate instead, which protects a
+      // key only when one of that exact name exists.
+      if (ctx.pat.requiresDotForCallee?.(callee) && !key.includes('.')) {
+        ctx.bareCandidates.add(key)
+        continue
+      }
       ctx.usages.push({ key, file: ctx.filePath, line: lineNumber, callee })
     }
   }
@@ -172,7 +182,7 @@ function extractConcatMatches(line: string, lineNumber: number, ctx: LineExtract
   }
 }
 
-export function extractKeys(content: string, filePath: string, patterns?: ScanPatternSet, constTable?: Map<string, string>): { usages: KeyUsage[]; dynamicKeys: DynamicKeyUsage[] } {
+export function extractKeys(content: string, filePath: string, patterns?: ScanPatternSet, constTable?: Map<string, string>): { usages: KeyUsage[]; dynamicKeys: DynamicKeyUsage[]; bareStringCandidates: Set<string> } {
   const pat = patterns ?? VUE_NUXT_PATTERNS
   const ctx: LineExtraction = {
     pat,
@@ -180,6 +190,7 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
     filePath,
     usages: [],
     dynamicKeys: [],
+    bareCandidates: new Set<string>(),
   }
 
   const lines = content.split('\n')
@@ -190,7 +201,7 @@ export function extractKeys(content: string, filePath: string, patterns?: ScanPa
     extractConcatMatches(line, lineNumber, ctx)
   }
 
-  return { usages: ctx.usages, dynamicKeys: ctx.dynamicKeys }
+  return { usages: ctx.usages, dynamicKeys: ctx.dynamicKeys, bareStringCandidates: ctx.bareCandidates }
 }
 
 // ─── Dynamic key pattern matching ───────────────────────────────
@@ -475,9 +486,10 @@ export async function scanSourceFiles(rootDir: string, excludeDirs?: string[], p
     }
 
     const constTable = pat.resolveLocalConsts ? collectConstKeyTable(content) : new Map<string, string>()
-    const { usages, dynamicKeys } = extractKeys(content, filePath, pat, constTable)
+    const { usages, dynamicKeys, bareStringCandidates: bareFromCalls } = extractKeys(content, filePath, pat, constTable)
     allUsages.push(...usages)
     allDynamicKeys.push(...dynamicKeys)
+    for (const candidate of bareFromCalls) bareStringCandidates.add(candidate)
 
     collectBareCandidates(content, constTable, bareStringCandidates, bareDynamicCandidates, pat.bareShapes)
 

--- a/packages/cli/tests/scanner/code-scanner.test.ts
+++ b/packages/cli/tests/scanner/code-scanner.test.ts
@@ -6,6 +6,38 @@ import { extractKeys, findOrphanKeysForConfig, scanSourceFiles, toRelativePath, 
 
 const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '../../.tmp-test/scanner')
 
+describe('single-segment keys used via a bare t()', () => {
+  /**
+   * `requiresDotForCallee` skips `t('word')` because a bare `t` is ambiguous —
+   * `emit('save')` is not a translation. That guard is right, but dropping the
+   * match entirely means a flat catalogue's keys look unreferenced, and
+   * remove-orphans offers a live key for deletion (#298).
+   *
+   * The argument is kept as a bare candidate instead: candidates only protect
+   * a key when one of that exact name exists, so an `emit('save')` in a project
+   * with no `save` key still protects nothing.
+   */
+  it('keeps the argument as a bare candidate rather than dropping it', () => {
+    const { usages, bareStringCandidates } = extractKeys(`const x = t('save')`, 'a.ts')
+
+    expect(usages).toHaveLength(0)
+    expect(bareStringCandidates.has('save')).toBe(true)
+  })
+
+  it('still records a dotted key as a confirmed usage', () => {
+    const { usages } = extractKeys(`const x = t('nested.used')`, 'a.ts')
+
+    expect(usages.map(u => u.key)).toEqual(['nested.used'])
+  })
+
+  // $t and this.$t are unambiguous, so they were never subject to the guard.
+  it('leaves the unambiguous callees recording usages', () => {
+    const { usages } = extractKeys(`{{ $t('save') }}`, 'a.vue')
+
+    expect(usages.map(u => u.key)).toEqual(['save'])
+  })
+})
+
 describe('extractKeys', () => {
   function extract(content: string, filePath = 'test.vue') {
     return extractKeys(content, filePath)


### PR DESCRIPTION
Closes #298.

A flat catalogue's keys were reported as orphans even when the source referenced them — and not in a protective bucket, but in `orphanKeys`, which `remove-orphans` deletes on a non-dry run.

```
locales/en.json   { "save": "Save", "cancel": "Cancel", "nested": { "used": "Used" } }
src/App.tsx       t('save')   t('nested.used')
```

```
before: {"orphans":{"default":["cancel","save"]},"count":2}
after:  {"orphans":{"default":["cancel"]},"count":1}
```

## Why it happened

`requiresDotForCallee` skips a bare `t('word')` because the callee is ambiguous — `emit('save')` is not a translation. **That guard is correct** and this PR keeps it.

What was wrong is that the match was *discarded*. The scanner's second safety net, `bareStringCandidates`, also requires a dot (`if (expr.includes('.'))`), so a dotless key is invisible to both nets at once and falls straight through to the deletable bucket. Namespaced projects never notice; flat catalogues — the common React and plain-Vue shape — lose keys.

## The fix

The rejected argument is kept as a bare string candidate instead of dropped.

That is the conservative lever rather than the aggressive one. Candidates are intersected with the real catalogue, so they protect a key only when one of that exact name exists: `emit('save')` in a project with no `save` key still protects nothing. And because the key is recorded as a *candidate* rather than a *usage*, `check` / `find_undefined_keys` gains no false "used but never defined" reports — which is what the guard was protecting in the first place.

The trade-off is deliberate: for flat catalogues, a string matching a key name anywhere in an i18n call now protects it. The scan errs toward not deleting, which is the direction it already documents ("conservative on purpose") and the opposite of what it did here.

## Verification

- 3 new tests at the extraction seam: the candidate is kept, dotted keys still record usages, and the unambiguous callees (`$t`, `this.$t`) are unaffected
- 944 CLI tests pass
- original reproduction confirmed fixed, with `cancel` still correctly reported — the scan stays useful rather than protecting everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)
