### PR TITLE
fix(generic): support flat PHP locale files end to end

### DIFF
--- a/packages/cli/src/adapters/generic/index.ts
+++ b/packages/cli/src/adapters/generic/index.ts
@@ -71,11 +71,14 @@ export class GenericAdapter implements FrameworkAdapter {
       )
     }
 
-    const locales: LocaleDefinition[] = discoveredLocales.map(code => ({
+    const locales: LocaleDefinition[] = await Promise.all(discoveredLocales.map(async code => ({
       code,
       language: code,
-      ...(detectedFormat === 'json' ? { file: `${code}.json` } : {}),
-    }))
+      // `file` names the flat file to read and write. A namespaced PHP layout
+      // (Laravel's lang/<locale>/<namespace>.php) has no single file, and
+      // resolveLocaleEntries discovers those from disk instead.
+      ...(await flatFileFor(localeDirs, code, detectedFormat)),
+    })))
 
     log.info(
       `Generic adapter: ${locales.length} locale(s), format=${detectedFormat}, `
@@ -96,6 +99,22 @@ export class GenericAdapter implements FrameworkAdapter {
   }
 }
 
+/**
+ * The flat file for a locale, when there is one. Absent for a namespaced
+ * layout, where each namespace is its own file and no single name applies.
+ */
+async function flatFileFor(
+  localeDirs: Array<{ path: string }>,
+  code: string,
+  format: LocaleFileFormat,
+): Promise<{ file?: string }> {
+  const ext = format === 'php-array' ? '.php' : '.json'
+  for (const dir of localeDirs) {
+    if (existsSync(join(dir.path, `${code}${ext}`))) return { file: `${code}${ext}` }
+  }
+  return {}
+}
+
 async function detectFileFormat(localeDir: string): Promise<LocaleFileFormat> {
   let entries: import('node:fs').Dirent[]
   try {
@@ -105,9 +124,13 @@ async function detectFileFormat(localeDir: string): Promise<LocaleFileFormat> {
     return 'json'
   }
 
-  // Flat files: en.json, de.json
+  // Flat files: en.json, de.json — or en.php, de.php for a PHP project that
+  // does not use Laravel's directory-per-locale layout.
   if (entries.some(e => e.isFile() && e.name.endsWith('.json'))) {
     return 'json'
+  }
+  if (entries.some(e => e.isFile() && e.name.endsWith('.php'))) {
+    return 'php-array'
   }
 
   // Directory-per-locale: en/, de/ — check contents
@@ -140,8 +163,9 @@ async function discoverLocales(localeDirs: LocaleDir[], format: LocaleFileFormat
     for (const entry of entries) {
       if (entry.name.startsWith('.')) continue
 
-      if (entry.isFile() && entry.name.endsWith('.json') && format === 'json') {
-        const code = entry.name.replace(/\.json$/, '')
+      const flatExt = format === 'php-array' ? '.php' : '.json'
+      if (entry.isFile() && entry.name.endsWith(flatExt)) {
+        const code = entry.name.slice(0, -flatExt.length)
         if (!NON_LOCALE_NAMES.has(code.toLowerCase())) {
           codes.add(code)
         }

--- a/packages/cli/src/io/locale-data.ts
+++ b/packages/cli/src/io/locale-data.ts
@@ -39,7 +39,15 @@ export async function resolveLocaleEntries(
   if (!localeDir) return []
 
   if (config.localeFileFormat === 'php-array') {
-    return resolveNamespacedEntries(localeDir, locale.code, '.php')
+    // Laravel: lang/<locale>/<namespace>.php
+    const namespaced = await resolveNamespacedEntries(localeDir, locale.code, '.php')
+    if (namespaced.length > 0) return namespaced
+
+    // Flat: lang/<locale>.php. Not Laravel's layout, but a legitimate one that
+    // the generic adapter meets in the wild (#308), and indistinguishable from
+    // namespaced by format alone — only the directory says which it is.
+    const flat = locale.file ?? `${locale.code}.php`
+    return existsSync(join(localeDir, flat)) ? [{ path: join(localeDir, flat), namespace: null }] : []
   }
 
   // Namespaced JSON (Next.js/React: messages/en/common.json)
@@ -151,9 +159,14 @@ export async function mutateLocaleData(
   const filesWritten = new Set<string>()
 
   const entries = await resolveLocaleEntries(config, layer, locale)
-  const isNamespaced = config.localeFileFormat === 'php-array'
-    || entries.some(e => e.namespace !== null)
-    || await hasNamespacedJsonLayout(config, layer)
+  // What is on disk decides, not the declared format: a PHP project may be
+  // namespaced (Laravel) or flat (#308), and writing one as the other would
+  // restructure someone's locale files rather than edit them. The format is
+  // the fallback for a locale that has no files yet, where there is nothing
+  // to observe — scaffolding a new Laravel locale, for instance.
+  const isNamespaced = entries.length > 0
+    ? entries.some(e => e.namespace !== null)
+    : config.localeFileFormat === 'php-array' || await hasNamespacedJsonLayout(config, layer)
 
   if (isNamespaced) {
     // Per-namespace write (PHP arrays or namespaced JSON)

--- a/packages/cli/tests/adapters/generic-adapter.test.ts
+++ b/packages/cli/tests/adapters/generic-adapter.test.ts
@@ -254,6 +254,58 @@ describe('GenericAdapter.resolve', () => {
   })
 })
 
+describe('GenericAdapter with flat PHP locale files (#308)', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `generic-php-test-${Date.now()}`)
+    mkdirSync(join(tempDir, 'lang'), { recursive: true })
+    writeFileSync(join(tempDir, 'lang', 'en.php'), '<?php\nreturn [\n  "save" => "Save",\n];\n')
+    writeFileSync(join(tempDir, 'lang', 'de.php'), '<?php\nreturn [\n  "save" => "Speichern",\n];\n')
+    writeFileSync(join(tempDir, '.i18n-mcp.json'), JSON.stringify({
+      localeDirs: ['lang'],
+      defaultLocale: 'en',
+    }))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // Detection only looked for .php inside per-locale directories, so a flat
+  // layout read as an empty directory and resolve threw "No locale files found".
+  it('detects the format from flat .php files', async () => {
+    const config = await new GenericAdapter().resolve(tempDir)
+
+    expect(config.localeFileFormat).toBe('php-array')
+  })
+
+  it('discovers the locales rather than failing', async () => {
+    const config = await new GenericAdapter().resolve(tempDir)
+
+    expect(config.locales.map(l => l.code)).toEqual(['de', 'en'])
+  })
+
+  // `file` is what tells the reader there is a single file per locale. A
+  // namespaced PHP layout has none, and leaves it unset.
+  it('names the flat file on each locale', async () => {
+    const config = await new GenericAdapter().resolve(tempDir)
+
+    expect(config.locales.map(l => l.file)).toEqual(['de.php', 'en.php'])
+  })
+
+  it('leaves a namespaced PHP layout without a file name', async () => {
+    rmSync(join(tempDir, 'lang'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, 'lang', 'en'), { recursive: true })
+    writeFileSync(join(tempDir, 'lang', 'en', 'auth.php'), '<?php\nreturn [\n  "failed" => "Failed",\n];\n')
+
+    const config = await new GenericAdapter().resolve(tempDir)
+
+    expect(config.localeFileFormat).toBe('php-array')
+    expect(config.locales.map(l => l.file)).toEqual([undefined])
+  })
+})
+
 describe('Adapter registry: Generic vs others', () => {
   let tempDir: string
 

--- a/packages/cli/tests/io/locale-data.test.ts
+++ b/packages/cli/tests/io/locale-data.test.ts
@@ -637,3 +637,74 @@ describe('resolveLocaleEntries flat-layout misconfiguration', () => {
     }
   })
 })
+
+describe('flat PHP locale files (#308)', () => {
+  /**
+   * `php-array` meant Laravel's lang/<locale>/<namespace>.php, always. A flat
+   * lang/<locale>.php could not be resolved, and the write path would have
+   * restructured it into directories rather than editing it. What is on disk
+   * decides now; the format is only the fallback when there is nothing there
+   * yet to observe.
+   */
+  function makeFlatPhpConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+    return {
+      rootDir: tempDir,
+      defaultLocale: 'en',
+      fallbackLocale: { default: ['en'] },
+      locales: [
+        { code: 'en', language: 'en', file: 'en.php' },
+        { code: 'de', language: 'de', file: 'de.php' },
+      ],
+      localeDirs: [{ path: join(tempDir, 'lang'), layer: 'default', layerRootDir: tempDir }],
+      layerRootDirs: [tempDir],
+      localeFileFormat: 'php-array',
+      apps: [{ name: 'default', rootDir: tempDir, layers: ['default'] }],
+      ...overrides,
+    }
+  }
+
+  const de: LocaleDefinition = { code: 'de', language: 'de', file: 'de.php' }
+
+  beforeEach(async () => {
+    await mkdir(join(tempDir, 'lang'), { recursive: true })
+    await writeFile(join(tempDir, 'lang', 'de.php'), '<?php\nreturn [\n  "save" => "Speichern",\n];\n')
+  })
+
+  it('resolves the flat file', async () => {
+    const entries = await resolveLocaleEntries(makeFlatPhpConfig(), 'default', de)
+
+    expect(entries).toEqual([{ path: join(tempDir, 'lang', 'de.php'), namespace: null }])
+  })
+
+  it('reads its keys unnamespaced', async () => {
+    const data = await readLocaleData(makeFlatPhpConfig(), 'default', de)
+
+    expect(data).toEqual({ save: 'Speichern' })
+  })
+
+  it('writes back into the same file instead of creating a directory', async () => {
+    const written = await mutateLocaleData(makeFlatPhpConfig(), 'default', de, (data) => {
+      data.cancel = 'Abbrechen'
+    })
+
+    expect([...written]).toEqual([join(tempDir, 'lang', 'de.php')])
+
+    const onDisk = await readFile(join(tempDir, 'lang', 'de.php'), 'utf-8')
+    expect(onDisk).toContain('"cancel" => "Abbrechen"')
+    expect(onDisk).toContain('"save" => "Speichern"')
+  })
+
+  // The Laravel layout must keep working: entries carry a namespace, so the
+  // namespaced write path still applies.
+  it('still treats a namespaced PHP layout as namespaced', async () => {
+    await mkdir(join(tempDir, 'lang', 'de'), { recursive: true })
+    await writeFile(join(tempDir, 'lang', 'de', 'auth.php'), '<?php\nreturn [\n  "failed" => "Fehlgeschlagen",\n];\n')
+
+    const config = makeFlatPhpConfig({
+      locales: [{ code: 'de', language: 'de' }],
+    })
+    const entries = await resolveLocaleEntries(config, 'default', { code: 'de', language: 'de' })
+
+    expect(entries.map(e => e.namespace)).toEqual(['auth'])
+  })
+})


### PR DESCRIPTION
Closes #308.

```
lang/en.php   <?php return [ "save" => "Save", "cancel" => "Cancel" ];
lang/de.php   <?php return [ "save" => "Speichern" ];
```

```
before: {"error":{"code":"CONFIG_ERROR","message":"No locale files found in .../lang"}}
after:  {"missing":{"de":{"default":["cancel"]}},"total":1}
```

## Why detection alone would have been worse than the error

`detectFileFormat` only looked for `.php` **inside per-locale directories**, so a flat layout read as an empty directory. Laravel is unaffected — its own layout *is* directory-per-locale — which is why this only ever surfaced on the generic adapter.

But `php-array` was taken to mean Laravel's `lang/<locale>/<namespace>.php` everywhere, in three places: `resolveLocaleEntries` short-circuited to namespaced resolution, and the write path set `isNamespaced` from the format constant. So had I only fixed detection, the CLI would have read flat files and written them back **as directories** — restructuring someone's locale files instead of editing them. A loud `CONFIG_ERROR` is better than that.

## The fix: observe the layout, don't assume it

- `detectFileFormat` recognises flat `.php` files
- locale discovery uses the detected format's extension for flat files, and sets `file` on each locale so the reader can find it — a namespaced layout has no single file and leaves it unset
- `resolveLocaleEntries` tries the namespaced layout first, then falls back to a flat `<code>.php`
- the write path decides namespaced-vs-flat from **the entries actually on disk**, falling back to the declared format only when there are none — a locale being scaffolded for the first time, where there is nothing to observe

That last point is the one that matters for Laravel: entries there carry a namespace, so the namespaced write path still applies, and a brand-new locale with no files still scaffolds as namespaced.

## Verification

End to end on the reported layout, not just unit tests:

```
$ the-i18n-cli write --layer default --translations '{"cancel":{"de":"Abbrechen"}}'
{"written":["cancel"],"filesWritten":1}

$ find lang -type f
lang/de.php    lang/en.php          ← no directory created

$ cat lang/de.php
<?php

return [
  "cancel" => "Abbrechen",
  "save" => "Speichern",
];
```

- 8 new tests: format detection, locale discovery, `file` naming, the namespaced layout still resolving as namespaced, and a read/write round trip asserting the file is edited in place
- 949 CLI tests pass, lint and typecheck clean

## Note for #324

This is **not** fixed by the typed-config work. The reproduction already declares `localeDirs` and `defaultLocale` explicitly and still failed — the bug was in format detection and layout handling, not in locating the directory. The two are independent despite being linked as related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
