### PR TITLE
feat(mcp): expose find_empty_translations

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -112,6 +112,7 @@ The Vue and React/Next adapters resolve a single locale directory and take the a
 | `remove_translations` | Remove keys from all locale files in a layer |
 | `rename_translation_key` | Rename/move a key across all locales |
 | `get_missing_translations` | Find keys missing in target locales |
+| `find_empty_translations` | Find keys whose value is an empty string — present in the file, so not missing, but rendering as nothing |
 | `get_translation_status` | Coverage in one call: per-locale and per-layer counts plus an overall completion percentage. Use instead of calling `get_missing_translations` per layer |
 | `search_translations` | Search by key or value (case-insensitive substring, not fuzzy) |
 | `translate_missing` | Find and translate missing keys — provider mode translates directly, agent mode returns fallback contexts |

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,7 @@ import {
   getTranslations,
   writeTranslations,
   getMissingTranslations,
+  findEmptyTranslations,
   getTranslationStatus,
   searchTranslations,
   removeTranslations,
@@ -317,6 +318,39 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
         return jsonContent(result)
       } catch (error) {
         return toolErrorResponse('listing namespaces', error)
+      }
+    },
+  )
+
+  // ─── Tool: find_empty_translations ─────────────────────────────
+
+  server.registerTool(
+    'find_empty_translations',
+    {
+      title: 'Find Empty Translations',
+      description:
+        'Find keys whose value is an empty string. '
+        + 'These exist in the locale file, so they are not reported as missing, and they render as nothing in the UI. '
+        + 'Use this after a scaffold or an interrupted translation run to find keys that were created but never filled.',
+      inputSchema: z.object({
+        layer: z
+          .string()
+          .optional()
+          .describe('Layer name to filter by (e.g., "root", "app-admin"). If omitted, checks all layers. Call discover to discover available layers.'),
+        locale: z
+          .string()
+          .optional()
+          .describe('Locale to check (e.g., "de"). If omitted, checks every locale.'),
+        projectDir: projectDirInput(),
+        outputFile: outputFileInput('/tmp/empty-translations.json'),
+      }),
+    },
+    async ({ layer, locale, projectDir = DEFAULT_PROJECT_DIR, outputFile }) => {
+      try {
+        const result = await findEmptyTranslations({ layer, locale, projectDir, outputFile })
+        return jsonContent(result)
+      } catch (error) {
+        return toolErrorResponse('finding empty translations', error)
       }
     },
   )

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -99,6 +99,7 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(names).toEqual([
       'discover',
       'find_duplicate_keys',
+      'find_empty_translations',
       'find_orphan_keys',
       'find_undefined_keys',
       'get_missing_translations',
@@ -129,6 +130,29 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     const result = await client.readResource({ uri: 'i18n:///root/de' })
     const content = result.contents[0] as { text: string }
     expect(JSON.parse(content.text)).toMatchObject({ greeting: 'Hallo {name}' })
+  })
+
+  it('find_empty_translations reports a key that exists but has no value', async () => {
+    // Empty values are not missing keys — they are present in the file and
+    // render as nothing, which is why they need a report of their own.
+    const dir = await makeProject()
+    await writeFile(join(dir, 'i18n', 'locales', 'en.json'), JSON.stringify({
+      greeting: '',
+      actions: { save: 'Save' },
+    }))
+
+    const { json } = await callTool('find_empty_translations', { projectDir: dir })
+
+    expect(json?.summary).toMatchObject({ totalEmpty: 1 })
+  })
+
+  it('find_empty_translations narrows to one locale when asked', async () => {
+    const dir = await makeProject()
+    await writeFile(join(dir, 'i18n', 'locales', 'en.json'), JSON.stringify({ greeting: '' }))
+
+    const { json } = await callTool('find_empty_translations', { projectDir: dir, locale: 'de' })
+
+    expect(json?.summary).toMatchObject({ totalEmpty: 0 })
   })
 
   it('discover returns the project configuration and the agent translation mode', async () => {


### PR DESCRIPTION
Closes #252 — the last item left on it, after the four CLI commands were restored.

`findEmptyTranslations` has been in the core and reachable as the `empty` CLI command. Over MCP it did not exist, so an agent could ask for missing keys and for orphans, but not for keys that are **present with an empty value** — not missing, since the key is in the file, and rendering as nothing in the UI.

That is exactly the state left behind by a `scaffold_locale` or an interrupted `translate_missing`, which makes it the question an agent picking up that work needs to ask.

## Surface

Same shape as its sibling read tools — `layer`, `locale`, `projectDir`, `outputFile` — using the shared `projectDirInput()` and `outputFileInput()` helpers so the descriptions stay identical across tools, and the same `toolErrorResponse` envelope.

Registered next to `list_namespaces`, which it matches most closely.

## Verification

- the tool-surface test now asserts 17 tools rather than 16, so a future removal is caught
- two behavioural tests: a key with an empty value is reported, and `locale` narrows the search
- both confirmed to actually run (`-t find_empty` → 2 passed), not silently skipped
- 30 MCP tests pass; typecheck and lint clean

Documented in the MCP README's tool table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)