### PR TITLE
feat: tell users on the old package names that the kit has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ Agent changes wording for an existing key
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [**the-i18n-cli**](./packages/cli) | [![npm](https://img.shields.io/npm/v/the-i18n-cli?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-cli) | CLI + core library — install globally |
-| [**the-i18n-mcp**](./packages/mcp) | [![npm](https://img.shields.io/npm/v/the-i18n-mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-mcp) | MCP server for AI agents |
+| [**@the-i18n-kit/cli**](./packages/cli) | [![npm](https://img.shields.io/npm/v/@the-i18n-kit/cli?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/cli) | CLI + core library — install globally |
+| [**@the-i18n-kit/mcp**](./packages/mcp) | [![npm](https://img.shields.io/npm/v/@the-i18n-kit/mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/mcp) | MCP server for AI agents |
 | [**@the-i18n-kit/nuxt**](./packages/nuxt) | [![npm](https://img.shields.io/npm/v/@the-i18n-kit/nuxt?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/nuxt) | Nuxt module — publishes the layer graph and locale table Nuxt already resolved |
+
+
+> **Renamed.** The packages moved to the `@the-i18n-kit` scope. `the-i18n-cli` and
+> `the-i18n-mcp` still publish from the same source at the same versions and keep
+> working, but they will stop receiving updates — switch when convenient.
 
 ---
 
@@ -65,7 +70,7 @@ Agent changes wording for an existing key
 ### CLI
 
 ```bash
-npm install -g the-i18n-cli
+npm install -g @the-i18n-kit/cli
 
 the-i18n-cli init                      # create .i18n-mcp.json from framework detection
 the-i18n-cli missing                   # find missing translations
@@ -86,7 +91,7 @@ Add to your MCP host (VS Code, Cursor, Claude Desktop, Zed):
     "the-i18n-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["the-i18n-mcp@latest"]
+      "args": ["@the-i18n-kit/mcp@latest"]
     }
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # the-i18n-cli
 
-[![npm version](https://img.shields.io/npm/v/the-i18n-cli?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-cli)
+[![npm version](https://img.shields.io/npm/v/@the-i18n-kit/cli?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/cli)
 [![License](https://img.shields.io/npm/l/the-i18n-cli?style=flat&colorA=18181b&colorB=4fc08d)](https://github.com/fabkho/the-i18n-kit/blob/main/LICENSE)
 
 CLI and core library for managing i18n translation files — supports Nuxt, Laravel, Vue, React/Next.js, and any project with JSON or PHP locale files.
@@ -13,7 +13,7 @@ Part of [the-i18n-kit](https://github.com/fabkho/the-i18n-kit) monorepo. For MCP
 
 ```bash
 # Global install
-npm install -g the-i18n-cli
+npm install -g @the-i18n-kit/cli
 
 # Or use directly with npx
 npx the-i18n-cli --help

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -13,5 +13,14 @@ const isHelpOrVersion = args.includes('--help') || args.includes('-h')
 if (!isHelpOrVersion) {
   guardStdout()
 }
+// Renamed packages announce themselves once per invocation, on stderr so the
+// JSON on stdout is untouched. The package reads its own name, so this is
+// silent when running as @the-i18n-kit/cli (#315).
+const { renameNotice } = await import('./utils/rename-notice.js')
+const { createRequire } = await import('node:module')
+const { name } = createRequire(import.meta.url)('../package.json') as { name: string }
+const notice = renameNotice(name)
+if (notice) process.stderr.write(`[the-i18n-cli] ${notice}\n`)
+
 const { runCli } = await import('./cli.js')
 await runCli()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,6 +51,7 @@ export { readLocaleData } from './io/locale-data.js'
 
 // Errors
 export { ToolError, toErrorMessage } from './utils/errors.js'
+export { renameNotice } from './utils/rename-notice.js'
 
 // LLM providers
 export { createTranslateFn, TranslateProviderError, classifyProviderError, resolveProviderBaseUrl, BASE_URL_ENV } from './llm/providers.js'

--- a/packages/cli/src/utils/rename-notice.ts
+++ b/packages/cli/src/utils/rename-notice.ts
@@ -1,0 +1,41 @@
+/**
+ * The kit is renaming to the `@the-i18n-kit` scope (#315). During the window
+ * both names publish from one source at matching versions, so nothing breaks —
+ * but a user on the old name has no way of learning that unless the package
+ * tells them.
+ *
+ * A package finds out it is the old one by reading its own `name` at runtime,
+ * which is why this takes the name rather than deciding for itself: the same
+ * code ships under both names, and only the manifest differs.
+ */
+
+interface Rename {
+  /** Where it moved to. */
+  to: string
+  /** How to move, phrased for whoever is going to read this particular notice. */
+  how: string
+}
+
+const RENAMES: Record<string, Rename> = {
+  'the-i18n-cli': {
+    to: '@the-i18n-kit/cli',
+    how: 'Install it with: npm i -g @the-i18n-kit/cli',
+  },
+  'the-i18n-mcp': {
+    to: '@the-i18n-kit/mcp',
+    how: 'Update your MCP client config to run: npx @the-i18n-kit/mcp@latest',
+  },
+}
+
+/**
+ * The notice for a package running under a legacy name, or null when it is
+ * already running under its new one — which is the case that must stay silent,
+ * since a notice there would be telling people to do what they have done.
+ */
+export function renameNotice(packageName: string): string | null {
+  const rename = RENAMES[packageName]
+  if (!rename) return null
+
+  return `${packageName} is now ${rename.to}. Both names publish from the same source at the same versions, `
+    + `and the old one will stop receiving updates. ${rename.how}`
+}

--- a/packages/cli/tests/cli/bin-streams.test.ts
+++ b/packages/cli/tests/cli/bin-streams.test.ts
@@ -47,6 +47,15 @@ describe('bin stream routing', () => {
     expect(stdout).toContain('--batchSize')
   })
 
+  // The rename notice (#315) is a diagnostic, and CI pipes stdout into jq.
+  it('prints the rename notice on stderr, leaving stdout parseable', async () => {
+    const { stdout, stderr } = await runBin(['--version'])
+
+    expect(stderr).toContain('@the-i18n-kit/cli')
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(stdout).not.toContain('@the-i18n-kit/cli')
+  })
+
   it('--version prints the version on stdout', async () => {
     const { stdout, code } = await runBin(['--version'])
     expect(code).toBe(0)

--- a/packages/cli/tests/cli/rename-notice.test.ts
+++ b/packages/cli/tests/cli/rename-notice.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { renameNotice } from '../../src/utils/rename-notice.js'
+
+/**
+ * During the rename window (#315) both names publish from one source, so
+ * nothing breaks — but a user on the old name has no way of finding out unless
+ * the package says so. The same code ships under both names, which is why this
+ * decides from the name it is given rather than from anything ambient.
+ */
+
+describe('the rename notice', () => {
+  it('tells a legacy CLI where it moved and how to move with it', () => {
+    const notice = renameNotice('the-i18n-cli')
+
+    expect(notice).toContain('@the-i18n-kit/cli')
+    expect(notice).toContain('npm i -g @the-i18n-kit/cli')
+  })
+
+  // The MCP server is not installed by hand — an editor runs it through npx —
+  // so "npm i" would be the wrong instruction to give.
+  it('tells a legacy MCP server to update its client config instead', () => {
+    const notice = renameNotice('the-i18n-mcp')
+
+    expect(notice).toContain('@the-i18n-kit/mcp')
+    expect(notice).toContain('npx @the-i18n-kit/mcp@latest')
+    expect(notice).not.toContain('npm i')
+  })
+
+  // The case that must stay silent: telling someone to do what they have done.
+  it.each(['@the-i18n-kit/cli', '@the-i18n-kit/mcp', '@the-i18n-kit/nuxt'])(
+    'says nothing when already running as %s',
+    (name) => {
+      expect(renameNotice(name)).toBeNull()
+    },
+  )
+
+  it('says nothing for a package it knows nothing about', () => {
+    expect(renameNotice('some-other-package')).toBeNull()
+  })
+
+  it('explains that both names work, so the notice does not read as a break', () => {
+    const notice = renameNotice('the-i18n-cli')
+
+    expect(notice).toContain('same source')
+    expect(notice).toContain('stop receiving updates')
+  })
+})

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,14 +1,14 @@
 # the-i18n-mcp
 
-[![npm version](https://img.shields.io/npm/v/the-i18n-mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/the-i18n-mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/the-i18n-mcp)
+[![npm version](https://img.shields.io/npm/v/@the-i18n-kit/mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/mcp)
+[![npm downloads](https://img.shields.io/npm/dm/@the-i18n-kit/mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://npmjs.com/package/@the-i18n-kit/mcp)
 [![License](https://img.shields.io/npm/l/the-i18n-mcp?style=flat&colorA=18181b&colorB=4fc08d)](https://github.com/fabkho/the-i18n-kit/blob/main/LICENSE)
 
 MCP server for managing i18n translation files — gives your AI agent full control over your app's translations without dumping entire locale files into context.
 
 13 purpose-built tools that let the agent work surgically — touching only the keys it needs. Auto-detects Nuxt, Laravel, Vue, React/Next.js, or any project with JSON/PHP locale files.
 
-Part of [the-i18n-kit](https://github.com/fabkho/the-i18n-kit) monorepo. For CLI usage, see [the-i18n-cli](https://www.npmjs.com/package/the-i18n-cli).
+Part of [the-i18n-kit](https://github.com/fabkho/the-i18n-kit) monorepo. For CLI usage, see [@the-i18n-kit/cli](https://www.npmjs.com/package/@the-i18n-kit/cli).
 
 ## Quick Start
 
@@ -25,7 +25,7 @@ Add to `.vscode/mcp.json`:
     "the-i18n-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["the-i18n-mcp@latest"]
+      "args": ["@the-i18n-kit/mcp@latest"]
     }
   }
 }
@@ -43,7 +43,7 @@ Add to `.zed/settings.json`:
   "context_servers": {
     "the-i18n-mcp": {
       "command": "npx",
-      "args": ["the-i18n-mcp@latest"]
+      "args": ["@the-i18n-kit/mcp@latest"]
     }
   }
 }
@@ -61,7 +61,7 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "the-i18n-mcp": {
       "command": "npx",
-      "args": ["the-i18n-mcp@latest"]
+      "args": ["@the-i18n-kit/mcp@latest"]
     }
   }
 }
@@ -242,7 +242,7 @@ Set environment variables on the server process and the server calls the LLM pro
     "the-i18n-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["the-i18n-mcp@latest"],
+      "args": ["@the-i18n-kit/mcp@latest"],
       "env": {
         "I18N_PROVIDER": "google",
         "I18N_MODEL": "gemini-2.5-flash",
@@ -284,7 +284,7 @@ Locales listed in `protectedLocales` are excluded from default translate targets
 
 > `npx the-i18n-mcp` and `npx nuxt-i18n-mcp` still work — both bin names point to the same server.
 
-MCP sampling was removed: `translate_missing` no longer asks the host to pick a model, and `samplingPreferences` in `.i18n-mcp.json` is ignored (still accepted for backward compatibility). To keep server-side translation, configure provider mode via the env variables above; otherwise the tools run in agent mode and your agent translates the returned fallback contexts itself. The core logic lives in [the-i18n-cli](https://www.npmjs.com/package/the-i18n-cli).
+MCP sampling was removed: `translate_missing` no longer asks the host to pick a model, and `samplingPreferences` in `.i18n-mcp.json` is ignored (still accepted for backward compatibility). To keep server-side translation, configure provider mode via the env variables above; otherwise the tools run in agent mode and your agent translates the returned fallback contexts itself. The core logic lives in [@the-i18n-kit/cli](https://www.npmjs.com/package/@the-i18n-kit/cli).
 
 ## License
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,13 +4,14 @@ import type { CacheHint } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 
 const require = createRequire(import.meta.url)
-const { version } = require('../package.json') as { version: string }
+const { name: packageName, version } = require('../package.json') as { name: string, version: string }
 
 import {
   detectI18nConfig,
   getCachedConfig,
   readLocaleData,
   ToolError,
+  renameNotice,
   detectConfig,
   listLocaleDirs,
   getTranslations,
@@ -181,11 +182,34 @@ function toolErrorResponse(context: string, error: unknown) {
 }
 
 /**
+ * The rename notice (#315), or null when running under the new name.
+ *
+ * An editor spawns this server through `npx`, so an install-time deprecation
+ * is printed into a stream nobody reads and the agent using the tools never
+ * learns the package moved. It has to reach the model at runtime instead.
+ */
+const RENAME_NOTICE = renameNotice(packageName)
+
+/**
+ * Delivered once, not on every response. Repeating it on every tool call would
+ * cost context on each one and teach the model to skip it — the opposite of
+ * what a notice is for.
+ */
+let noticeDelivered = false
+
+/**
  * Wrap a plain result object as MCP text content.
  */
 function jsonContent(data: unknown) {
+  let payload = data
+
+  if (RENAME_NOTICE && !noticeDelivered && payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
+    noticeDelivered = true
+    payload = { ...payload, _notice: RENAME_NOTICE }
+  }
+
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
   }
 }
 
@@ -223,12 +247,17 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     ? { mode: 'provider', translateFn: options.translateFn }
     : await resolveTranslationBackend()
 
+  // Each server gets its own one-shot, so a process hosting several does not
+  // silently swallow the notice for all but the first.
+  noticeDelivered = false
+
   const server = new McpServer(
     {
       name: 'the-i18n-mcp',
       version,
     },
     {
+      ...(RENAME_NOTICE ? { instructions: RENAME_NOTICE } : {}),
       // 2026-07-28 responses only — legacy-era responses never carry cache
       // fields. Everything is 'private': locale data is project-local.
       cacheHints: {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -191,25 +191,30 @@ function toolErrorResponse(context: string, error: unknown) {
 const RENAME_NOTICE = renameNotice(packageName)
 
 /**
- * Delivered once, not on every response. Repeating it on every tool call would
- * cost context on each one and teach the model to skip it — the opposite of
- * what a notice is for.
+ * Wrap a plain result object as MCP text content, delivering the rename notice
+ * on the first result this server produces.
+ *
+ * Built per server rather than shared: with the flag at module scope, two
+ * servers in one process race for a single delivery and whichever called
+ * second never announced itself at all.
+ *
+ * Once, not per call. Repeating it would cost context on every response and
+ * teach the model to skip it — the opposite of what a notice is for.
  */
-let noticeDelivered = false
+function createJsonContent() {
+  let noticeDelivered = false
 
-/**
- * Wrap a plain result object as MCP text content.
- */
-function jsonContent(data: unknown) {
-  let payload = data
+  return function jsonContent(data: unknown) {
+    let payload = data
 
-  if (RENAME_NOTICE && !noticeDelivered && payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
-    noticeDelivered = true
-    payload = { ...payload, _notice: RENAME_NOTICE }
-  }
+    if (RENAME_NOTICE && !noticeDelivered && payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
+      noticeDelivered = true
+      payload = { ...payload, _notice: RENAME_NOTICE }
+    }
 
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+    }
   }
 }
 
@@ -247,9 +252,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     ? { mode: 'provider', translateFn: options.translateFn }
     : await resolveTranslationBackend()
 
-  // Each server gets its own one-shot, so a process hosting several does not
-  // silently swallow the notice for all but the first.
-  noticeDelivered = false
+  const jsonContent = createJsonContent()
 
   const server = new McpServer(
     {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -132,6 +132,18 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(JSON.parse(content.text)).toMatchObject({ greeting: 'Hallo {name}' })
   })
 
+  it('carries the rename notice on the first tool result and no later one', async () => {
+    // An editor spawns this server through npx, so an install-time deprecation
+    // is printed where nobody reads it. The notice has to reach the model at
+    // runtime — once, because repeating it on every call costs context on each
+    // one and teaches the model to skip it (#315).
+    const first = await callTool('discover', { projectDir })
+    const second = await callTool('discover', { projectDir })
+
+    expect(first.json?._notice).toContain('@the-i18n-kit/mcp')
+    expect(second.json).not.toHaveProperty('_notice')
+  })
+
   it('find_empty_translations reports a key that exists but has no value', async () => {
     // Empty values are not missing keys — they are present in the file and
     // render as nothing, which is why they need a report of their own.

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -132,6 +132,34 @@ describe('the-i18n-mcp server over in-memory transport', () => {
     expect(JSON.parse(content.text)).toMatchObject({ greeting: 'Hallo {name}' })
   })
 
+  // With the flag at module scope, two servers in one process raced for a
+  // single delivery: whichever called second never announced itself. Interleaved
+  // rather than sequential, because sequential passes either way.
+  it('gives each server its own notice, interleaved', async () => {
+    // Imported here for the same reason as the shared client above: the server
+    // reads its default project dir from the environment at module load.
+    const { createServer } = await import('../src/server.js')
+    const [a, b] = await Promise.all([
+      connectClient(await createServer()),
+      connectClient(await createServer()),
+    ])
+
+    try {
+      const firstA = await callToolOn(a, 'discover', { projectDir })
+      const firstB = await callToolOn(b, 'discover', { projectDir })
+      const secondA = await callToolOn(a, 'discover', { projectDir })
+      const secondB = await callToolOn(b, 'discover', { projectDir })
+
+      expect(firstA.json?._notice).toContain('@the-i18n-kit/mcp')
+      expect(firstB.json?._notice).toContain('@the-i18n-kit/mcp')
+      expect(secondA.json).not.toHaveProperty('_notice')
+      expect(secondB.json).not.toHaveProperty('_notice')
+    }
+    finally {
+      await Promise.all([a.close(), b.close()])
+    }
+  })
+
   it('carries the rename notice on the first tool result and no later one', async () => {
     // An editor spawns this server through npx, so an install-time deprecation
     // is printed where nobody reads it. The notice has to reach the model at


### PR DESCRIPTION
Second step of #315. The scoped packages published with 4.9.0 / 7.3.0, so there is now somewhere to send people.

## How a package knows it is the old one

It reads its own `name` at runtime. The same code ships under both names and only the manifest differs, so nothing is built twice, and the notice is **silent under the new names** — telling someone to do what they have already done is worse than saying nothing.

## Three surfaces, because one does not reach everyone

**CLI — one line on stderr per invocation.** stdout stays machine-readable, which the stdout guard exists to protect and which CI pipes into `jq`:

```
$ the-i18n-cli --version
4.9.0                                        ← stdout
[the-i18n-cli] the-i18n-cli is now @the-i18n-kit/cli. …   ← stderr
```

**MCP — the handshake, plus one shot.** This is the case that motivated the whole design. An editor spawns the server through `npx`, so an install-time deprecation is printed into a stream nobody reads, and the agent using the tools never learns the package moved. So it announces through the `instructions` field at `initialize`, which clients surface to the model once at connect, and appends `_notice` to the **first** tool result as a backstop.

Once, not per call. Repeating it would spend context on every response and teach the model to skip it — the opposite of what a notice is for, and against the context discipline the rest of this kit argues for.

**Docs** now install the scoped names, with a note that the old ones keep working and will simply stop moving.

## Verification

- `renameNotice` covers both legacy names with the right instruction for each — `npm i -g` for the CLI, `npx …@latest` for the server, since nobody installs an MCP server by hand — and returns null for all three scoped names and for anything unknown
- a stream-level test asserts the notice is on stderr and that stdout still parses as a bare version
- an MCP test asserts `_notice` on the first tool result and its absence on the second
- 1,018 CLI, 34 MCP and 37 module tests pass; lint, typecheck and `fallow audit` clean

## Not here

`npm deprecate` on the two old names. That is a registry operation rather than a code change, and it is the point of no return for discoverability — worth doing deliberately once this has shipped a release and the notices are actually live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, configuration, and package references to use the new scoped package names.
  * Documented legacy package names and migration guidance.

* **New Features**
  * Added rename notices for legacy CLI and MCP package names.
  * CLI notices are sent to stderr, preserving machine-readable stdout.
  * MCP rename guidance appears once in the initial tool response.

* **Bug Fixes**
  * Added coverage confirming version output and MCP responses remain correctly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->