### PR TITLE
fix(config): generate the published JSON Schema from the zod schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ This context is automatically loaded on `discover` before any translation work, 
 
 | Field | Purpose |
 |-------|---------|
-| `framework` | Force framework detection: `"nuxt"`, `"laravel"`, or `"generic"` |
+| `framework` | Force framework detection: any adapter name — `"nuxt"`, `"laravel"`, `"vue"`, `"react"` or `"generic"` |
 | `context` | Free-form project background for the agent |
 | `layerRules` | Rules for which layer a new key belongs to |
 | `glossary` | Term dictionary for consistent translations |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "pnpm -r --filter='./packages/*' build",
     "test": "pnpm -r --filter='./packages/*' test",
     "lint": "eslint packages/*/src/",
+    "generate:schema": "node scripts/generate-schema.mjs",
     "typecheck": "pnpm --filter the-i18n-cli build && pnpm -r --filter='./packages/*' typecheck"
   },
   "devDependencies": {

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -12,6 +12,15 @@ export function resetRegistry(): void {
   adapters.length = 0
 }
 
+/**
+ * The names of every registered adapter, in registration order. The published
+ * JSON Schema advertises these as `framework` suggestions, so an adapter added
+ * later shows up in editors without anyone editing a list by hand.
+ */
+export function listAdapterNames(): string[] {
+  return adapters.map(a => a.name)
+}
+
 export interface FrameworkMatch {
   adapter: FrameworkAdapter
   /** Detection score. 0 when the adapter was forced by hint rather than detected. */

--- a/packages/cli/src/config/schema-json.ts
+++ b/packages/cli/src/config/schema-json.ts
@@ -1,0 +1,52 @@
+/**
+ * The published JSON Schema (`packages/mcp/schema.json`) as generated output of
+ * the zod schema in `./schema.ts`.
+ *
+ * It used to be hand-written, and drifted: it hard-coded three adapter names in
+ * an `enum` while zod deliberately leaves `framework` open (adapters are a
+ * runtime registry), and it was `additionalProperties: false` without listing
+ * the deprecated keys zod still accepts. Both made editors flag configuration
+ * the tool happily runs. Generating it means the only way to change the
+ * published contract is to change the schema that enforces it.
+ *
+ * Run `pnpm generate:schema` after touching `./schema.ts`; a test fails if the
+ * committed file and this function disagree.
+ */
+import { z } from 'zod'
+import { projectConfigSchema } from './schema.js'
+import { listAdapterNames } from '../adapters/registry.js'
+// Registers the built-in adapters, so their names can be advertised below.
+import './detector.js'
+
+/**
+ * Metadata the published file carries that no zod field can express: consumers
+ * point `$schema` at `$id`, so it is part of the contract.
+ */
+const documentMeta = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json',
+  title: 'the-i18n-mcp project configuration',
+  description:
+    'Configuration for the-i18n-kit. Declare it as .i18n-mcp.json or i18n-kit.config.ts at '
+    + 'your project root, or as the i18nKit block in nuxt.config.ts — all three accept this '
+    + 'same shape. Every field is optional.',
+} as const
+
+function buildConfigJsonSchema(): Record<string, unknown> {
+  const generated = z.toJSONSchema(projectConfigSchema) as Record<string, unknown>
+  const properties = generated.properties as Record<string, Record<string, unknown>>
+
+  // Suggestions, not constraints: `framework` accepts any registered adapter
+  // name, including ones added after this file was generated, so the names go
+  // in as `examples` (which editors autocomplete) rather than an `enum` (which
+  // they reject anything outside of).
+  properties.framework = { ...properties.framework, examples: listAdapterNames() }
+
+  const { $schema: _generatedDialect, ...body } = generated
+  return { ...documentMeta, ...body }
+}
+
+/** The file as it should be committed — trailing newline included. */
+export function renderConfigJsonSchema(): string {
+  return `${JSON.stringify(buildConfigJsonSchema(), null, 2)}\n`
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -6,6 +6,11 @@
  * `nuxt.config.ts` all accept this same shape, and all validate against this
  * same schema. The `ProjectConfig` interface in `./types.ts` documents it;
  * the guard at the bottom of this file fails the build if the two drift.
+ *
+ * The `.describe()` text on each field is the published documentation of that
+ * field: `./schema-json.ts` converts this schema into `packages/mcp/schema.json`,
+ * which editors read for validation and tooltips. Write it for a user looking
+ * at their own config file, not for a reader of this module.
  */
 import { z } from 'zod'
 import type { ProjectConfig } from './types.js'
@@ -14,41 +19,152 @@ import { log } from '../utils/logger.js'
 const nonEmptyString = z.string().min(1).refine(s => s.trim().length > 0, 'Must not be empty or whitespace-only')
 
 const layerRuleSchema = z.object({
-  layer: z.string(),
-  description: z.string(),
-  when: z.string(),
+  layer: z.string()
+    .describe('Layer name (e.g., \'root\', \'app-admin\', \'app-shop\', \'lang\').'),
+  description: z.string()
+    .describe('What this layer contains — key namespaces, domain scope, etc.'),
+  when: z.string()
+    .describe('Natural-language rule describing when a key should go in this layer.'),
 })
 
 const localeDirEntrySchema = z.union([
-  nonEmptyString,
+  nonEmptyString
+    .describe('Relative path to a locale directory. Layer name defaults to \'default\'.'),
   z.object({
-    path: nonEmptyString,
-    layer: nonEmptyString,
+    path: nonEmptyString.describe('Relative path to a locale directory.'),
+    layer: nonEmptyString.describe('Layer name for this locale directory.'),
   }),
 ])
 
-const projectConfigSchema = z.object({
-  $schema: z.string().optional(),
-  framework: z.string().optional(),
-  context: z.string().optional(),
-  layerRules: z.array(layerRuleSchema).optional(),
-  glossary: z.record(z.string(), z.string()).optional(),
-  translationPrompt: z.string().optional(),
-  localeNotes: z.record(z.string(), z.string()).optional(),
-  examples: z.array(z.record(z.string(), z.string())).optional(),
+export const projectConfigSchema = z.object({
+  $schema: z.string()
+    .describe('Path or URL to the JSON schema for IDE autocompletion.')
+    .optional(),
+  framework: z.string()
+    .describe(
+      'Force framework detection instead of auto-detecting from project structure. '
+      + 'Any registered adapter name is accepted — the suggestions are the adapters '
+      + 'that ship today, not the only permitted values.',
+    )
+    .optional(),
+  context: z.string()
+    .describe(
+      'Free-form project background for the agent — business domain, user base, brand '
+      + 'voice, anything that helps the agent understand the project.',
+    )
+    .optional(),
+  layerRules: z.array(layerRuleSchema)
+    .describe(
+      'Rules that help the agent decide which layer a new translation key belongs to. '
+      + 'The agent interprets the natural-language \'when\' field.',
+    )
+    .optional(),
+  glossary: z.record(z.string(), z.string())
+    .describe(
+      'Term dictionary for consistent translations. Keys are source terms, values '
+      + 'describe the required translation or usage note.',
+    )
+    .optional(),
+  translationPrompt: z.string()
+    .describe(
+      'System prompt prepended to all translation requests (provider mode and agent-mode '
+      + 'fallback contexts). Sets tone, style, and constraints.',
+    )
+    .optional(),
+  localeNotes: z.record(z.string(), z.string())
+    .describe(
+      'Per-locale context included in translation prompts. Keys are locale codes (e.g., '
+      + '\'de-DE\', \'en-US\', \'de-DE-formal\'), values describe register, regional '
+      + 'conventions, or other locale-specific guidance.',
+    )
+    .optional(),
+  examples: z.array(
+    z.record(z.string(), z.string())
+      .describe(
+        'A single translation example. \'key\' holds the dot-path translation key (e.g., '
+        + '\'common.actions.save\'), \'note\' an optional style comment, and every other '
+        + 'property is a locale code (e.g., \'de-DE\', \'en-US\') mapped to its translated value.',
+      ),
+  )
+    .describe(
+      'Few-shot translation examples that demonstrate the project\'s style. The agent uses '
+      + 'these as reference when generating translations.',
+    )
+    .optional(),
   orphanScan: z.record(z.string(), z.object({
-    ignorePatterns: z.array(z.string()).optional(),
-  }).passthrough()).optional(), // passthrough for backwards-compat with deprecated keys like includeParentLayer
-  localeDirs: z.array(localeDirEntrySchema).optional(),
-  defaultLocale: nonEmptyString.optional(),
-  locales: z.array(nonEmptyString).optional(),
-  protectedLocales: z.array(nonEmptyString).optional(),
-  reportOutput: z.union([z.literal(true), nonEmptyString]).optional(),
-  localeFileFormat: z.enum(['json', 'php-array']).optional(),
-  providerBaseUrl: nonEmptyString.optional(),
+    ignorePatterns: z.array(z.string())
+      .describe(
+        'Glob patterns for translation keys to exclude from orphan detection (e.g., '
+        + '"common.datetime.months.*"). Use * to match a single key segment, ** to match any depth.',
+      )
+      .optional(),
+  // passthrough for backwards-compat with deprecated keys like includeParentLayer
+  }).passthrough())
+    .describe(
+      'Per-layer configuration for orphan key detection. Map each layer name to its settings. '
+      + 'Scan directories are automatically determined from each layer\'s root directory.',
+    )
+    .optional(),
+  localeDirs: z.array(localeDirEntrySchema)
+    .describe(
+      'Locale directories for the generic adapter. Each entry is a path string (layer defaults '
+      + 'to \'default\') or an object with \'path\' and \'layer\' properties.',
+    )
+    .optional(),
+  defaultLocale: nonEmptyString
+    .describe('Default locale code. Required for generic adapter activation.')
+    .optional(),
+  locales: z.array(nonEmptyString)
+    .describe(
+      'Explicit list of locale codes to operate on. If absent, locales are auto-discovered '
+      + 'from files on disk.',
+    )
+    .optional(),
+  protectedLocales: z.array(nonEmptyString)
+    .describe(
+      'Human-maintained locales excluded from automatic translation. Entries may be any locale '
+      + 'ref (code, language tag, or file name); entries that do not match a known locale are '
+      + 'ignored with a warning. Explicitly naming a protected locale in targetLocales overrides '
+      + 'the protection (with a warning).',
+    )
+    .optional(),
+  reportOutput: z.union([
+    z.literal(true)
+      .describe('Set to true to write reports to the default \'.i18n-reports/\' directory.'),
+    nonEmptyString
+      .describe('Custom directory path (relative to project root) where diagnostic tool reports are written.'),
+  ])
+    .describe(
+      'Enable file output for diagnostic tools (get_missing_translations, search_translations, '
+      + 'find_orphan_keys, remove_orphan_keys). When set, each tool writes its full JSON report to '
+      + '<reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true '
+      + 'for the default \'.i18n-reports/\' directory, or a string for a custom path.',
+    )
+    .optional(),
+  localeFileFormat: z.enum(['json', 'php-array'])
+    .describe(
+      'Override the auto-detected locale file format. Useful when both formats exist or '
+      + 'auto-detection picks wrong.',
+    )
+    .optional(),
+  providerBaseUrl: nonEmptyString
+    .describe(
+      'Base URL for the LLM provider — gateways, self-hosted model servers and corporate proxies '
+      + 'that speak the provider\'s own protocol. Overrides the endpoint only, not the request shape '
+      + 'or auth header. Overridden by the I18N_BASE_URL environment variable and by --baseUrl. '
+      + 'Not supported by the "google" provider, which rejects it rather than ignoring it.',
+    )
+    .optional(),
   // Deprecated with the removal of MCP sampling: accepted so existing config
   // files keep validating (the schema is strict), warned about, and ignored.
-  samplingPreferences: z.unknown().optional(),
+  samplingPreferences: z.unknown()
+    .meta({
+      deprecated: true,
+      description:
+        'Deprecated and ignored — MCP sampling was removed. Still accepted so existing config '
+        + 'files keep validating. Configure a provider instead (e.g., I18N_PROVIDER/I18N_MODEL).',
+    })
+    .optional(),
 }).strict()
 
 /**

--- a/packages/cli/tests/cli/config-schema-json.test.ts
+++ b/packages/cli/tests/cli/config-schema-json.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Contract tests for the published JSON Schema, `packages/mcp/schema.json`.
+ *
+ * It ships in the mcp package's `files` array and users point `$schema` at it,
+ * so it is the schema editors validate against. It is generated from the zod
+ * schema that validates config at runtime (#346) — this test fails if the
+ * committed file drifts from the generator, and asserts the two divergences
+ * that motivated generating it, so a future reader knows what regressed
+ * before: `framework` rejecting shipped adapters, and the deprecated
+ * `samplingPreferences` key being rejected by a strict schema that omitted it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { renderConfigJsonSchema } from '../../src/config/schema-json'
+import { projectConfigSchema } from '../../src/config/schema'
+import { listAdapterNames } from '../../src/adapters/registry'
+
+const schemaPath = resolve(import.meta.dirname, '../../../mcp/schema.json')
+
+async function loadPublishedSchema(): Promise<{ raw: string, doc: Record<string, any> }> {
+  const raw = await readFile(schemaPath, 'utf-8')
+  return { raw, doc: JSON.parse(raw) as Record<string, any> }
+}
+
+describe('packages/mcp/schema.json', () => {
+  it('matches what the generator produces (run `pnpm generate:schema`)', async () => {
+    const { raw } = await loadPublishedSchema()
+    expect(raw).toBe(renderConfigJsonSchema())
+  })
+
+  it('keeps the document metadata consumers point $schema at', async () => {
+    const { doc } = await loadPublishedSchema()
+    expect(doc.$schema).toBe('https://json-schema.org/draft/2020-12/schema')
+    expect(doc.$id).toBe(
+      'https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json',
+    )
+    expect(doc.title).toBe('the-i18n-mcp project configuration')
+    expect(doc.description).toBeTruthy()
+    // Self-contained: no $ref out of the file, nothing to resolve.
+    expect(JSON.stringify(doc)).not.toContain('$ref')
+  })
+
+  it('describes every field, since editors surface the text as tooltips', async () => {
+    const { doc } = await loadPublishedSchema()
+    for (const [name, property] of Object.entries<any>(doc.properties)) {
+      expect(property.description, `${name} has no description`).toBeTruthy()
+    }
+  })
+
+  // ─── Regression: framework used to be an enum of three adapters ───
+  //
+  // Adapters are a runtime registry, so zod leaves `framework` a plain string.
+  // The hand-written schema hard-coded enum: ["nuxt", "laravel", "generic"],
+  // which flagged "vue" and "react" as invalid even though both adapters ship.
+
+  it('suggests every registered adapter for framework without constraining it', async () => {
+    const { doc } = await loadPublishedSchema()
+    const framework = doc.properties.framework
+
+    expect(framework.enum).toBeUndefined()
+    expect(framework.examples).toEqual(listAdapterNames())
+    expect(framework.examples).toEqual(expect.arrayContaining(['nuxt', 'laravel', 'generic', 'vue', 'react']))
+  })
+
+  it('validates framework set to any registered adapter, and to an unlisted value', () => {
+    for (const name of listAdapterNames()) {
+      expect(projectConfigSchema.safeParse({ framework: name }).success, name).toBe(true)
+    }
+    // An adapter that does not exist yet must not fail schema validation —
+    // detection reports an unknown hint, the schema does not pre-empt it.
+    expect(projectConfigSchema.safeParse({ framework: 'svelte' }).success).toBe(true)
+  })
+
+  // ─── Regression: samplingPreferences was rejected by the published schema ───
+  //
+  // The key is deprecated, warned about and dropped — accepted on purpose so
+  // existing config files keep validating. The published schema was
+  // additionalProperties: false and omitted it, rejecting exactly the configs
+  // the deprecation was designed to keep working.
+
+  it('accepts the deprecated samplingPreferences key and marks it deprecated', async () => {
+    const { doc } = await loadPublishedSchema()
+
+    expect(doc.additionalProperties).toBe(false)
+    expect(doc.properties.samplingPreferences).toBeDefined()
+    expect(doc.properties.samplingPreferences.deprecated).toBe(true)
+    expect(doc.properties.samplingPreferences.description).toMatch(/deprecated/i)
+
+    expect(projectConfigSchema.safeParse({
+      samplingPreferences: { hints: [{ name: 'claude-3-5-sonnet' }] },
+    }).success).toBe(true)
+  })
+
+  it('still accepts the self-referential $schema key', async () => {
+    const { doc } = await loadPublishedSchema()
+    expect(doc.properties.$schema.type).toBe('string')
+    expect(projectConfigSchema.safeParse({ $schema: './schema.json' }).success).toBe(true)
+  })
+})

--- a/packages/mcp/schema.json
+++ b/packages/mcp/schema.json
@@ -2,9 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/fabkho/the-i18n-kit/main/packages/mcp/schema.json",
   "title": "the-i18n-mcp project configuration",
-  "description": "Configuration file for the-i18n-mcp MCP server. Place as .i18n-mcp.json at your project root (next to nuxt.config.ts or artisan). All fields are optional — the server passes them to the AI agent as context for translation workflows.",
+  "description": "Configuration for the-i18n-kit. Declare it as .i18n-mcp.json or i18n-kit.config.ts at your project root, or as the i18nKit block in nuxt.config.ts — all three accept this same shape. Every field is optional.",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -12,8 +11,14 @@
     },
     "framework": {
       "type": "string",
-      "enum": ["nuxt", "laravel", "generic"],
-      "description": "Force framework detection instead of auto-detecting from project structure."
+      "description": "Force framework detection instead of auto-detecting from project structure. Any registered adapter name is accepted — the suggestions are the adapters that ship today, not the only permitted values.",
+      "examples": [
+        "nuxt",
+        "laravel",
+        "generic",
+        "vue",
+        "react"
+      ]
     },
     "context": {
       "type": "string",
@@ -21,15 +26,8 @@
     },
     "layerRules": {
       "type": "array",
-      "description": "Rules that help the agent decide which layer a new translation key belongs to. The agent interprets the natural-language 'when' field.",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "layer",
-          "description",
-          "when"
-        ],
         "properties": {
           "layer": {
             "type": "string",
@@ -43,15 +41,25 @@
             "type": "string",
             "description": "Natural-language rule describing when a key should go in this layer."
           }
-        }
-      }
+        },
+        "required": [
+          "layer",
+          "description",
+          "when"
+        ],
+        "additionalProperties": false
+      },
+      "description": "Rules that help the agent decide which layer a new translation key belongs to. The agent interprets the natural-language 'when' field."
     },
     "glossary": {
       "type": "object",
-      "description": "Term dictionary for consistent translations. Keys are source terms, values describe the required translation or usage note.",
+      "propertyNames": {
+        "type": "string"
+      },
       "additionalProperties": {
         "type": "string"
-      }
+      },
+      "description": "Term dictionary for consistent translations. Keys are source terms, values describe the required translation or usage note."
     },
     "translationPrompt": {
       "type": "string",
@@ -59,120 +67,134 @@
     },
     "localeNotes": {
       "type": "object",
-      "description": "Per-locale context included in translation prompts. Keys are locale codes (e.g., 'de-DE', 'en-US', 'de-DE-formal'), values describe register, regional conventions, or other locale-specific guidance.",
+      "propertyNames": {
+        "type": "string"
+      },
       "additionalProperties": {
         "type": "string"
-      }
+      },
+      "description": "Per-locale context included in translation prompts. Keys are locale codes (e.g., 'de-DE', 'en-US', 'de-DE-formal'), values describe register, regional conventions, or other locale-specific guidance."
     },
     "examples": {
       "type": "array",
-      "description": "Few-shot translation examples that demonstrate the project's style. The agent uses these as reference when generating translations.",
       "items": {
         "type": "object",
-        "description": "A single translation example. Must have a 'key' property. All other properties are locale codes (e.g., 'de-DE', 'en-US') mapped to their translated value, or 'note' with a style comment.",
-        "required": [
-          "key"
-        ],
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The dot-path translation key (e.g., 'common.actions.save')."
-          },
-          "note": {
-            "type": "string",
-            "description": "Optional style or context note about this example."
-          }
+        "propertyNames": {
+          "type": "string"
         },
         "additionalProperties": {
           "type": "string"
-        }
-      }
+        },
+        "description": "A single translation example. 'key' holds the dot-path translation key (e.g., 'common.actions.save'), 'note' an optional style comment, and every other property is a locale code (e.g., 'de-DE', 'en-US') mapped to its translated value."
+      },
+      "description": "Few-shot translation examples that demonstrate the project's style. The agent uses these as reference when generating translations."
     },
     "orphanScan": {
       "type": "object",
-      "description": "Per-layer configuration for orphan key detection. Map each layer name to its settings. Scan directories are automatically determined from each layer's root directory.",
+      "propertyNames": {
+        "type": "string"
+      },
       "additionalProperties": {
         "type": "object",
         "properties": {
           "ignorePatterns": {
             "type": "array",
-            "description": "Glob patterns for translation keys to exclude from orphan detection (e.g., \"common.datetime.months.*\"). Use * to match a single key segment, ** to match any depth.",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Glob patterns for translation keys to exclude from orphan detection (e.g., \"common.datetime.months.*\"). Use * to match a single key segment, ** to match any depth."
           }
         },
-        "additionalProperties": false
-      }
-    },
-    "protectedLocales": {
-      "type": "array",
-      "description": "Human-maintained locales excluded from automatic translation. Entries may be any locale ref (code, language tag, or file name); entries that do not match a known locale are ignored with a warning. Explicitly naming a protected locale in targetLocales overrides the protection (with a warning).",
-      "items": {
-        "type": "string"
-      }
-    },
-    "reportOutput": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "Custom directory path (relative to project root) where diagnostic tool reports are written."
-        },
-        {
-          "type": "boolean",
-          "const": true,
-          "description": "Set to true to write reports to the default '.i18n-reports/' directory."
-        }
-      ],
-      "description": "Enable file output for diagnostic tools (get_missing_translations, search_translations, find_orphan_keys, remove_orphan_keys). When set, each tool writes its full JSON report to <reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true for the default '.i18n-reports/' directory, or a string for a custom path."
+        "additionalProperties": {}
+      },
+      "description": "Per-layer configuration for orphan key detection. Map each layer name to its settings. Scan directories are automatically determined from each layer's root directory."
     },
     "localeDirs": {
       "type": "array",
-      "description": "Locale directories for the generic adapter. Each entry is a path string (layer defaults to 'default') or an object with 'path' and 'layer' properties.",
       "items": {
-        "oneOf": [
+        "anyOf": [
           {
             "type": "string",
+            "minLength": 1,
             "description": "Relative path to a locale directory. Layer name defaults to 'default'."
           },
           {
             "type": "object",
-            "required": ["path", "layer"],
-            "additionalProperties": false,
             "properties": {
               "path": {
                 "type": "string",
+                "minLength": 1,
                 "description": "Relative path to a locale directory."
               },
               "layer": {
                 "type": "string",
+                "minLength": 1,
                 "description": "Layer name for this locale directory."
               }
-            }
+            },
+            "required": [
+              "path",
+              "layer"
+            ],
+            "additionalProperties": false
           }
         ]
-      }
+      },
+      "description": "Locale directories for the generic adapter. Each entry is a path string (layer defaults to 'default') or an object with 'path' and 'layer' properties."
     },
     "defaultLocale": {
       "type": "string",
+      "minLength": 1,
       "description": "Default locale code. Required for generic adapter activation."
     },
     "locales": {
       "type": "array",
-      "description": "Explicit list of locale codes to operate on. If absent, locales are auto-discovered from files on disk.",
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Explicit list of locale codes to operate on. If absent, locales are auto-discovered from files on disk."
+    },
+    "protectedLocales": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Human-maintained locales excluded from automatic translation. Entries may be any locale ref (code, language tag, or file name); entries that do not match a known locale are ignored with a warning. Explicitly naming a protected locale in targetLocales overrides the protection (with a warning)."
+    },
+    "reportOutput": {
+      "anyOf": [
+        {
+          "type": "boolean",
+          "const": true,
+          "description": "Set to true to write reports to the default '.i18n-reports/' directory."
+        },
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Custom directory path (relative to project root) where diagnostic tool reports are written."
+        }
+      ],
+      "description": "Enable file output for diagnostic tools (get_missing_translations, search_translations, find_orphan_keys, remove_orphan_keys). When set, each tool writes its full JSON report to <reportOutput>/<toolName>.json and returns only a summary in the MCP response. Set to true for the default '.i18n-reports/' directory, or a string for a custom path."
     },
     "localeFileFormat": {
       "type": "string",
-      "enum": ["json", "php-array"],
+      "enum": [
+        "json",
+        "php-array"
+      ],
       "description": "Override the auto-detected locale file format. Useful when both formats exist or auto-detection picks wrong."
     },
     "providerBaseUrl": {
       "type": "string",
       "minLength": 1,
       "description": "Base URL for the LLM provider — gateways, self-hosted model servers and corporate proxies that speak the provider's own protocol. Overrides the endpoint only, not the request shape or auth header. Overridden by the I18N_BASE_URL environment variable and by --baseUrl. Not supported by the \"google\" provider, which rejects it rather than ignoring it."
+    },
+    "samplingPreferences": {
+      "deprecated": true,
+      "description": "Deprecated and ignored — MCP sampling was removed. Still accepted so existing config files keep validating. Configure a provider instead (e.g., I18N_PROVIDER/I18N_MODEL)."
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Write `packages/mcp/schema.json` from the CLI's zod config schema.
+ *
+ * The published schema is generated rather than hand-maintained so it cannot
+ * disagree with the schema that actually validates config (#346). Run this
+ * after changing `packages/cli/src/config/schema.ts`:
+ *
+ *   pnpm generate:schema
+ *
+ * The source is loaded through jiti rather than the built `dist`, so the
+ * generator works on a clean checkout without a build step. A test in the CLI
+ * package fails if the committed file drifts from the schema.
+ *
+ * Usage: node scripts/generate-schema.mjs [--check]
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const cliPackage = new URL('../packages/cli/package.json', import.meta.url)
+const schemaSource = new URL('../packages/cli/src/config/schema-json.ts', import.meta.url)
+const target = new URL('../packages/mcp/schema.json', import.meta.url)
+
+// jiti is a dependency of the CLI package, so resolve it from there.
+const { createJiti } = await import(createRequire(cliPackage).resolve('jiti'))
+const jiti = createJiti(import.meta.url)
+const { renderConfigJsonSchema } = await jiti.import(schemaSource.pathname)
+
+const generated = renderConfigJsonSchema()
+
+if (process.argv.includes('--check')) {
+  const committed = readFileSync(target, 'utf-8')
+  if (committed !== generated) {
+    console.error('packages/mcp/schema.json is out of date — run `pnpm generate:schema`.')
+    process.exit(1)
+  }
+  console.log('packages/mcp/schema.json is up to date.')
+}
+else {
+  writeFileSync(target, generated)
+  console.log('Wrote packages/mcp/schema.json.')
+}


### PR DESCRIPTION
Closes #346. Unblocks #350.

## The problem

Two definitions of the kit's declared configuration, disagreeing. The zod schema validates at runtime for all three declaration sites; `packages/mcp/schema.json` was hand-written, ships to npm, and is what users point `$schema` at. Every divergence showed up as an editor rejecting configuration the tool happily accepts.

| Field | Before | Why it was wrong |
|---|---|---|
| `framework` | `enum: ["nuxt","laravel","generic"]` | `"vue"` and `"react"` flagged invalid, though both adapters ship and both READMEs tell you to write them. zod leaves the field open because adapters are a runtime registry. |
| `samplingPreferences` | absent, under `additionalProperties: false` | zod accepts it on purpose — deprecated, warned, ignored, kept valid so old configs still load. The schema rejected exactly the configs the deprecation protects. |

## The fix

The schema is generated now, so the two cannot drift again. zod 4 converts natively — no dependency added.

`framework` uses `examples` sourced from the adapter registry rather than `enum`: editors autocomplete the names, a sixth adapter appears on the next regeneration, and nothing outside the list is rejected.

**Most of the diff is moving the field descriptions onto the zod fields.** They only existed in the hand-written JSON, and they are what editors show as tooltips. They are now single-sourced with the validation they describe, which is also the prerequisite for #350 generating the docs reference from the same place.

## Generation is not part of the build

A build step writing a tracked file means dirty working trees and ordering coupling between the cli and mcp builds, for no benefit. The guard is a drift test in the CLI suite; `pnpm generate:schema --check` is available if you want a faster CI signal.

## Two loosenings, both faithful to the runtime

- `orphanScan` entries now allow unknown keys, matching the `passthrough()` that exists for deprecated keys like `includeParentLayer`.
- `examples` entries no longer require `key`. **This one is the artifact having been right and the runtime being wrong** — `ops-translate.ts` renders `` `- ${ex.key}: …` `` straight into the provider prompt, so an entry without `key` silently sends `- undefined:` as a style example. Filed as #367 rather than papered over here, since fixing it means changing runtime validation and this PR deliberately does not.

## Verified

1025 CLI tests + 35 MCP tests pass. `pnpm build`, `lint`, `typecheck` clean. `npx fallow audit` clean. Drift check reports up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded configuration documentation with Vue and React framework adapters.
  * Added descriptions, examples, locale guidance, and deprecation details to configuration fields.

* **Improvements**
  * Updated the published configuration schema to support all registered framework adapters.
  * Added support for `locales`, `protectedLocales`, and deprecated `samplingPreferences`.
  * Strengthened validation for locale directories, translations, report output, and related settings.

* **Tooling**
  * Added a command to generate and verify the published configuration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->