### PR TITLE
fix(ci): let a tripped gate redden the job without discarding the work

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
     default: 'latest'
 
 outputs:
+  gate_tripped:
+    description: 'Names of any CI gates that tripped. The job fails after the translations are committed.'
+    value: ${{ steps.translate.outputs.gate_tripped }}
   translated_count:
     description: 'Number of keys translated'
     value: ${{ steps.translate.outputs.translated_count }}
@@ -172,12 +175,16 @@ runs:
         echo "translated_count=$count" >> "$GITHUB_OUTPUT"
         echo "failed_count=$failed" >> "$GITHUB_OUTPUT"
 
+        # A tripped gate is recorded, not acted on here. Failing this step would
+        # skip the PR step below, throwing away the translations the run did
+        # produce — reported red and lost, with the next run redoing all of it.
+        # The gate fails the job in a later step, once the work is safe.
         case "$status" in
           0) ;;
           2)
             gates=$(echo "$output" | jq -rc '[.gatesTripped[]?.name] | join(", ")' 2>/dev/null || echo "unknown")
-            echo "::error::CI gate tripped: ${gates}. The run itself succeeded — this is a findings gate, not a failure."
-            exit 2
+            echo "::warning::CI gate tripped: ${gates}. The run itself succeeded — the job fails after the translations are committed."
+            echo "gate_tripped=${gates}" >> "$GITHUB_OUTPUT"
             ;;
           *)
             echo "::error::translate failed (exit ${status}) — check provider, model, and API key."
@@ -270,3 +277,11 @@ runs:
       shell: bash
       run: |
         echo "::notice::Dry run complete. ${{ steps.translate.outputs.translated_count }} keys would be translated."
+
+    # Last, so the gate reddens the job without costing the run its work.
+    - name: Fail on tripped gate
+      if: steps.translate.outputs.gate_tripped != ''
+      shell: bash
+      run: |
+        echo "::error::CI gate tripped: ${{ steps.translate.outputs.gate_tripped }}. Findings exist; the translations that succeeded were still committed."
+        exit 2

--- a/action.yml
+++ b/action.yml
@@ -183,6 +183,11 @@ runs:
           0) ;;
           2)
             gates=$(echo "$output" | jq -rc '[.gatesTripped[]?.name] | join(", ")' 2>/dev/null || echo "unknown")
+            # An absent or empty gatesTripped joins to "", which the final step
+            # reads as "no gate" and skips — turning exit 2 into a green job.
+            # The exit code is the authority on whether a gate tripped; the
+            # names only shape the message.
+            gates=${gates:-unnamed gate}
             echo "::warning::CI gate tripped: ${gates}. The run itself succeeded — the job fails after the translations are committed."
             echo "gate_tripped=${gates}" >> "$GITHUB_OUTPUT"
             ;;

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -238,12 +238,19 @@
       # as summary.message in the payload printed above, naming the affected
       # locales. Branching on a parsed count is what this template stopped doing.
 
+      # A tripped gate is recorded, not acted on yet. Exiting here would throw
+      # away the translations the run did produce: the commit is further down,
+      # so a partial success would be reported red AND lost, and the next run
+      # would redo all of it. The gate still fails the job — after the work is
+      # safe. A failed run (exit 1) translated nothing, so there is nothing to
+      # keep and it exits immediately.
+      GATE_TRIPPED=0
+      GATE_NAMES=""
       case "$STATUS" in
         0) ;;
         2)
-          GATES=$(jq -rc '[.gatesTripped[]?.name] | join(", ")' .i18n-reports/translate-output.json 2>/dev/null || echo "unknown")
-          echo "GATE: ${GATES} tripped. The run itself succeeded — this is a findings gate, not a failure."
-          exit 2
+          GATE_TRIPPED=1
+          GATE_NAMES=$(jq -rc '[.gatesTripped[]?.name] | join(", ")' .i18n-reports/translate-output.json 2>/dev/null || echo "unknown")
           ;;
         *)
           echo "ERROR: translate failed (exit ${STATUS}) — check provider, model, and API key."
@@ -251,15 +258,24 @@
           ;;
       esac
 
+      # Every exit below goes through this, so no path can drop the gate.
+      finish() {
+        if [ "$GATE_TRIPPED" = "1" ]; then
+          echo "GATE: ${GATE_NAMES} tripped. The run itself succeeded and anything it translated has been committed — this is a findings gate, not a failure."
+          exit 2
+        fi
+        exit 0
+      }
+
       if [ "$I18N_DRY_RUN" = "true" ]; then
         echo "Dry run complete. No files written."
-        exit 0
+        finish
       fi
 
       # Check if there are locale file changes (configurable path pattern)
       if git diff --quiet -- $I18N_LOCALE_PATHS && git diff --cached --quiet -- $I18N_LOCALE_PATHS; then
         echo "No translation changes to commit."
-        exit 0
+        finish
       fi
 
       CHANGED_FILES=$(git status --porcelain -- $I18N_LOCALE_PATHS | wc -l | tr -d ' ')
@@ -313,6 +329,8 @@
           echo "Fix: give I18N_PUSH_TOKEN the api scope (the job then auto-triggers a follow-up MR pipeline), or press 'Run pipeline' on the MR."
         fi
       fi
+
+      finish
 
   artifacts:
     paths:

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -251,6 +251,9 @@
         2)
           GATE_TRIPPED=1
           GATE_NAMES=$(jq -rc '[.gatesTripped[]?.name] | join(", ")' .i18n-reports/translate-output.json 2>/dev/null || echo "unknown")
+          # The exit code decides; the names only shape the message, and an
+          # absent or empty gatesTripped joins to "".
+          GATE_NAMES=${GATE_NAMES:-unnamed gate}
           ;;
         *)
           echo "ERROR: translate failed (exit ${STATUS}) — check provider, model, and API key."

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -147,8 +147,17 @@ describe('gitlab-ci.yml job scripts, executed', () => {
       stubResult: string,
       stubExit: number,
       env: Record<string, string> = {},
+      asGitRepo = false,
     ): Promise<Run & { args: string }> {
       const dir = await mkdtemp(join(tmpdir(), 'i18n-tpl-translate-'))
+      if (asGitRepo) {
+        // The commit path needs a repo to ask about changes.
+        await execFileAsync('git', ['init', '-q'], { cwd: dir })
+        await execFileAsync('git', ['commit', '-q', '--allow-empty', '-m', 'root'], {
+          cwd: dir,
+          env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+        })
+      }
       const stubBin = join(dir, '.bin')
       await mkdir(stubBin, { recursive: true })
       const shim = join(stubBin, 'the-i18n-cli')
@@ -206,6 +215,22 @@ describe('gitlab-ci.yml job scripts, executed', () => {
       const failLooking = JSON.stringify({ summary: { totalTranslated: 0, totalFailed: 9 } })
 
       expect((await runTranslate(failLooking, 0)).code).toBe(0)
+    })
+
+    // The gate must outlive the steps that follow it rather than short-circuit
+    // them. Exiting at the status check threw away whatever the run did
+    // translate — 54 keys discarded because 3 failed, seen on a real project.
+    // Proven here by the gate message arriving after a later step's output.
+    it('reports the gate after continuing, not at the status check', async () => {
+      const partial = JSON.stringify({
+        summary: { totalTranslated: 54, totalFailed: 3 },
+        gatesTripped: [{ name: 'fail-on-failed', observed: 3, threshold: 0 }],
+      })
+      const run = await runTranslate(partial, 2)
+
+      expect(run.code).toBe(2)
+      expect(run.stdout.indexOf('Dry run complete'))
+        .toBeLessThan(run.stdout.indexOf('GATE: fail-on-failed tripped'))
     })
 
     it('requests the partial-failure gate only when asked', async () => {
@@ -302,13 +327,17 @@ describe('action.yml translate step, executed against a stub CLI', () => {
     expect(run.stdout).toContain('translate failed (exit 1)')
   })
 
-  it('propagates exit 2 as a gate, named and distinct from a failure', async () => {
+  // The gate is recorded here and acted on in a later step. Failing this one
+  // would skip the PR step, so a partial success would be reported red AND
+  // lost — 54 good translations discarded because 3 failed, observed on a real
+  // project before this changed.
+  it('records a tripped gate for a later step instead of failing here', async () => {
     const run = await runStep(JSON.stringify({
       summary: { totalTranslated: 5, totalFailed: 0 },
       gatesTripped: [{ name: 'fail-on-missing', observed: 12, threshold: 0 }],
     }), 2)
 
-    expect(run.code).toBe(2)
+    expect(run.code).toBe(0)
     expect(run.stdout).toContain('CI gate tripped: fail-on-missing')
     expect(run.stdout).not.toContain('translate failed')
   })

--- a/packages/cli/tests/cli/template-gate-execution.test.ts
+++ b/packages/cli/tests/cli/template-gate-execution.test.ts
@@ -54,12 +54,30 @@ async function runScript(
   }
 }
 
-async function jobScript(name: string): Promise<string> {
+interface Job { script: string[], variables?: Record<string, string>, extends?: string }
+
+async function readJob(name: string): Promise<Job> {
   const raw = await readFile(join(repoRoot, 'gitlab-ci.yml'), 'utf-8')
-  const doc = parse(raw) as Record<string, { script: string[] }>
+  const doc = parse(raw) as Record<string, Job>
   const job = doc[name]
   if (!job) throw new Error(`job ${name} not found in gitlab-ci.yml`)
-  return job.script.join('\n')
+  return job
+}
+
+async function jobScript(name: string): Promise<string> {
+  return (await readJob(name)).script.join('\n')
+}
+
+/**
+ * The `variables:` block, which GitLab exports into the job. Taken from the
+ * template rather than restated here: the scripts run under `set -u`, so a
+ * variable declared there but missing from a test aborts the script silently
+ * mid-run, which reads as a template bug rather than a fixture gap.
+ */
+async function jobVariables(name: string): Promise<Record<string, string>> {
+  const job = await readJob(name)
+  const inherited = job.extends ? await jobVariables(job.extends) : {}
+  return { ...inherited, ...(job.variables ?? {}) }
 }
 
 describe('gitlab-ci.yml job scripts, executed', () => {
@@ -139,25 +157,41 @@ describe('gitlab-ci.yml job scripts, executed', () => {
   /**
    * The translate job needs a real provider, so its CLI call is stubbed. Its
    * STATUS branching is the part under test, and I18N_DRY_RUN keeps the run
-   * short of the git and push stages that follow it.
+   * short of the git and push stages that follow it — except in the commit-path
+   * test, which needs those stages to prove the gate outlives them.
    */
   describe('.i18n-translate STATUS branching', () => {
+    /**
+     * Stands the job up on a repo whose locale file has uncommitted changes,
+     * as it would be after a real translate wrote to it. `git push` is shimmed
+     * to succeed (there is no remote) while everything before it stays real, so
+     * the commit is genuinely made rather than simulated.
+     */
+    async function seedRepoWithTranslations(dir: string, stubBin: string): Promise<void> {
+      const git = { cwd: dir, env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' } }
+      await execFileAsync('git', ['init', '-q'], git)
+      await mkdir(join(dir, 'i18n/locales'), { recursive: true })
+      await writeFile(join(dir, 'i18n/locales/de.json'), '{}\n')
+      await execFileAsync('git', ['add', 'i18n/locales/de.json'], git)
+      await execFileAsync('git', ['commit', '-q', '-m', 'root'], git)
+      await writeFile(join(dir, 'i18n/locales/de.json'), '{"a":"Hallo"}\n')
+
+      const realGit = (await execFileAsync('sh', ['-c', 'command -v git'])).stdout.trim()
+      await writeFile(
+        join(stubBin, 'git'),
+        `#!/bin/sh\nif [ "$1" = push ]; then echo "push $2 $3"; exit 0; fi\nexec '${realGit}' "$@"\n`,
+      )
+      await chmod(join(stubBin, 'git'), 0o755)
+    }
+
     /** The stub records the args it was handed, so flag wiring is observable. */
     async function runTranslate(
       stubResult: string,
       stubExit: number,
       env: Record<string, string> = {},
-      asGitRepo = false,
-    ): Promise<Run & { args: string }> {
+      seedRepo = false,
+    ): Promise<Run & { args: string, log: string }> {
       const dir = await mkdtemp(join(tmpdir(), 'i18n-tpl-translate-'))
-      if (asGitRepo) {
-        // The commit path needs a repo to ask about changes.
-        await execFileAsync('git', ['init', '-q'], { cwd: dir })
-        await execFileAsync('git', ['commit', '-q', '--allow-empty', '-m', 'root'], {
-          cwd: dir,
-          env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
-        })
-      }
       const stubBin = join(dir, '.bin')
       await mkdir(stubBin, { recursive: true })
       const shim = join(stubBin, 'the-i18n-cli')
@@ -167,8 +201,14 @@ describe('gitlab-ci.yml job scripts, executed', () => {
         `#!/bin/sh\nprintf '%s ' "$@" > '${argsFile}'\ncat <<'JSON'\n${stubResult}\nJSON\nexit ${stubExit}\n`,
       )
       await chmod(shim, 0o755)
+      if (seedRepo) await seedRepoWithTranslations(dir, stubBin)
 
       const run = await runScript(await jobScript('.i18n-translate'), dir, {
+        ...await jobVariables('.i18n-translate'),
+        CI_COMMIT_REF_NAME: 'feat/translate',
+        CI_SERVER_HOST: 'gitlab.test',
+        CI_PROJECT_PATH: 'group/project',
+        CI_JOB_TOKEN: 'stub',
         I18N_PROVIDER: 'openai',
         I18N_MODEL: 'stub-model',
         I18N_API_KEY: 'stub',
@@ -182,8 +222,11 @@ describe('gitlab-ci.yml job scripts, executed', () => {
       }, stubBin)
 
       const args = existsSync(argsFile) ? await readFile(argsFile, 'utf-8') : ''
+      const log = seedRepo
+        ? (await execFileAsync('git', ['log', '--format=%s'], { cwd: dir })).stdout
+        : ''
       await rm(dir, { recursive: true, force: true })
-      return { ...run, args }
+      return { ...run, args, log }
     }
 
     it('exits 0 on a successful run', async () => {
@@ -230,6 +273,22 @@ describe('gitlab-ci.yml job scripts, executed', () => {
 
       expect(run.code).toBe(2)
       expect(run.stdout.indexOf('Dry run complete'))
+        .toBeLessThan(run.stdout.indexOf('GATE: fail-on-failed tripped'))
+    })
+
+    // The case the dry run cannot reach: with a gate tripped, the work the run
+    // did produce must still be committed and pushed before the job goes red.
+    it('commits and pushes the partial result, then exits 2', async () => {
+      const partial = JSON.stringify({
+        summary: { totalTranslated: 54, totalFailed: 3 },
+        gatesTripped: [{ name: 'fail-on-failed', observed: 3, threshold: 0 }],
+      })
+      const run = await runTranslate(partial, 2, { I18N_DRY_RUN: 'false' }, true)
+
+      expect(run.code).toBe(2)
+      expect(run.log).toContain('i18n: auto-translate missing keys')
+      expect(run.stdout).toContain('Pushed 1 locale file(s) to feat/translate')
+      expect(run.stdout.indexOf('Pushed 1 locale file(s)'))
         .toBeLessThan(run.stdout.indexOf('GATE: fail-on-failed tripped'))
     })
 
@@ -340,6 +399,18 @@ describe('action.yml translate step, executed against a stub CLI', () => {
     expect(run.code).toBe(0)
     expect(run.stdout).toContain('CI gate tripped: fail-on-missing')
     expect(run.stdout).not.toContain('translate failed')
+  })
+
+  // The later step keys off gate_tripped being non-empty, so a gate the CLI
+  // did not name would leave it blank and quietly turn exit 2 into a green job.
+  it('records an unnamed gate under a placeholder rather than an empty output', async () => {
+    const run = await runStep(JSON.stringify({
+      summary: { totalTranslated: 5, totalFailed: 0 },
+      gatesTripped: [],
+    }), 2)
+
+    expect(run.code).toBe(0)
+    expect(run.outputs).toContain('gate_tripped=unnamed gate')
   })
 
   // The old implementation decided from these counts, so a payload whose


### PR DESCRIPTION
## Problem

Both CI templates exited the moment a gate tripped — before the commit and push. A run that translated 54 keys and failed 3 reported red *and* threw all 54 away. The next run would translate them again, for the same cost, to the same end.

That made `--fail-on-failed` worse than the silent green it replaced. Turning a gate on should change what you are told, not what you keep.

Seen on a real pipeline: anny-ui !2091.

## Change

The gate is recorded at the status check and acted on at the end:

- **GitLab**: a `GATE_TRIPPED` flag plus a `finish()` that every exit path goes through.
- **Action**: a `gate_tripped` step output plus a final `Fail on tripped gate` step, ordered after `Create PR with translations`.

Exit code 2 is unchanged. A run that failed outright (exit 1) still stops immediately — it translated nothing worth keeping.

## Verification

Extracted the job script and ran it under `dash` with a stub CLI returning 54/3 and a tripped gate: it now reaches the commit path and reports the gate afterwards. The template test asserts the ordering by requiring the gate message to arrive after a later step's output — it fails if the gate short-circuits again.

Refs #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `gate_tripped` output to report translation quality gates detected during CI runs.
  - Translation jobs now complete and commit successful translations before reporting deferred gate findings.
  - Dry runs and runs without changes consistently report gate results.

- **Bug Fixes**
  - Translation gate findings no longer interrupt follow-up processing prematurely.
  - Other translation or scan failures continue to fail immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->