### PR TITLE
fix(config): check every declaration site, and alias the name the docs use

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -293,7 +293,7 @@ These files are executed, so a `next.config.js` wrapped in `withNextIntl(...)` o
 A value you declare yourself always wins over both. To pin the reference locale regardless of what any framework config says:
 
 ```ts
-import { defineI18nKitConfig } from 'the-i18n-cli/config'
+import { defineI18nKitConfig } from '@the-i18n-kit/cli/config'
 
 export default defineI18nKitConfig({
   defaultLocale: 'en',
@@ -327,7 +327,7 @@ await translateKey({
 Project-specific context goes in `i18n-kit.config.ts` at your project root, where the editor checks it:
 
 ```ts
-import { defineI18nKitConfig } from 'the-i18n-cli/config'
+import { defineI18nKitConfig } from '@the-i18n-kit/cli/config'
 
 export default defineI18nKitConfig({
   context: 'B2B SaaS booking platform',

--- a/packages/cli/src/config/typed-config.ts
+++ b/packages/cli/src/config/typed-config.ts
@@ -125,7 +125,7 @@ export async function loadTypedConfig(
   if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
     throw new ConfigError(
       `${path} must export a config object as its default export — got ${describe(exported)}. `
-      + 'Wrap it in defineI18nKitConfig() from "the-i18n-cli/config".',
+      + `Wrap it in defineI18nKitConfig() from "${CONFIG_SPECIFIER}".`,
     )
   }
 
@@ -138,7 +138,16 @@ export async function loadTypedConfig(
 }
 
 /**
- * Point `the-i18n-cli/config` at the copy of `defineI18nKitConfig` that is
+ * The specifier the documentation tells you to import from. Both spellings
+ * publish the same code at the same versions (#315), so a config file may
+ * legitimately name either — but only one of them belongs in a message that
+ * tells someone what to write.
+ */
+const CONFIG_SPECIFIER = '@the-i18n-kit/cli/config'
+const DEPRECATED_CONFIG_SPECIFIER = 'the-i18n-cli/config'
+
+/**
+ * Point the `/config` specifiers at the copy of `defineI18nKitConfig` that is
  * already running.
  *
  * A config file imports it for the types, and types only need the package
@@ -146,6 +155,10 @@ export async function loadTypedConfig(
  * project that never added it as a dependency, where a bare import would be
  * unresolvable and take the whole config down with it. Resolving it to
  * ourselves costs nothing and is the same function either way: identity.
+ *
+ * Both spellings are aliased: the rescue path is worth nothing if it covers a
+ * name the docs no longer recommend, and the deprecated one has to keep working
+ * until the window in #344 closes.
  *
  * Returns no alias when the entry cannot be located, which leaves normal
  * resolution to find the installed package.
@@ -155,7 +168,9 @@ function selfAlias(): Record<string, string> {
   // chunk this code ends up in; `../` when running from source, as tests do.
   for (const candidate of ['./define-config.js', '../define-config.js', '../define-config.ts']) {
     const path = fileURLToPath(new URL(candidate, import.meta.url))
-    if (existsSync(path)) return { 'the-i18n-cli/config': path }
+    if (existsSync(path)) {
+      return { [CONFIG_SPECIFIER]: path, [DEPRECATED_CONFIG_SPECIFIER]: path }
+    }
   }
   return {}
 }

--- a/packages/cli/src/define-config.ts
+++ b/packages/cli/src/define-config.ts
@@ -2,7 +2,7 @@
  * The entry point a project's own `i18n-kit.config.ts` imports:
  *
  * ```ts
- * import { defineI18nKitConfig } from 'the-i18n-cli/config'
+ * import { defineI18nKitConfig } from '@the-i18n-kit/cli/config'
  *
  * export default defineI18nKitConfig({ defaultLocale: 'en' })
  * ```

--- a/packages/cli/tests/config/typed-config.test.ts
+++ b/packages/cli/tests/config/typed-config.test.ts
@@ -32,16 +32,27 @@ describe('loadTypedConfig', () => {
     expect(loaded?.path).toBe(resolve(project.dir, 'i18n-kit.config.ts'))
   })
 
-  it('resolves defineI18nKitConfig without the package being installed', async () => {
-    // What a project written against the docs actually contains. jiti resolves
-    // the import to the running CLI, so an npx invocation works too.
+  // What a project written against the docs actually contains. jiti resolves
+  // the import to the running CLI, so an npx invocation works too. Both
+  // spellings publish the same code, and the rescue path is worth nothing if
+  // it covers a name the docs no longer recommend.
+  it.each([
+    ['@the-i18n-kit/cli/config', 'fr'],
+    ['the-i18n-cli/config', 'it'],
+  ])('resolves defineI18nKitConfig from %s without the package being installed', async (specifier, locale) => {
     await write('i18n-kit.config.ts', `
-      import { defineI18nKitConfig } from 'the-i18n-cli/config'
-      export default defineI18nKitConfig({ defaultLocale: 'fr' })
+      import { defineI18nKitConfig } from '${specifier}'
+      export default defineI18nKitConfig({ defaultLocale: '${locale}' })
     `)
 
     const loaded = await loadTypedConfig(project.dir)
-    expect(loaded?.config.defaultLocale).toBe('fr')
+    expect(loaded?.config.defaultLocale).toBe(locale)
+  })
+
+  it('names the current package when telling you what to wrap the config in', async () => {
+    await write('i18n-kit.config.ts', `export default 'nope'`)
+
+    await expect(loadTypedConfig(project.dir)).rejects.toThrow(/@the-i18n-kit\/cli\/config/)
   })
 
   it('accepts a plain .js config', async () => {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -44,7 +44,8 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@nuxt/kit": "^3.0.0 || ^4.0.0"
+    "@nuxt/kit": "^3.0.0 || ^4.0.0",
+    "jiti": "^2.4.2"
   },
   "devDependencies": {
     "@nuxt/module-builder": "^1.0.3",

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,15 +1,13 @@
-import { existsSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { addTemplate, defineNuxtModule, useLogger } from '@nuxt/kit'
 import type { NuxtModule } from '@nuxt/schema'
 
 import { version } from '../package.json'
 import { buildArtifact } from './artifact'
+import { protectedLocalesFrom, readConfigSources } from './project-config'
+import type { LoggerLike } from './project-config'
 import { checkOwnedKeys, checkProtectedLocales } from './validate'
 import type { Diagnostic } from './validate'
-
-const CONFIG_FILENAME = '.i18n-mcp.json'
 
 /**
  * Fixed, not configurable. The CLI looks for `<app>/.nuxt/i18n-kit.json` without
@@ -72,7 +70,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
         return
       }
 
-      const projectConfig = await readProjectConfig(nuxt.options.rootDir, logger)
+      const configSources = await readConfigSources(nuxt.options.rootDir, logger)
 
       const artifact = await buildArtifact({
         appDir: nuxt.options.rootDir,
@@ -84,8 +82,8 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
       // Checked against the locale table Nuxt actually resolved — the point of
       // validating here rather than at translate time.
       const diagnostics = [
-        ...checkOwnedKeys(projectConfig),
-        ...checkProtectedLocales(projectConfig?.protectedLocales as string[] | undefined, artifact.locales),
+        ...checkOwnedKeys(configSources),
+        ...checkProtectedLocales(protectedLocalesFrom(configSources), artifact.locales),
       ]
 
       report(diagnostics, logger, options.failOnInvalidConfig ?? true)
@@ -119,12 +117,6 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
 export default module
 
-interface LoggerLike {
-  warn: (message: string) => void
-  error: (message: string) => void
-  success: (message: string) => void
-}
-
 function report(diagnostics: Diagnostic[], logger: LoggerLike, failOnInvalidConfig: boolean): void {
   const errors = diagnostics.filter(d => d.level === 'error')
 
@@ -137,35 +129,8 @@ function report(diagnostics: Diagnostic[], logger: LoggerLike, failOnInvalidConf
   // to stderr is what let de-DE-formal protect nothing for months.
   if (errors.length > 0 && failOnInvalidConfig) {
     throw new Error(
-      `${CONFIG_FILENAME} does not agree with your Nuxt config (${errors.length} problem(s), listed above). `
+      `Your i18n-kit configuration does not agree with your Nuxt config (${errors.length} problem(s), listed above). `
       + 'Set i18nKit.failOnInvalidConfig to false to report without failing.',
     )
-  }
-}
-
-/**
- * Nearest `.i18n-mcp.json` walking up from the app, the same way the CLI finds
- * it — in a layered repo the config sits at the root while each app builds from
- * its own directory.
- */
-async function readProjectConfig(
-  startDir: string,
-  logger: LoggerLike,
-): Promise<Record<string, unknown> | null> {
-  let dir = startDir
-  for (;;) {
-    const candidate = join(dir, CONFIG_FILENAME)
-    if (existsSync(candidate)) {
-      try {
-        return JSON.parse(await readFile(candidate, 'utf-8')) as Record<string, unknown>
-      }
-      catch (error) {
-        logger.warn(`Could not read ${candidate}: ${error instanceof Error ? error.message : String(error)}`)
-        return null
-      }
-    }
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
   }
 }

--- a/packages/nuxt/src/project-config.ts
+++ b/packages/nuxt/src/project-config.ts
@@ -1,0 +1,125 @@
+/**
+ * The hand-written configuration this module validates against what Nuxt
+ * resolved.
+ *
+ * There are two places to write it — `.i18n-mcp.json` and `i18n-kit.config.*`
+ * — and the CLI reads both, so a check that reads one of them declares half a
+ * rule. The typed config is the recommended one, which made it the half that
+ * went unchecked (#362).
+ *
+ * Deliberately not the CLI's loader: depending on the CLI from a Nuxt module
+ * would pull the providers and the whole scanner into every consumer's build to
+ * answer which keys a file declares. Nothing here validates — the CLI owns the
+ * schema, and it will report a bad config with a better message than this could.
+ */
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+
+/** Kept in step with the CLI's list, which is the authority on what it reads. */
+const TYPED_CONFIG_FILENAMES = [
+  'i18n-kit.config.ts',
+  'i18n-kit.config.mts',
+  'i18n-kit.config.js',
+  'i18n-kit.config.mjs',
+  'i18n-kit.config.cjs',
+  'i18n-kit.config.cts',
+] as const
+
+const JSON_CONFIG_FILENAME = '.i18n-mcp.json'
+
+/** A config file that exists, with the path to name it by when it is wrong. */
+export interface ConfigSource {
+  path: string
+  config: Record<string, unknown>
+}
+
+export interface LoggerLike {
+  warn: (message: string) => void
+  error: (message: string) => void
+  success: (message: string) => void
+}
+
+/**
+ * Every hand-written config that applies to this app, nearest first.
+ *
+ * Each file is searched for on its own, walking up from the app — in a layered
+ * repo the config sits at the root while each app builds from its own
+ * directory. A file that cannot be read is reported and skipped: this module
+ * exists to publish an artifact, and failing the build over a config the CLI
+ * would report better is not its job.
+ */
+export async function readConfigSources(
+  startDir: string,
+  logger: LoggerLike,
+): Promise<ConfigSource[]> {
+  const sources = await Promise.all([
+    readJsonConfig(startDir, logger),
+    readTypedConfig(startDir, logger),
+  ])
+  return sources.filter((source): source is ConfigSource => source !== null)
+}
+
+/** `protectedLocales` from wherever it was declared, across every source. */
+export function protectedLocalesFrom(sources: ConfigSource[]): string[] {
+  return sources.flatMap((source) => {
+    const value = source.config.protectedLocales
+    return Array.isArray(value) ? value.filter(entry => typeof entry === 'string') : []
+  })
+}
+
+async function readJsonConfig(startDir: string, logger: LoggerLike): Promise<ConfigSource | null> {
+  const path = findUp(startDir, [JSON_CONFIG_FILENAME])
+  if (!path) return null
+
+  try {
+    return { path, config: JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown> }
+  }
+  catch (error) {
+    logger.warn(`Could not read ${path}: ${message(error)}`)
+    return null
+  }
+}
+
+/**
+ * Load `i18n-kit.config.*` with jiti, the way the CLI does, so a TypeScript
+ * config is read as it sits on disk rather than after a build.
+ */
+async function readTypedConfig(startDir: string, logger: LoggerLike): Promise<ConfigSource | null> {
+  const path = findUp(startDir, TYPED_CONFIG_FILENAMES)
+  if (!path) return null
+
+  try {
+    const { createJiti } = await import('jiti')
+    const jiti = createJiti(import.meta.url, { interopDefault: true })
+    const exported = await jiti.import(path, { default: true })
+
+    if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
+      logger.warn(`${path} does not export a config object, so it was not checked against your Nuxt config.`)
+      return null
+    }
+
+    return { path, config: exported as Record<string, unknown> }
+  }
+  catch (error) {
+    logger.warn(`Could not read ${path}: ${message(error)}`)
+    return null
+  }
+}
+
+/** Nearest of `names` walking up from `startDir`, or null at the root. */
+function findUp(startDir: string, names: readonly string[]): string | null {
+  let dir = resolve(startDir)
+  for (;;) {
+    const found = names.map(name => join(dir, name)).find(path => existsSync(path))
+    if (found) return found
+
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/nuxt/src/validate.ts
+++ b/packages/nuxt/src/validate.ts
@@ -1,4 +1,5 @@
 import type { ArtifactLocale } from './artifact'
+import type { ConfigSource } from './project-config'
 
 /**
  * Same precedence the CLI resolves with (#301): an exact `code` outranks a
@@ -87,15 +88,20 @@ export function checkProtectedLocales(
 /**
  * Keys the module derives must not also be declared by hand. Silent precedence
  * between the two is how the drift this module exists to remove began.
+ *
+ * Every hand-written source is checked, not just the JSON one: the typed config
+ * is the recommended place to declare things, so checking only `.i18n-mcp.json`
+ * left the file people are steered towards as the one that could conflict in
+ * silence (#362).
  */
-export function checkOwnedKeys(projectConfig: Record<string, unknown> | null): Diagnostic[] {
-  if (!projectConfig) return []
-
-  return MODULE_OWNED_KEYS
-    .filter(key => projectConfig[key] !== undefined)
-    .map(key => ({
-      level: 'error' as const,
-      message: `.i18n-mcp.json declares "${key}", which this module derives from your Nuxt config. `
-        + `Remove it from .i18n-mcp.json — keeping both means two sources of truth and no way to tell which won.`,
-    }))
+export function checkOwnedKeys(sources: ConfigSource[]): Diagnostic[] {
+  return sources.flatMap(source =>
+    MODULE_OWNED_KEYS
+      .filter(key => source.config[key] !== undefined)
+      .map(key => ({
+        level: 'error' as const,
+        message: `${source.path} declares "${key}", which this module derives from your Nuxt config. `
+          + `Remove it — keeping both means two sources of truth and no way to tell which won.`,
+      })),
+  )
 }

--- a/packages/nuxt/tests/project-config.test.ts
+++ b/packages/nuxt/tests/project-config.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { protectedLocalesFrom, readConfigSources } from '../src/project-config'
+import { checkProtectedLocales } from '../src/validate'
+import type { ArtifactLocale } from '../src/artifact'
+
+const logger = { warn: vi.fn(), error: vi.fn(), success: vi.fn() }
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'i18n-kit-nuxt-config-'))
+  vi.clearAllMocks()
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('reading the hand-written config', () => {
+  it('finds nothing when the project has neither file', async () => {
+    // A project with no config is the case that must keep building as before.
+    expect(await readConfigSources(dir, logger)).toEqual([])
+  })
+
+  it('reads a TypeScript config as it sits on disk, with no build step', async () => {
+    await writeFile(join(dir, 'i18n-kit.config.ts'), `
+      const protectedLocales: string[] = ['de-formal']
+      export default { protectedLocales }
+    `)
+
+    const [source, ...rest] = await readConfigSources(dir, logger)
+
+    expect(rest).toEqual([])
+    expect(source?.config.protectedLocales).toEqual(['de-formal'])
+  })
+
+  it('reads both files when a project has both', async () => {
+    await writeFile(join(dir, '.i18n-mcp.json'), JSON.stringify({ defaultLocale: 'en' }))
+    await writeFile(join(dir, 'i18n-kit.config.ts'), `export default { protectedLocales: ['de'] }`)
+
+    const sources = await readConfigSources(dir, logger)
+
+    expect(sources).toHaveLength(2)
+  })
+
+  it('walks up from the app, so a layered repo finds the config at its root', async () => {
+    await writeFile(join(dir, 'i18n-kit.config.ts'), `export default { protectedLocales: ['de'] }`)
+    const app = join(dir, 'apps/booking')
+    await mkdir(app, { recursive: true })
+
+    const [source] = await readConfigSources(app, logger)
+
+    expect(source?.path).toBe(join(dir, 'i18n-kit.config.ts'))
+  })
+
+  it('reports a config it cannot read and carries on rather than failing the build', async () => {
+    await writeFile(join(dir, '.i18n-mcp.json'), '{ not json')
+
+    expect(await readConfigSources(dir, logger)).toEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('.i18n-mcp.json'))
+  })
+})
+
+describe('protectedLocales across both files', () => {
+  const locales: ArtifactLocale[] = [
+    { code: 'de', language: 'de-DE', file: 'de-DE.json' },
+    { code: 'de-formal', language: 'de-DE', file: 'de-DE-formal.json' },
+  ]
+
+  // The failure #362 was filed for: a protected locale declared in the
+  // recommended file was never checked against the locale table, so a typo
+  // there protected nothing — silently, which is how de-DE-formal sat in the
+  // machine-translation target list for months.
+  it('checks a ref declared only in the typed config', async () => {
+    await writeFile(join(dir, 'i18n-kit.config.ts'), `export default { protectedLocales: ['de-DE-formal'] }`)
+
+    const sources = await readConfigSources(dir, logger)
+    const [diagnostic] = checkProtectedLocales(protectedLocalesFrom(sources), locales)
+
+    expect(diagnostic?.level).toBe('error')
+    expect(diagnostic?.message).toContain('"de-DE-formal" matches no locale')
+  })
+
+  it('collects the refs from both files', async () => {
+    await writeFile(join(dir, '.i18n-mcp.json'), JSON.stringify({ protectedLocales: ['de'] }))
+    await writeFile(join(dir, 'i18n-kit.config.ts'), `export default { protectedLocales: ['de-formal'] }`)
+
+    const refs = protectedLocalesFrom(await readConfigSources(dir, logger))
+
+    expect(refs.sort()).toEqual(['de', 'de-formal'])
+  })
+
+  it('has nothing to check when neither file declares any', async () => {
+    await writeFile(join(dir, '.i18n-mcp.json'), JSON.stringify({ defaultLocale: 'en' }))
+
+    expect(protectedLocalesFrom(await readConfigSources(dir, logger))).toEqual([])
+  })
+})

--- a/packages/nuxt/tests/validate.test.ts
+++ b/packages/nuxt/tests/validate.test.ts
@@ -68,18 +68,37 @@ describe('protectedLocales against the real locale table', () => {
 })
 
 describe('keys the module derives', () => {
-  it.each(['locales', 'localeDirs', 'defaultLocale'])('errors when .i18n-mcp.json declares %s', (key) => {
-    const [diagnostic, ...rest] = checkOwnedKeys({ [key]: 'anything' })
+  const json = (config: Record<string, unknown>) => ({ path: '/app/.i18n-mcp.json', config })
+  const typed = (config: Record<string, unknown>) => ({ path: '/app/i18n-kit.config.ts', config })
+
+  // Both files, because the typed one is what the docs recommend — checking
+  // only the JSON config left the declaration site people are steered towards
+  // as the one that could conflict in silence (#362).
+  it.each([
+    ['.i18n-mcp.json', json],
+    ['i18n-kit.config.ts', typed],
+  ])('errors when %s declares a derived key', (filename, source) => {
+    const [diagnostic, ...rest] = checkOwnedKeys([source({ locales: ['en'] })])
 
     expect(rest).toEqual([])
     expect(diagnostic?.level).toBe('error')
-    expect(diagnostic?.message).toContain(`declares "${key}"`)
+    expect(diagnostic?.message).toContain(`declares "locales"`)
+    // Naming the file is the point: with two of them, "remove it" is otherwise
+    // an instruction you cannot act on.
+    expect(diagnostic?.message).toContain(filename)
   })
 
   it('reports every conflict rather than only the first', () => {
-    const diagnostics = checkOwnedKeys({ locales: [], defaultLocale: 'de', glossary: {} })
+    const diagnostics = checkOwnedKeys([json({ locales: [], defaultLocale: 'de', glossary: {} })])
 
     expect(diagnostics).toHaveLength(2)
+  })
+
+  it('reports the same key declared in both files once per file', () => {
+    const diagnostics = checkOwnedKeys([json({ defaultLocale: 'en' }), typed({ defaultLocale: 'de' })])
+
+    expect(diagnostics).toHaveLength(2)
+    expect(diagnostics.map(d => d.message).join('\n')).toContain('i18n-kit.config.ts')
   })
 
   it('leaves the keys Nuxt cannot know alone', () => {
@@ -91,10 +110,10 @@ describe('keys the module derives', () => {
       context: 'a booking platform',
     }
 
-    expect(checkOwnedKeys(config)).toEqual([])
+    expect(checkOwnedKeys([typed(config)])).toEqual([])
   })
 
   it('has nothing to say when there is no config file', () => {
-    expect(checkOwnedKeys(null)).toEqual([])
+    expect(checkOwnedKeys([])).toEqual([])
   })
 })

--- a/playground/README.md
+++ b/playground/README.md
@@ -33,4 +33,4 @@ Each also has locales that are deliberately incomplete, so `missing`, `status` a
 
 It needs a real install: its config loads `@the-i18n-kit/nuxt`, and the E2E translate workflow builds and runs it.
 
-The rest are fixtures with no `node_modules`, which is why adding four of them costs CI nothing. They still contain the imports a real project would (`next-intl/routing`, `@intlify/unplugin-vue-i18n/vite`, `the-i18n-cli/config`), because the CLI substitutes what it cannot resolve — and prefers the real package wherever one is installed. Run `pnpm install` inside any of them and the output does not change.
+The rest are fixtures with no `node_modules`, which is why adding four of them costs CI nothing. They still contain the imports a real project would (`next-intl/routing`, `@intlify/unplugin-vue-i18n/vite`, `@the-i18n-kit/cli/config`), because the CLI substitutes what it cannot resolve — and prefers the real package wherever one is installed. Run `pnpm install` inside any of them and the output does not change.

--- a/playground/generic/i18n-kit.config.ts
+++ b/playground/generic/i18n-kit.config.ts
@@ -1,4 +1,4 @@
-import { defineI18nKitConfig } from 'the-i18n-cli/config'
+import { defineI18nKitConfig } from '@the-i18n-kit/cli/config'
 
 /**
  * There is no framework here to ask, so everything is declared. `localeDirs`

--- a/playground/vue/README.md
+++ b/playground/vue/README.md
@@ -27,7 +27,7 @@ $ the-i18n-cli status --projectDir playground/vue --json | jq .summary.protected
 
 ## No install required
 
-There is no `node_modules` here — this is a fixture, not a workspace member, so it costs CI nothing. The plugin is substituted rather than imported, and `the-i18n-cli/config` resolves to the running CLI, so both files are read as they are.
+There is no `node_modules` here — this is a fixture, not a workspace member, so it costs CI nothing. The plugin is substituted rather than imported, and `@the-i18n-kit/cli/config` resolves to the running CLI, so both files are read as they are.
 
 ## Deliberately incomplete
 

--- a/playground/vue/i18n-kit.config.ts
+++ b/playground/vue/i18n-kit.config.ts
@@ -1,4 +1,4 @@
-import { defineI18nKitConfig } from 'the-i18n-cli/config'
+import { defineI18nKitConfig } from '@the-i18n-kit/cli/config'
 
 /**
  * The half no config file of Vue's can state: which locale is the source of

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@nuxt/kit':
         specifier: ^3.0.0 || ^4.0.0
         version: 4.4.2(magicast@0.5.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.7.0
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.3
@@ -3293,6 +3296,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:


### PR DESCRIPTION
Fixes #362, fixes #361.

## #362 — the module checked one of the two config files

`readProjectConfig` read `.i18n-mcp.json` only, so with `i18n-kit.config.ts`:

- a module-derived key (`locales`, `localeDirs`, `defaultLocale`) declared there raised nothing;
- `protectedLocales` declared there was **never checked against the locale table at all**.

The typed config is the recommended declaration site, so the file users are steered towards was the one that could conflict in silence — and the second point is the exact failure this module exists to catch: a locale marked human-maintained, matching nothing, machine-translated anyway.

Both files are read now, and every diagnostic names the file it came from — "remove it" isn't actionable when there are two.

The module loads the typed config with jiti rather than through the CLI's loader. Depending on the CLI from a Nuxt module would pull the providers and the scanner into every consumer's build to answer which keys a file declares. It validates nothing: the CLI owns the schema and reports a bad config with a better message than this could.

The issue's third point — the `artifact.ts` comment about a merged policy being re-validated — no longer applies; #372 removed `mergePolicy` and the comment with it.

## #361 — the self-alias missed the documented spelling

`selfAlias()` resolved `the-i18n-cli/config` only. Since the rename, the docs say `@the-i18n-kit/cli/config`, so the rescue path for running under `npx` without a local install covered the one name the docs no longer recommend. Invisible in any repo that has the package installed.

Both spellings resolve now; the unscoped one stays until #344 closes the deprecation window. The validation message names the current package, as do the READMEs and the playground fixtures.

## Verification

- Reverted each fix and confirmed the new tests fail: 5 for the config-source change, 1 for the alias.
- `playground/vue` has no `node_modules` and now imports the scoped specifier — the built CLI reads its `protectedLocales` from it, so the alias is exercised end to end rather than only in a temp dir.
- Full suite green (1023 CLI / 35 MCP / 35 nuxt), lint and audit clean, both packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)