### PR TITLE
fix(docs): give the landing page a layout that has containers

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,26 +1,135 @@
 ---
-title: the-i18n-kit
-description: The i18n toolkit for AI agents and large monorepos.
-navigation: false
+seo:
+  title: The i18n toolkit for AI agents and large monorepos
+  description: Find missing keys, remove dead ones, and rename across every locale
+    and layer at once — from your agent, your terminal, or your pipeline.
 ---
 
-# the-i18n-kit
+::u-page-hero
+#title
+The i18n toolkit for AI agents and large monorepos
 
-The i18n toolkit for AI agents and large monorepos. Find missing keys, remove
-dead ones, and rename across every locale and layer at once — from your agent,
-your terminal, or your pipeline.
+#description
+Find missing keys, remove dead ones, and rename across every locale and layer at
+once. One engine behind a CLI, an MCP server, a Nuxt module and two CI
+integrations — so your terminal and your agent give the same answers.
 
-::note
-This site is being built out. The scaffold is live; the content lands over the
-tickets tracked in [#300](https://github.com/fabkho/the-i18n-kit/issues/300).
+#links
+  :::u-button
+  ---
+  color: neutral
+  size: xl
+  to: /introduction/why
+  trailing-icon: i-lucide-arrow-right
+  ---
+  Why this toolkit
+  :::
+
+  :::u-button
+  ---
+  color: neutral
+  size: xl
+  to: /reference/cli
+  variant: outline
+  ---
+  CLI reference
+  :::
 ::
 
-## Install
+::u-page-section
+#title
+Built for agents, and for repositories nobody can hold in their head
 
-```bash
-npm install -g @the-i18n-kit/cli
-```
+#features
+  :::u-page-feature
+  ---
+  icon: i-lucide-bot
+  to: /introduction/built-for-agents
+  ---
+  #title
+  Agent-native, with receipts
 
-```bash
-the-i18n-cli status
-```
+  #description
+  Reports divert to disk on request, so a thousand-key result never enters a
+  context window. Machine output cannot be corrupted by a library logging to
+  stdout. Failures carry a reason from a closed set, so an agent branches on a
+  value instead of pattern-matching English.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-network
+  to: /monorepos/layers
+  ---
+  #title
+  Monorepo-native
+
+  #description
+  Usage is counted per consuming app, so a key used in one app is never treated
+  as protecting a key in another. Keys with ambiguous evidence go in their own
+  bucket and are never deleted, which is what makes an automated cleanup safe to
+  review.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-git-pull-request
+  to: /reference/cli/check
+  ---
+  #title
+  CI-native
+
+  #description
+  Findings gate a pipeline through exit codes, so a run that translated nothing
+  cannot go green. A GitHub Action and a GitLab template ship with the kit,
+  provider-agnostic, with your own API key.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-layers
+  to: /frameworks/detection
+  ---
+  #title
+  Reads your project rather than asking you to restate it
+
+  #description
+  Nuxt, Laravel, Vue, React and Next, or anything with JSON or PHP locale files.
+  Where a project already declares its locales — a next-intl routing file, a Vite
+  plugin, a Nuxt config — the kit executes that file and reads it.
+  :::
+::
+
+::u-page-section
+#title
+Start where you are
+
+#features
+  :::u-page-feature
+  ---
+  icon: i-lucide-terminal
+  to: /reference/cli
+  ---
+  #title
+  From the terminal
+
+  #description
+  Install `@the-i18n-kit/cli`, then run `the-i18n-cli status` for coverage per
+  locale and per layer. Every command is documented from its own definition, so
+  the reference cannot describe a flag that no longer exists.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-settings-2
+  to: /configuration/where-config-lives
+  ---
+  #title
+  From your config
+
+  #description
+  Declare a glossary, tone notes and protected locales once, typed, with no build
+  step — so the policy applies in an unbuilt checkout too, where a build artifact
+  would not have reached the tool.
+  :::
+::


### PR DESCRIPTION
The home page rendered edge to edge — no horizontal padding, no sidebar.

## Cause

`index.md` is assigned to Docus's **landing** collection by filename, not by frontmatter, so `navigation: false` was never what put it there. The landing route renders content without the `UPage`/`UPageBody` wrapper that gives every other page its container, on the assumption that the page is built from landing components which bring their own. Plain markdown there gets padding from nothing.

Confirmed by diffing the rendered HTML: docs pages carry `max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8` around the body; the home page had that only on the header and footer.

## Fix

Written as an actual landing page, following the shape the Docus starter uses — `::u-page-hero` with two calls to action, then `::u-page-section` feature blocks. I took the syntax from the starter rather than inferring it, having already wasted time on this site guessing at config.

Positioning is the one already agreed for #357: agent-led headline with the monorepo capability as substantiation, because an agent claim alone is easy to dismiss and the consumer graph is what makes it credible. Every feature names its mechanism rather than reaching for an adjective, per the house style.

Links point only at pages that exist today. `failOnError` means a link to one that does not fails the build rather than shipping a dead card.

## On the missing sidebar

Two separate things, only one of them a bug.

**The landing page has no sidebar by design** — that is what a landing layout is. It now reads as intentional rather than broken.

**Every other page has one, populated with all 36 links** and correct base-path prefixes; I verified that against the deployed HTML. Its classes are `hidden … lg:block`, so it collapses below 1024px. That is ordinary responsive behaviour, not a fault — worth knowing in case the window was narrow, since the mobile affordance is in the header rather than a persistent rail.

## Verified

153 routes prerendered, exit 0. Home page now has five containers with `px-4 sm:px-6 lg:px-8`; the hero renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the placeholder landing page with a structured product overview.
  * Added SEO metadata and navigation links.
  * Added sections highlighting agent support, monorepos, CI, framework detection, terminal usage, and configuration.
  * Removed outdated scaffold messaging and installation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->